### PR TITLE
fix: prevent release-plz loop on chart-only commits

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'charts/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Add paths-ignore for charts/** to release-plz.yml so chart-only commits from update_helm_chart don't re-trigger release-plz.