### PR TITLE
fix(lite): preserve follow wait budget after lagged recovery

### DIFF
--- a/lite/src/backend/read.rs
+++ b/lite/src/backend/read.rs
@@ -187,8 +187,7 @@ impl Backend {
                     }
                     match client.follow(state.start_seq_num).await? {
                         Ok(mut follow_rx) => {
-                            // Re-entering follow after lagged recovery must not extend the
-                            // absolute wait budget unless records were actually delivered.
+                            // Only a delivered batch should reset the absolute wait budget.
                             state.arm_wait_deadline_if_unset();
                             if state.wait_deadline_expired() {
                                 break;


### PR DESCRIPTION
## Summary
- persist the follow-mode wait deadline in read session state so lagged recovery does not reset it
- only re-arm the wait budget when a read batch is actually delivered
- add a regression test for lagged follow recovery when DB catch-up yields no records

## Testing
- cargo test -p s2-lite read_wait_is_not_reset_after_follow_lag_without_catchup_records -- --nocapture
- cargo test -p s2-lite