### PR TITLE
fix: upgrade slatedb to 0.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1565,7 +1565,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1720,7 +1720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3134,7 +3134,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3933,7 +3933,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4460,7 +4460,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5074,9 +5074,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slatedb"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33982c2d4f2f66fddb6e4bd050c6fcc415944221c0c2775a407b5af0af3388"
+checksum = "d945c6cd6f239873e640c5b7bb204f5638ed5681b02145cdcc2e80b2d3882b8a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5121,9 +5121,9 @@ dependencies = [
 
 [[package]]
 name = "slatedb-common"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f25d1e125ea2f5dcf315e7cc40bc4adce655b382d2350ec37b66d7e97802ff"
+checksum = "2893ff22bb9a1013af0fb5e85380307ccd9d0a4fa8a111e187a48750e14b9a47"
 dependencies = [
  "chrono",
  "tokio",
@@ -5131,9 +5131,9 @@ dependencies = [
 
 [[package]]
 name = "slatedb-txn-obj"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5f20e6b8c7d01cb6a4050a495d3a2e8c435bc8ce439c9b0b72fa2d3096bed8"
+checksum = "2c33d5597404e23b9706aa32a1723399f022f0513a289d1059df8810a282dcc4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5353,7 +5353,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6411,7 +6411,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ s2-sdk = { path = "sdk", version = "0.24" }
 schemars = "1.2"
 serde = "1.0"
 serde_json = "1.0"
-slatedb = "0.11"
+slatedb = "0.11.2"
 strum = "0.28"
 tabled = "0.20"
 thiserror = "2.0"


### PR DESCRIPTION
## Summary

- Upgrades slatedb from 0.11.1 to 0.11.2 to fix an unbounded memory leak in `TransactionManager::track_recent_committed_write_batch`
- In 0.11.1, every non-transactional write batch unconditionally pushes a `TransactionState` (with cloned write keys) into an unbounded `VecDeque`. The deque is only drained on explicit transaction drop, which is infrequent in s2's append-heavy workload. This leads to OOM.
- 0.11.2 includes [slatedb/slatedb#1379](https://github.com/slatedb/slatedb/pull/1379) which drains the deque when no active transactions exist

## Evidence

Heap profiles from a production instance showed memory growing from 423 MB → 911 MB in 50 minutes. The block cache plateaued at ~648 MB as expected, while `track_recent_committed_write_batch` and pinned key data grew unboundedly at ~6.7 MB/min (accelerating), putting a 3 GB container on track to OOM within hours.

## Test plan

- [x] `cargo check` passes
- [ ] CI passes
- [ ] Deploy to staging and verify memory stabilizes after cache fills

🤖 Generated with [Claude Code](https://claude.com/claude-code)