### PR TITLE
fix(lite): use memory durability for DOE scan

### DIFF
--- a/lite/src/backend/bgtasks/stream_doe.rs
+++ b/lite/src/backend/bgtasks/stream_doe.rs
@@ -73,9 +73,8 @@ impl Backend {
         &self,
         now: TimestampSecs,
     ) -> Result<Page<(StreamId, PendingStreamDoe)>, StorageError> {
-        // Use Memory durability so TTL filtering advances with wall time even when the DB is idle.
         static SCAN_OPTS: ScanOptions = ScanOptions {
-            durability_filter: DurabilityLevel::Memory,
+            durability_filter: DurabilityLevel::Remote,
             dirty: false,
             read_ahead_bytes: 1,
             cache_blocks: false,
@@ -175,8 +174,9 @@ impl Backend {
                 timestamp: Timestamp::MIN,
             },
         );
+        // Use Memory durability so TTL filtering advances with wall time even when the DB is idle.
         static SCAN_OPTS: ScanOptions = ScanOptions {
-            durability_filter: DurabilityLevel::Remote,
+            durability_filter: DurabilityLevel::Memory,
             dirty: false,
             read_ahead_bytes: 1,
             cache_blocks: false,


### PR DESCRIPTION
## Summary
- read DOE emptiness with Memory durability so TTL advances on idle DBs
- document the TTL/time-source rationale in code

## Testing
- not run (not requested)