### PR TITLE
ci: add PR title conventional commit check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,32 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            The subject "{subject}" is not valid.
+            Please use a non-empty subject after the type/scope.


### PR DESCRIPTION
## Summary
- Adds a CI workflow to validate PR titles follow conventional commit format
- Uses the `amannn/action-semantic-pull-request` action
- Supports standard types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert

## Test plan
- [ ] Open a PR with an invalid title (e.g., "Add feature") and verify it fails
- [ ] Open a PR with a valid title (e.g., "feat: add feature") and verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)