### PR TITLE
fix(lite): bound `resolve_timestamp` scan to stream

### DIFF
--- a/lite/src/backend/store.rs
+++ b/lite/src/backend/store.rs
@@ -34,6 +34,7 @@ impl Backend {
         timestamp: Timestamp,
     ) -> Result<Option<StreamPosition>, StorageError> {
         let start_key = kv::stream_record_timestamp::ser_key(stream_id, timestamp, SeqNum::MIN);
+        let end_key = kv::stream_record_timestamp::ser_key(stream_id, Timestamp::MAX, SeqNum::MAX);
         static SCAN_OPTS: ScanOptions = ScanOptions {
             durability_filter: DurabilityLevel::Remote,
             dirty: false,
@@ -41,7 +42,10 @@ impl Backend {
             cache_blocks: false,
             max_fetch_tasks: 1,
         };
-        let mut it = self.db.scan_with_options(start_key.., &SCAN_OPTS).await?;
+        let mut it = self
+            .db
+            .scan_with_options(start_key..end_key, &SCAN_OPTS)
+            .await?;
         Ok(match it.next().await? {
             Some(kv) => {
                 let (deser_stream_id, deser_timestamp, deser_seq_num) =
@@ -75,4 +79,55 @@ pub(super) async fn db_txn_get<K: AsRef<[u8]> + Send, V>(
         .map(deser)
         .transpose()?;
     Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bytesize::ByteSize;
+    use slatedb::{Db, object_store::memory::InMemory};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn resolve_timestamp_bounded_to_stream() {
+        let object_store = Arc::new(InMemory::new());
+        let db = Db::builder("/test", object_store).build().await.unwrap();
+        let backend = Backend::new(db, ByteSize::mib(10));
+
+        let stream_a: StreamId = [0u8; 32].into();
+        let stream_b: StreamId = [1u8; 32].into();
+
+        backend
+            .db
+            .put(
+                kv::stream_record_timestamp::ser_key(stream_a, 1000, 0),
+                kv::stream_record_timestamp::ser_value(),
+            )
+            .await
+            .unwrap();
+        backend
+            .db
+            .put(
+                kv::stream_record_timestamp::ser_key(stream_b, 2000, 0),
+                kv::stream_record_timestamp::ser_value(),
+            )
+            .await
+            .unwrap();
+
+        // Should find record in stream_a
+        let result = backend.resolve_timestamp(stream_a, 500).await.unwrap();
+        assert_eq!(
+            result,
+            Some(StreamPosition {
+                seq_num: 0,
+                timestamp: 1000
+            })
+        );
+
+        // Should return None, not find stream_b's record
+        let result = backend.resolve_timestamp(stream_a, 1500).await.unwrap();
+        assert_eq!(result, None);
+    }
 }


### PR DESCRIPTION
The unbounded scan could return records from other streams when the target stream had no records at or after the requested timestamp, causing an assertion panic.

Closes #65 