### PR TITLE
fix(lite): temporary workaround for slatedb status() method

### DIFF
--- a/lite/src/backend/store.rs
+++ b/lite/src/backend/store.rs
@@ -9,8 +9,11 @@ use super::Backend;
 use crate::backend::{error::StorageError, kv, stream_id::StreamId};
 
 impl Backend {
-    pub fn db_status(&self) -> Result<(), slatedb::Error> {
-        self.db.status()
+    // TODO: switch to `self.db.status()` once slatedb releases with
+    // https://github.com/slatedb/slatedb/pull/1234
+    pub async fn db_status(&self) -> Result<(), slatedb::Error> {
+        let _ = self.db.get(b"ping").await?;
+        Ok(())
     }
 
     pub(super) async fn db_get<K: AsRef<[u8]> + Send, V>(

--- a/lite/src/handlers/mod.rs
+++ b/lite/src/handlers/mod.rs
@@ -17,7 +17,7 @@ pub fn router() -> axum::Router<Backend> {
 }
 
 async fn health(State(backend): State<Backend>) -> Response {
-    match backend.db_status() {
+    match backend.db_status().await {
         Ok(()) => "OK".into_response(),
         Err(err) => (StatusCode::SERVICE_UNAVAILABLE, format!("{err:?}")).into_response(),
     }


### PR DESCRIPTION
## Summary

Use `db.get()` approach until slatedb releases with `db.status()` method.

Blocked by: https://github.com/slatedb/slatedb/pull/1234

Once slatedb releases, we can switch back to `self.db.status()`.

## Test plan

- [x] `cargo check -p s2-lite` passes
- [ ] Merge and re-trigger release

🤖 Generated with [Claude Code](https://claude.com/claude-code)