### PR TITLE
fix(lite): avoid caching dead streamer clients

### DIFF
--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -216,9 +216,13 @@ impl Backend {
             if is_same_init {
                 match result {
                     Ok(client) => {
-                        oe.insert(StreamerClientSlot::Ready {
-                            client: client.clone(),
-                        });
+                        if client.is_dead() {
+                            oe.remove();
+                        } else {
+                            oe.insert(StreamerClientSlot::Ready {
+                                client: client.clone(),
+                            });
+                        }
                     }
                     Err(_) => {
                         oe.remove();

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -424,6 +424,10 @@ impl StreamerClient {
         self.id
     }
 
+    pub fn is_dead(&self) -> bool {
+        self.msg_tx.is_closed()
+    }
+
     pub fn stream_id(&self) -> StreamId {
         self.stream_id
     }


### PR DESCRIPTION
- add StreamerClient::is_dead to detect when the streamer task channel is already closed
- in streamer_finish_initialization, remove the slot instead of caching when init returns a dead client
- keep existing stale-init-id behavior intact

Fixes #230 
