### PR TITLE
feat(common): add EnumString and IntoStaticStr derives to BasinScope

### DIFF
--- a/common/src/types/basin.rs
+++ b/common/src/types/basin.rs
@@ -200,7 +200,9 @@ impl crate::http::ParseableHeader for BasinName {
 
 pub type ListBasinsRequest = ListItemsRequest<BasinNamePrefix, BasinNameStartAfter>;
 
-#[derive(Debug, strum::Display, Clone, Copy, PartialEq, Eq)]
+#[derive(
+    Debug, strum::Display, strum::EnumString, strum::IntoStaticStr, Clone, Copy, PartialEq, Eq,
+)]
 pub enum BasinScope {
     #[strum(serialize = "aws:us-east-1")]
     AwsUsEast1,


### PR DESCRIPTION
## Summary
- Add `strum::EnumString` and `strum::IntoStaticStr` derives to `BasinScope` enum, enabling string parsing and static str conversion.

## Test plan
- [ ] `just test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)