### PR TITLE
fix(cli): use FuturesOrdered for append ack stream

### DIFF
--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1,6 +1,6 @@
 use std::{pin::Pin, time::Duration};
 
-use futures::{Stream, StreamExt, TryStreamExt, stream, stream::FuturesUnordered};
+use futures::{Stream, StreamExt, TryStreamExt, stream, stream::FuturesOrdered};
 use s2_sdk::{
     self as sdk, S2, S2Stream,
     batching::BatchingConfig,
@@ -498,7 +498,7 @@ where
 
     async_stream::stream! {
         let mut records = records;
-        let mut pending_acks = FuturesUnordered::new();
+        let mut pending_acks = FuturesOrdered::new();
         let mut input_done = false;
         let mut stashed_record: Option<AppendRecord> = None;
         let mut stashed_bytes: u32 = 0;
@@ -509,7 +509,7 @@ where
                     match permit {
                         Ok(permit) => {
                             let record = stashed_record.take().unwrap();
-                            pending_acks.push(permit.submit(record));
+                            pending_acks.push_back(permit.submit(record));
                         }
                         Err(e) => {
                             yield Err(CliError::op(OpKind::Append, e));


### PR DESCRIPTION
Using `FuturesUnordered` was leading to acks being polled out of order. This caused duplications of ack data, e.g.:
```console
  ✓ [APPENDED] 2861695..2862695 // tail: 2925695 @ 1770861677925
  ✓ [APPENDED] 2996740..2997740 // tail: 3006740 @ 1770861677947
  ✓ [APPENDED] 2861695..2862695 // tail: 2925695 @ 1770861677925
```

Fix verified with:
```
seq 0 99999999 \
   | s2 append s2://tttt2222/hi 2>&1 >/dev/null \
   | awk -F'[. ]' '/APPENDED/ { n=$3+0; if (n <= prev) print "NOT MONOTONIC: prev="prev" cur="n" line="NR": "$0; prev=n }'
```