### PR TITLE
chore: switch to lowercase error msgs as per rust api guideline doc

### DIFF
--- a/api/src/v1/config.rs
+++ b/api/src/v1/config.rs
@@ -57,7 +57,7 @@ impl TryFrom<RetentionPolicy> for types::config::RetentionPolicy {
     fn try_from(value: RetentionPolicy) -> Result<Self, Self::Error> {
         match value {
             RetentionPolicy::Age(0) => Err(types::ValidationError(
-                "Age must be greater than 0 seconds".to_string(),
+                "age must be greater than 0 seconds".to_string(),
             )),
             RetentionPolicy::Age(age) => Ok(Self::Age(Duration::from_secs(age))),
             RetentionPolicy::Infinite(_) => Ok(Self::Infinite()),

--- a/api/src/v1/stream/mod.rs
+++ b/api/src/v1/stream/mod.rs
@@ -338,7 +338,7 @@ impl S2Format {
         Ok(match self {
             S2Format::Raw => s.into_bytes().into(),
             S2Format::Base64 => Base64::decode_vec(&s)
-                .map_err(|_| types::ValidationError("Invalid Base64 encoding".to_owned()))?
+                .map_err(|_| types::ValidationError("invalid Base64 encoding".to_owned()))?
                 .into(),
         })
     }

--- a/api/src/v1/stream/sse.rs
+++ b/api/src/v1/stream/sse.rs
@@ -50,9 +50,9 @@ impl FromStr for LastEventId {
         {
             let item = iter
                 .next()
-                .ok_or_else(|| format!("Missing {field} in Last-Event-Id"))?;
+                .ok_or_else(|| format!("missing {field} in Last-Event-Id"))?;
             item.parse()
-                .map_err(|e| format!("Invalid {field} in Last-Event-ID: {e}").into())
+                .map_err(|e| format!("invalid {field} in Last-Event-ID: {e}").into())
         }
 
         let seq_num = get_next(&mut iter, "seq_num")?;

--- a/common/src/record/command.rs
+++ b/common/src/record/command.rs
@@ -129,11 +129,11 @@ impl Encodable for CommandRecord {
 
 #[derive(Debug, PartialEq, thiserror::Error)]
 pub enum CommandPayloadError {
-    #[error("Invalid UTF-8")]
+    #[error("invalid UTF-8")]
     InvalidUtf8(Utf8Error),
     #[error(transparent)]
     FencingTokenTooLong(#[from] FencingTokenTooLongError),
-    #[error("Earliest sequence number to trim to was {0} bytes, must be 8")]
+    #[error("earliest sequence number to trim to was {0} bytes, must be 8")]
     TrimPointSize(usize),
 }
 

--- a/common/src/record/envelope.rs
+++ b/common/src/record/envelope.rs
@@ -7,11 +7,11 @@ use crate::deep_size::DeepSize;
 
 #[derive(Debug, PartialEq, thiserror::Error)]
 pub enum HeaderValidationError {
-    #[error("Too many")]
+    #[error("too many")]
     TooMany,
-    #[error("Too long")]
+    #[error("too long")]
     TooLong,
-    #[error("Empty name")]
+    #[error("empty name")]
     NameEmpty,
 }
 

--- a/common/src/record/fencing.rs
+++ b/common/src/record/fencing.rs
@@ -7,7 +7,7 @@ use crate::deep_size::DeepSize;
 pub const MAX_FENCING_TOKEN_LENGTH: usize = 36;
 
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]
-#[error("Fencing token was longer than {MAX_FENCING_TOKEN_LENGTH} bytes in length: {0}")]
+#[error("fencing token must not exceed {MAX_FENCING_TOKEN_LENGTH} characters in length")]
 pub struct FencingTokenTooLongError(pub usize);
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]

--- a/common/src/record/mod.rs
+++ b/common/src/record/mod.rs
@@ -47,20 +47,20 @@ impl DeepSize for StreamPosition {
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum InternalRecordError {
-    #[error("Truncated: {0}")]
+    #[error("truncated: {0}")]
     Truncated(&'static str),
-    #[error("Invalid value [{0}]: {1}")]
+    #[error("invalid value [{0}]: {1}")]
     InvalidValue(&'static str, &'static str),
 }
 
 /// `impl Display` can be safely returned to the client without leaking internal details.
 #[derive(Debug, PartialEq, thiserror::Error)]
 pub enum PublicRecordError {
-    #[error("Unknown command")]
+    #[error("unknown command")]
     UnknownCommand,
-    #[error("Invalid `{0}` command: {1}")]
+    #[error("invalid `{0}` command: {1}")]
     CommandPayload(CommandOp, CommandPayloadError),
-    #[error("Invalid header: {0}")]
+    #[error("invalid header: {0}")]
     Header(#[from] HeaderValidationError),
 }
 

--- a/common/src/types/access.rs
+++ b/common/src/types/access.rs
@@ -77,12 +77,12 @@ impl<T: StrProps> TryFrom<CompactString> for AccessTokenIdStr<T> {
 
     fn try_from(name: CompactString) -> Result<Self, Self::Error> {
         if !T::IS_PREFIX && name.is_empty() {
-            return Err(format!("Access token {} must not be empty", T::FIELD_NAME).into());
+            return Err(format!("access token {} must not be empty", T::FIELD_NAME).into());
         }
 
         if name.len() > Self::MAX_LENGTH {
             return Err(format!(
-                "Access token {} must not exceed {} characters in length",
+                "access token {} must not exceed {} characters in length",
                 T::FIELD_NAME,
                 Self::MAX_LENGTH
             )

--- a/common/src/types/basin.rs
+++ b/common/src/types/basin.rs
@@ -71,7 +71,7 @@ impl<T: StrProps> TryFrom<CompactString> for BasinNameStr<T> {
     fn try_from(name: CompactString) -> Result<Self, Self::Error> {
         if name.len() > caps::MAX_BASIN_NAME_LEN {
             return Err(format!(
-                "Basin {} must not exceed {} characters in length",
+                "basin {} must not exceed {} characters in length",
                 T::FIELD_NAME,
                 caps::MAX_BASIN_NAME_LEN
             )
@@ -80,7 +80,7 @@ impl<T: StrProps> TryFrom<CompactString> for BasinNameStr<T> {
 
         if !T::IS_PREFIX && name.len() < caps::MIN_BASIN_NAME_LEN {
             return Err(format!(
-                "Basin {} should be at least {} characters in length",
+                "basin {} should be at least {} characters in length",
                 T::FIELD_NAME,
                 caps::MIN_BASIN_NAME_LEN
             )
@@ -95,7 +95,7 @@ impl<T: StrProps> TryFrom<CompactString> for BasinNameStr<T> {
 
         if !first_char.is_ascii_lowercase() && !first_char.is_ascii_digit() {
             return Err(format!(
-                "Basin {} must begin with a lowercase letter or number",
+                "basin {} must begin with a lowercase letter or number",
                 T::FIELD_NAME
             )
             .into());
@@ -107,7 +107,7 @@ impl<T: StrProps> TryFrom<CompactString> for BasinNameStr<T> {
             && !last_char.is_ascii_digit()
         {
             return Err(format!(
-                "Basin {} must end with a lowercase letter or number",
+                "basin {} must end with a lowercase letter or number",
                 T::FIELD_NAME
             )
             .into());
@@ -115,7 +115,7 @@ impl<T: StrProps> TryFrom<CompactString> for BasinNameStr<T> {
 
         if chars.any(|c| !c.is_ascii_lowercase() && !c.is_ascii_digit() && c != '-') {
             return Err(format!(
-                "Basin {} must comprise lowercase letters, numbers, and hyphens",
+                "basin {} must comprise lowercase letters, numbers, and hyphens",
                 T::FIELD_NAME
             )
             .into());

--- a/common/src/types/stream.rs
+++ b/common/src/types/stream.rs
@@ -79,12 +79,12 @@ impl<T: StrProps> TryFrom<CompactString> for StreamNameStr<T> {
 
     fn try_from(name: CompactString) -> Result<Self, Self::Error> {
         if !T::IS_PREFIX && name.is_empty() {
-            return Err(format!("Stream {} must not be empty", T::FIELD_NAME).into());
+            return Err(format!("stream {} must not be empty", T::FIELD_NAME).into());
         }
 
         if name.len() > caps::MAX_STREAM_NAME_LEN {
             return Err(format!(
-                "Stream {} must not exceed {} characters in length",
+                "stream {} must not exceed {} characters in length",
                 T::FIELD_NAME,
                 caps::MAX_STREAM_NAME_LEN
             )
@@ -199,7 +199,7 @@ impl TryFrom<AppendRecordParts> for AppendRecord {
 
     fn try_from(parts: AppendRecordParts) -> Result<Self, Self::Error> {
         if parts.metered_size() > caps::RECORD_BATCH_MAX.bytes {
-            Err("Record must have metered size less than 1 MiB")
+            Err("record must have metered size less than 1 MiB")
         } else {
             Ok(Self(parts))
         }
@@ -237,15 +237,15 @@ impl TryFrom<Metered<Vec<AppendRecord>>> for AppendRecordBatch {
 
     fn try_from(records: Metered<Vec<AppendRecord>>) -> Result<Self, Self::Error> {
         if records.is_empty() {
-            return Err("Record batch must not be empty");
+            return Err("record batch must not be empty");
         }
 
         if records.len() > caps::RECORD_BATCH_MAX.count {
-            return Err("Record batch must not exceed 1000 records");
+            return Err("record batch must not exceed 1000 records");
         }
 
         if records.metered_size() > caps::RECORD_BATCH_MAX.bytes {
-            return Err("Record batch must not exceed a metered size of 1 MiB");
+            return Err("record batch must not exceed a metered size of 1 MiB");
         }
 
         Ok(Self(records))


### PR DESCRIPTION
> The error message given by the Display representation of an error type should be lowercase without trailing punctuation, and typically concise.

from https://rust-lang.github.io/api-guidelines/interoperability.html#error-types-are-meaningful-and-well-behaved-c-good-err