### PR TITLE
fix(common)!: harden Bash hashing

### DIFF
--- a/common/src/bash.rs
+++ b/common/src/bash.rs
@@ -11,7 +11,7 @@ impl Bash {
 
     /// Hashes components separated by a delimiter byte.
     /// Callers must ensure components do not contain the delimiter.
-    pub fn from_bytes_delimited(components: &[&[u8]], delimiter: u8) -> Self {
+    pub fn delimited(components: &[&[u8]], delimiter: u8) -> Self {
         let mut hasher = blake3::Hasher::new();
         for component in components {
             hasher.update(component);
@@ -21,7 +21,7 @@ impl Bash {
     }
 
     /// Hashes components with length prefixes to avoid separator ambiguity.
-    pub fn from_bytes_len_prefixed(components: &[&[u8]]) -> Self {
+    pub fn length_prefixed(components: &[&[u8]]) -> Self {
         let mut hasher = blake3::Hasher::new();
         for component in components {
             hasher.update(&(component.len() as u64).to_le_bytes());
@@ -91,8 +91,8 @@ mod tests {
 
     #[test]
     fn bash_len_prefixed_components_are_unambiguous() {
-        let bash1 = Bash::from_bytes_len_prefixed(&[b"a\0", b"b"]);
-        let bash2 = Bash::from_bytes_len_prefixed(&[b"a", b"\0b"]);
+        let bash1 = Bash::length_prefixed(&[b"a\0", b"b"]);
+        let bash2 = Bash::length_prefixed(&[b"a", b"\0b"]);
 
         assert_ne!(bash1, bash2);
     }

--- a/lite/src/backend/basins.rs
+++ b/lite/src/backend/basins.rs
@@ -215,7 +215,7 @@ impl Backend {
 }
 
 fn creation_idempotency_key(req_token: &RequestToken, config: &BasinConfig) -> Bash {
-    Bash::from_bytes_len_prefixed(&[
+    Bash::length_prefixed(&[
         req_token.as_bytes(),
         &serde_json::to_vec(&s2_api::v1::config::BasinConfig::from(config.clone()))
             .expect("serializable"),

--- a/lite/src/backend/kv/basin_meta.rs
+++ b/lite/src/backend/kv/basin_meta.rs
@@ -262,7 +262,7 @@ mod tests {
             config: config.clone(),
             created_at,
             deleted_at,
-            creation_idempotency_key: Some(Bash::from_bytes_len_prefixed(&[
+            creation_idempotency_key: Some(Bash::length_prefixed(&[
                 b"test-basin",
                 b"request-token-123",
             ])),
@@ -289,10 +289,7 @@ mod tests {
             config: None,
             created_at: OffsetDateTime::from_unix_timestamp(1_234_567).unwrap(),
             deleted_at: None,
-            creation_idempotency_key: Some(Bash::from_bytes_len_prefixed(&[
-                b"my-basin",
-                b"req-789",
-            ])),
+            creation_idempotency_key: Some(Bash::length_prefixed(&[b"my-basin", b"req-789"])),
         };
         let bytes = Bytes::from(serde_json::to_vec(&serde_value).unwrap());
         let decoded = super::deser_value(bytes).unwrap();

--- a/lite/src/backend/kv/stream_meta.rs
+++ b/lite/src/backend/kv/stream_meta.rs
@@ -183,7 +183,7 @@ mod tests {
             config: config.clone(),
             created_at,
             deleted_at,
-            creation_idempotency_key: Some(Bash::from_bytes_len_prefixed(&[
+            creation_idempotency_key: Some(Bash::length_prefixed(&[
                 b"test-basin",
                 b"test-stream",
                 b"request-token-456",
@@ -207,7 +207,7 @@ mod tests {
             config: None,
             created_at: OffsetDateTime::from_unix_timestamp(2_345_678).unwrap(),
             deleted_at: None,
-            creation_idempotency_key: Some(Bash::from_bytes_len_prefixed(&[
+            creation_idempotency_key: Some(Bash::length_prefixed(&[
                 b"my-basin",
                 b"my-stream",
                 b"req-abc",

--- a/lite/src/backend/stream_id.rs
+++ b/lite/src/backend/stream_id.rs
@@ -24,7 +24,7 @@ impl StreamId {
     const SEPARATOR: u8 = 0;
 
     pub fn new(basin: &BasinName, stream: &StreamName) -> Self {
-        Self(Bash::from_bytes_delimited(
+        Self(Bash::delimited(
             &[basin.as_bytes(), stream.as_bytes()],
             Self::SEPARATOR,
         ))

--- a/lite/src/backend/streams.rs
+++ b/lite/src/backend/streams.rs
@@ -350,7 +350,7 @@ impl Backend {
 }
 
 fn creation_idempotency_key(req_token: &RequestToken, config: &OptionalStreamConfig) -> Bash {
-    Bash::from_bytes_len_prefixed(&[
+    Bash::length_prefixed(&[
         req_token.as_bytes(),
         &s2_api::v1::config::StreamConfig::to_opt(config.clone())
             .as_ref()


### PR DESCRIPTION
- introduce `Bash::delimited` for explicit delimiter-based hashing (used only by `StreamId`)
- add `Bash::length_prefixed` for collision-resistant hashing
- use length-prefixed hashing for idempotency keys and kv test fixtures

Fixes #204