### PR TITLE
ci: enable signed commits in sync_specs workflow

### DIFF
--- a/.github/workflows/sync_specs.yaml
+++ b/.github/workflows/sync_specs.yaml
@@ -7,7 +7,6 @@ permissions:
 on:
   repository_dispatch:
     types: [s2-specs-update]
-  workflow_dispatch: # temporary for testing
 
 jobs:
   sync-submodule:


### PR DESCRIPTION
  - Update peter-evans/create-pull-request from v7 to v8
  - Enable `sign-commits: true` for verified commit signatures on automated PRs

  ## Test plan
  - [x] Triggered workflow manually, confirmed `pull-request-commits-verified = true`
  - [x] Verified commit signature via API shows `verified: true`