### PR TITLE
fix(lite): handle lagged bgtask triggers immediately

### DIFF
--- a/lite/src/backend/bgtasks/mod.rs
+++ b/lite/src/backend/bgtasks/mod.rs
@@ -77,7 +77,15 @@ fn spawn_bgtask<Tick, Fut, E>(
                                 reset_sleep(&mut sleep);
                             }
                         }
-                        Err(broadcast::error::RecvError::Lagged(_)) => {}
+                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                            warn!(
+                                task = name,
+                                skipped,
+                                "bgtask trigger channel lagged, running tick immediately"
+                            );
+                            run_tick(name, &tick, &backend).await;
+                            reset_sleep(&mut sleep);
+                        }
                         Err(broadcast::error::RecvError::Closed) => {
                             break;
                         }


### PR DESCRIPTION
## Summary
- handle `broadcast::error::RecvError::Lagged` in background task trigger receivers
- log a warning with skipped trigger count when the channel lags
- run the corresponding background tick immediately and reset the interval timer

## Testing
- just fmt
- just test *(fails in this environment on existing unrelated test: `s2-cli::cli missing_access_token`)*
- cargo test -p s2-lite backend::bgtasks::tests::run_tick_repeats_until_done

Closes #277
