### PR TITLE
feat: add release automation and justfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: release
+
+permissions:
+  contents: write
+  packages: write
+
+on:
+  push:
+    tags: ["[0-9]+.[0-9]+*"]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: s2-streamstore/s2-lite
+
+jobs:
+  build-images:
+    name: Build ${{ matrix.arch }} image
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86-64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          else
+            echo "version=dev-$(date +%s)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push architecture-specific image
+        run: |
+          docker build \
+            -f lite/Dockerfile \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-${{ matrix.arch }} \
+            .
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-${{ matrix.arch }}
+
+  create-manifest:
+    name: Create multi-arch manifest
+    needs: build-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          else
+            echo "version=dev-$(date +%s)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-x86-64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-arm64
+          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+
+  create-release:
+    name: Create GitHub release
+    needs: [build-images, create-manifest]
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/justfile
+++ b/justfile
@@ -1,0 +1,115 @@
+# List available commands
+default:
+    @just --list
+
+# Sync git submodules
+sync:
+    git submodule update --init --recursive
+
+# Build the s2-lite server binary
+build: sync
+    cargo build --locked --release -p s2-lite
+
+# Run clippy linter
+clippy: sync
+    cargo clippy --workspace --all-features --all-targets -- -D warnings --allow deprecated
+
+# Ensure nightly toolchain is installed
+_ensure-nightly:
+    @rustup toolchain list | grep -q nightly || (echo "❌ Nightly toolchain required. Run: rustup toolchain install nightly" && exit 1)
+
+# Format code with rustfmt
+fmt: _ensure-nightly
+    cargo +nightly fmt
+
+# Ensure cargo-nextest is installed
+_ensure-nextest:
+    @cargo nextest --version > /dev/null 2>&1 || cargo install cargo-nextest
+
+# Run tests with nextest
+test: sync _ensure-nextest
+    cargo nextest run --workspace --all-features
+
+# Verify Cargo.lock is up-to-date
+check-locked:
+    cargo metadata --locked --format-version 1 >/dev/null
+
+# Clean build artifacts
+clean:
+    cargo clean
+
+# Publish crates to crates.io (in dependency order)
+publish:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Check for cargo credentials
+    if [[ -z "${CARGO_REGISTRY_TOKEN:-}" ]] && [[ ! -f ~/.cargo/credentials.toml ]]; then
+        echo "❌ No cargo credentials found. Run 'cargo login' or set CARGO_REGISTRY_TOKEN."
+        exit 1
+    fi
+
+    # Verify clean working directory
+    if ! git diff-index --quiet HEAD --; then
+        echo "❌ Working directory not clean. Commit or stash changes first."
+        exit 1
+    fi
+
+    # Verify on main branch
+    if [[ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]]; then
+        echo "❌ Publish must be run from main branch."
+        exit 1
+    fi
+
+    # Verify lockfile is up-to-date
+    just check-locked
+
+    echo "Publishing crates to crates.io..."
+
+    echo "→ Publishing s2-common"
+    cargo publish -p s2-common
+
+    echo "Waiting for crates.io to index..."
+    sleep 15
+
+    echo "→ Publishing s2-api"
+    cargo publish -p s2-api
+
+    echo "Waiting for crates.io to index..."
+    sleep 15
+
+    echo "→ Publishing s2-lite"
+    cargo publish -p s2-lite
+
+    echo "✓ All crates published successfully"
+
+# Create and push a release tag
+tag TAG:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Validate version format
+    if ! [[ "{{TAG}}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "❌ Invalid version format. Use semver: X.Y.Z"
+        exit 1
+    fi
+
+    # Verify clean working directory
+    if ! git diff-index --quiet HEAD --; then
+        echo "❌ Working directory not clean. Commit or stash changes first."
+        exit 1
+    fi
+
+    # Verify on main branch
+    if [[ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]]; then
+        echo "❌ Releases must be tagged from main branch."
+        exit 1
+    fi
+
+    # Verify lockfile is up-to-date
+    just check-locked
+
+    echo "Creating release tag: {{TAG}}"
+    git tag "{{TAG}}"
+    git push origin "{{TAG}}"
+    echo "✓ Tag {{TAG}} created and pushed - release workflow will start"


### PR DESCRIPTION
## Summary
- Add `justfile` with dev commands (`build`, `clippy`, `fmt`, `test`, `sync`, `clean`) and release helpers (`publish`, `tag`)
- Add release workflow for multi-arch Docker images and GitHub releases
- Includes safety checks: clean workdir, main branch, cargo credentials, semver validation

## Dev Commands
```
just build        # Build s2-lite server
just clippy       # Run linter
just fmt          # Format with nightly rustfmt
just test         # Run tests with nextest
just sync         # Sync git submodules
```

## Release Flow
1. Bump `workspace.package.version` in `Cargo.toml`
2. Commit: `git commit -m "release: X.Y.Z"`
3. Publish: `just publish`
4. Tag: `just tag X.Y.Z`
5. Workflow auto-builds Docker images + creates GitHub release

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)