### PR TITLE
chore: update basin endpoint from b.aws.s2.dev to b.s2.dev

### DIFF
--- a/lite/src/handlers/v1/paths.rs
+++ b/lite/src/handlers/v1/paths.rs
@@ -52,5 +52,5 @@ pub mod streams {
 
 pub mod cloud_endpoints {
     pub const ACCOUNT: &str = "https://aws.s2.dev/v1";
-    pub const BASIN: &str = "https://{basin}.b.aws.s2.dev/v1";
+    pub const BASIN: &str = "https://{basin}.b.s2.dev/v1";
 }

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -254,7 +254,7 @@ impl S2Endpoints {
             scheme: Scheme::HTTPS,
             account_authority: "aws.s2.dev".try_into().expect("valid authority"),
             basin_authority: BasinAuthority::ParentZone(
-                "b.aws.s2.dev".try_into().expect("valid authority"),
+                "b.s2.dev".try_into().expect("valid authority"),
             ),
         }
     }


### PR DESCRIPTION
## Summary
- Update basin endpoint from `b.aws.s2.dev` to `b.s2.dev` in both lite handler paths and SDK default endpoints.

## Test plan
- [ ] Verify basin connections work with the new endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)