### PR TITLE
fix(ci): migrate Docker builds to official buildx actions

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -132,6 +132,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Get version
         id: version
         uses: SebRollen/toml-action@v1.2.0
@@ -139,19 +142,16 @@ jobs:
           file: cli/Cargo.toml
           field: package.version
 
-      - name: Build image
-        run: |
-          docker build \
-            -f Dockerfile \
-            --target runtime \
-            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.value }}-${{ matrix.arch }} \
-            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-${{ matrix.arch }} \
-            .
-
-      - name: Push images
-        run: |
-          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.value }}-${{ matrix.arch }}
-          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-${{ matrix.arch }}
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          target: runtime
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.value }}-${{ matrix.arch }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-${{ matrix.arch }}
 
   create_manifest:
     name: Create multi-arch Docker manifest
@@ -168,6 +168,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Get version
         id: version
         uses: SebRollen/toml-action@v1.2.0
@@ -177,17 +180,15 @@ jobs:
 
       - name: Create and push versioned manifest
         run: |
-          docker manifest create --amend ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.value }} \
+          docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.value }} \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.value }}-x86-64 \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.value }}-arm64
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.value }}
 
       - name: Create and push latest manifest
         run: |
-          docker manifest create --amend ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+          docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-x86-64 \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-arm64
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
   upload_release_artifacts:
     needs: build_binaries


### PR DESCRIPTION
## Summary

- Replace manual `docker build`/`push` with `docker/setup-buildx-action` + `docker/build-push-action` in `build_images` job
- Replace `docker manifest create`/`push` with `docker buildx imagetools create` in `create_manifest` job
- Removes the need for `--provenance=false` / `--amend` workarounds that were required after GitHub runner updates changed Docker's default behavior

## Test plan

- [ ] Trigger `release-cli` workflow via `workflow_dispatch` and verify both `build_images` and `create_manifest` jobs succeed
- [ ] Verify multi-arch manifest with `docker buildx imagetools inspect ghcr.io/s2-streamstore/s2:<version>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)