### PR TITLE
fix: basin default inheritance for `delete_on_empty`

### DIFF
--- a/api/src/v1/config.rs
+++ b/api/src/v1/config.rs
@@ -333,8 +333,8 @@ impl TryFrom<StreamConfig> for types::config::OptionalStreamConfig {
         Ok(Self {
             storage_class: storage_class.map(Into::into),
             retention_policy,
-            timestamping: timestamping.unwrap_or_default().into(),
-            delete_on_empty: delete_on_empty.unwrap_or_default().into(),
+            timestamping: timestamping.map(Into::into).unwrap_or_default(),
+            delete_on_empty: delete_on_empty.map(Into::into).unwrap_or_default(),
         })
     }
 }


### PR DESCRIPTION
When converting `StreamConfig` to `OptionalStreamConfig`, an omitted `delete_on_empty`  field is incorrectly converted to Some(Duration::ZERO) instead of None

Example:

- Basin configuration has delete-on-empty enabled with a 5-minute minimum age:
```
OptionalDeleteOnEmptyConfig { min_age: Some(Duration::from_secs(300)) }
```

- Create a stream without specifying delete_on_empty:
- 
```
StreamConfig { delete_on_empty: None }
None.unwrap_or_default() → DeleteOnEmptyConfig { min_age_secs: 0 }
into() → OptionalDeleteOnEmptyConfig { min_age: Some(Duration::ZERO) }
```

- Merging with basin defaults uses or():
```
pub fn merge(self, basin_defaults: Self) -> DeleteOnEmptyConfig {
    let min_age = self.min_age.or(basin_defaults.min_age).unwrap_or_default();
    DeleteOnEmptyConfig { min_age }
}
```
Since Some(Duration::ZERO).or(Some(Duration::from_secs(300))) yields Some(Duration::ZERO), the stream ends up with min_age = Duration::ZERO instead of inheriting 300 seconds.
