### PR TITLE
fix: surface DNS resolution details in connect errors

### DIFF
--- a/sdk/src/api.rs
+++ b/sdk/src/api.rs
@@ -1049,6 +1049,8 @@ mod tests {
                 )
                 .unwrap(),
             )
+            // Skip native root CA loading so the test works in sandboxed
+            // CI environments without keychain access.
             .with_insecure_skip_cert_verification(true);
         let client = BaseClient::init(&config).expect("client init");
         let url = "https://no-such-basin.invalid/v1/streams"


### PR DESCRIPTION
## Summary

- Walk the hyper error source chain for hyper-util's structural `"dns error"` tag from `ConnectError::dns()` and extract the underlying resolver message
- DNS failures now show e.g. `"connect: dns resolution: failed to lookup address information: ..."` instead of the opaque `"connect: send error: client error (Connect)"`
- Falls back gracefully to the generic `Connect` variant if hyper-util changes the tag
- Regression test using `.invalid` TLD (RFC 6761) to catch future breakage

**Before:**
```
Failed to append: connect: send error: client error (Connect)
```

**After:**
```
Failed to append: connect: dns resolution: failed to lookup address information: nodename nor servname provided, or not known
```

## Test plan

- [x] `cargo test -p s2-sdk dns_error` passes
- [ ] Manual test: `s2 append s2://nonexistent-basin/stream` shows DNS detail
- [ ] CI passes (test uses `insecure_skip_cert_verification` to avoid native root CA dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)