### PR TITLE
fix: add s2-lite to workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ rkyv = "0.8"
 rstest = "0.26"
 s2-api = { version = "0.26.0", path = "api" }
 s2-common = { version = "0.26.0", path = "common" }
+s2-lite = { version = "0.26.0", path = "lite" }
 s2-sdk = "0.23.1"
 serde = "1.0"
 serde_json = "1.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,7 +33,7 @@ miette = { workspace = true, features = ["fancy"] }
 mimalloc = { workspace = true }
 rand = { workspace = true }
 rcgen = { workspace = true }
-s2-lite = { path = "../lite" }
+s2-lite = { workspace = true }
 s2-sdk = { workspace = true, features = ["_hidden"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }


### PR DESCRIPTION
## Summary

Add `s2-lite` to workspace dependencies so release-plz manages the version automatically. Required for crates.io publishing.

## Test plan

- [x] `cargo check -p s2-cli` passes
- [x] `cargo publish -p s2-cli --dry-run` passes
- [ ] Merge and re-trigger release

🤖 Generated with [Claude Code](https://claude.com/claude-code)