### PR TITLE
fix: use per-package tags in release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,6 @@
 [workspace]
 changelog_config = "cliff.toml"
 git_tag_enable = true
-git_tag_name = "v{{ version }}"
+git_tag_name = "{{ package }}-v{{ version }}"
 git_release_enable = true
 pr_labels = ["release"]


### PR DESCRIPTION
## Summary

Using a shared tag `v{{ version }}` caused release-plz to skip publishing packages because it assumed all packages were already released when the tag existed.

Switch to per-package tags `{{ package }}-v{{ version }}` so each package has its own release tag (e.g., `s2-cli-v0.26.0`, `s2-api-v0.26.0`).

## Test plan

- [ ] Merge and re-trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)