### PR TITLE
refactor: decouple JSON extraction rejection from axum

### DIFF
--- a/api/src/data.rs
+++ b/api/src/data.rs
@@ -175,6 +175,7 @@ pub mod extract {
         }
     }
 
+    // TODO: remove when we stop delegating to axum::Json.
     impl From<axum::extract::rejection::JsonRejection> for JsonExtractionRejection {
         fn from(rej: axum::extract::rejection::JsonRejection) -> Self {
             use axum::extract::rejection::JsonRejection::*;

--- a/api/src/data.rs
+++ b/api/src/data.rs
@@ -119,23 +119,22 @@ pub mod extract {
             status: http::StatusCode,
             message: Cow<'static, str>,
         },
-        MissingContentType {
-            status: http::StatusCode,
-            message: Cow<'static, str>,
-        },
+        MissingContentType,
         Other {
             status: http::StatusCode,
             message: Cow<'static, str>,
         },
     }
 
+    const MISSING_CONTENT_TYPE_MSG: &str = "Expected request with `Content-Type: application/json`";
+
     impl JsonExtractionRejection {
-        pub fn body_text(&self) -> String {
+        pub fn body_text(&self) -> &str {
             match self {
                 Self::SyntaxError { message, .. }
                 | Self::DataError { message, .. }
-                | Self::MissingContentType { message, .. }
-                | Self::Other { message, .. } => message.clone().into_owned(),
+                | Self::Other { message, .. } => message,
+                Self::MissingContentType => MISSING_CONTENT_TYPE_MSG,
             }
         }
 
@@ -143,20 +142,15 @@ pub mod extract {
             match self {
                 Self::SyntaxError { status, .. }
                 | Self::DataError { status, .. }
-                | Self::MissingContentType { status, .. }
                 | Self::Other { status, .. } => *status,
+                Self::MissingContentType => http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
             }
         }
     }
 
     impl std::fmt::Display for JsonExtractionRejection {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self {
-                Self::SyntaxError { message, .. }
-                | Self::DataError { message, .. }
-                | Self::MissingContentType { message, .. }
-                | Self::Other { message, .. } => f.write_str(message),
-            }
+            f.write_str(self.body_text())
         }
     }
 
@@ -165,13 +159,15 @@ pub mod extract {
     impl IntoResponse for JsonExtractionRejection {
         fn into_response(self) -> Response {
             let status = self.status();
-            let message = match self {
+            match self {
                 Self::SyntaxError { message, .. }
                 | Self::DataError { message, .. }
-                | Self::MissingContentType { message, .. }
-                | Self::Other { message, .. } => message,
-            };
-            (status, message.into_owned()).into_response()
+                | Self::Other { message, .. } => match message {
+                    Cow::Borrowed(s) => (status, s).into_response(),
+                    Cow::Owned(s) => (status, s).into_response(),
+                },
+                Self::MissingContentType => (status, MISSING_CONTENT_TYPE_MSG).into_response(),
+            }
         }
     }
 
@@ -188,10 +184,7 @@ pub mod extract {
                     status: e.status(),
                     message: e.body_text().into(),
                 },
-                MissingJsonContentType(e) => Self::MissingContentType {
-                    status: e.status(),
-                    message: e.body_text().into(),
-                },
+                MissingJsonContentType(_) => Self::MissingContentType,
                 other => Self::Other {
                     status: other.status(),
                     message: other.body_text().into(),
@@ -230,12 +223,7 @@ pub mod extract {
                 .as_ref()
                 .is_some_and(crate::mime::is_json)
             {
-                return Err(JsonExtractionRejection::MissingContentType {
-                    status: http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
-                    message: Cow::Borrowed(
-                        "Expected request with `Content-Type: application/json`",
-                    ),
-                });
+                return Err(JsonExtractionRejection::MissingContentType);
             }
             let bytes = Bytes::from_request(req, state).await.map_err(|e| {
                 JsonExtractionRejection::Other {

--- a/api/src/data.rs
+++ b/api/src/data.rs
@@ -286,21 +286,18 @@ pub mod extract {
         }
     }
 
-    /// Classify a JSON deserialization error via axum's pipeline and return the
-    /// status code from our rejection type. Used in tests to verify error
-    /// classification is consistent.
-    pub fn classify_json_error<T: DeserializeOwned>(
-        json: &[u8],
-    ) -> Result<T, JsonExtractionRejection> {
-        axum::Json::<T>::from_bytes(json)
-            .map(|axum::Json(v)| v)
-            .map_err(JsonExtractionRejection::from)
-    }
-
     #[cfg(test)]
     mod tests {
         use super::*;
         use crate::v1::stream::AppendInput;
+
+        fn classify_json_error<T: DeserializeOwned>(
+            json: &[u8],
+        ) -> Result<T, JsonExtractionRejection> {
+            axum::Json::<T>::from_bytes(json)
+                .map(|axum::Json(v)| v)
+                .map_err(JsonExtractionRejection::from)
+        }
 
         /// Verify that our rejection wrapper preserves axum's status code
         /// classification for a variety of invalid JSON payloads. This same

--- a/api/src/data.rs
+++ b/api/src/data.rs
@@ -105,15 +105,7 @@ pub mod extract {
     use bytes::Bytes;
     use serde::de::DeserializeOwned;
 
-    /// JSON extraction rejection type owned by s2-api.
-    ///
-    /// Decouples consumers from `axum::extract::rejection::JsonRejection` so the
-    /// underlying deserializer can be swapped without changing downstream code.
-    /// JSON extraction rejection type owned by s2-api.
-    ///
-    /// Every variant stores its status code and pre-rendered message so that
-    /// `body_text()`, `Display`, and `IntoResponse` all return the same
-    /// string without re-allocating.
+    /// Rejection type for JSON extraction, owned by s2-api.
     #[derive(Debug)]
     #[non_exhaustive]
     pub enum JsonExtractionRejection {
@@ -136,8 +128,6 @@ pub mod extract {
     }
 
     impl JsonExtractionRejection {
-        /// Return the pre-rendered error message. No allocation — returns a
-        /// clone of the already-stored `String`.
         pub fn body_text(&self) -> String {
             match self {
                 Self::SyntaxError { message, .. }

--- a/api/src/data.rs
+++ b/api/src/data.rs
@@ -109,6 +109,11 @@ pub mod extract {
     ///
     /// Decouples consumers from `axum::extract::rejection::JsonRejection` so the
     /// underlying deserializer can be swapped without changing downstream code.
+    /// JSON extraction rejection type owned by s2-api.
+    ///
+    /// Every variant stores its status code and pre-rendered message so that
+    /// `body_text()`, `Display`, and `IntoResponse` all return the same
+    /// string without re-allocating.
     #[derive(Debug)]
     #[non_exhaustive]
     pub enum JsonExtractionRejection {
@@ -120,7 +125,10 @@ pub mod extract {
             status: http::StatusCode,
             message: String,
         },
-        MissingContentType,
+        MissingContentType {
+            status: http::StatusCode,
+            message: String,
+        },
         Other {
             status: http::StatusCode,
             message: String,
@@ -128,16 +136,23 @@ pub mod extract {
     }
 
     impl JsonExtractionRejection {
+        /// Return the pre-rendered error message. No allocation — returns a
+        /// clone of the already-stored `String`.
         pub fn body_text(&self) -> String {
-            self.to_string()
+            match self {
+                Self::SyntaxError { message, .. }
+                | Self::DataError { message, .. }
+                | Self::MissingContentType { message, .. }
+                | Self::Other { message, .. } => message.clone(),
+            }
         }
 
         pub fn status(&self) -> http::StatusCode {
             match self {
-                Self::SyntaxError { status, .. } => *status,
-                Self::DataError { status, .. } => *status,
-                Self::MissingContentType => http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
-                Self::Other { status, .. } => *status,
+                Self::SyntaxError { status, .. }
+                | Self::DataError { status, .. }
+                | Self::MissingContentType { status, .. }
+                | Self::Other { status, .. } => *status,
             }
         }
     }
@@ -145,12 +160,10 @@ pub mod extract {
     impl std::fmt::Display for JsonExtractionRejection {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             match self {
-                Self::SyntaxError { message, .. } => f.write_str(message),
-                Self::DataError { message, .. } => f.write_str(message),
-                Self::MissingContentType => {
-                    f.write_str("Expected request with `Content-Type: application/json`")
-                }
-                Self::Other { message, .. } => f.write_str(message),
+                Self::SyntaxError { message, .. }
+                | Self::DataError { message, .. }
+                | Self::MissingContentType { message, .. }
+                | Self::Other { message, .. } => f.write_str(message),
             }
         }
     }
@@ -159,7 +172,15 @@ pub mod extract {
 
     impl IntoResponse for JsonExtractionRejection {
         fn into_response(self) -> Response {
-            (self.status(), self.body_text()).into_response()
+            let status = self.status();
+            // Destructure to move the String — no clone.
+            let message = match self {
+                Self::SyntaxError { message, .. }
+                | Self::DataError { message, .. }
+                | Self::MissingContentType { message, .. }
+                | Self::Other { message, .. } => message,
+            };
+            (status, message).into_response()
         }
     }
 
@@ -175,7 +196,10 @@ pub mod extract {
                     status: e.status(),
                     message: e.body_text(),
                 },
-                MissingJsonContentType(_) => Self::MissingContentType,
+                MissingJsonContentType(e) => Self::MissingContentType {
+                    status: e.status(),
+                    message: e.body_text(),
+                },
                 other => Self::Other {
                     status: other.status(),
                     message: other.body_text(),
@@ -214,7 +238,10 @@ pub mod extract {
                 .as_ref()
                 .is_some_and(crate::mime::is_json)
             {
-                return Err(JsonExtractionRejection::MissingContentType);
+                return Err(JsonExtractionRejection::MissingContentType {
+                    status: http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                    message: "Expected request with `Content-Type: application/json`".into(),
+                });
             }
             let bytes = Bytes::from_request(req, state).await.map_err(|e| {
                 JsonExtractionRejection::Other {

--- a/api/src/data.rs
+++ b/api/src/data.rs
@@ -99,25 +99,102 @@ pub struct S2FormatHeader {
 #[cfg(feature = "axum")]
 pub mod extract {
     use axum::{
-        extract::{
-            FromRequest, OptionalFromRequest, Request,
-            rejection::{BytesRejection, JsonRejection},
-        },
+        extract::{FromRequest, OptionalFromRequest, Request, rejection::BytesRejection},
         response::{IntoResponse, Response},
     };
     use bytes::Bytes;
     use serde::de::DeserializeOwned;
+
+    /// JSON extraction rejection type owned by s2-api.
+    ///
+    /// Decouples consumers from `axum::extract::rejection::JsonRejection` so the
+    /// underlying deserializer can be swapped without changing downstream code.
+    #[derive(Debug)]
+    #[non_exhaustive]
+    pub enum JsonExtractionRejection {
+        SyntaxError {
+            status: http::StatusCode,
+            message: String,
+        },
+        DataError {
+            status: http::StatusCode,
+            message: String,
+        },
+        MissingContentType,
+        Other {
+            status: http::StatusCode,
+            message: String,
+        },
+    }
+
+    impl JsonExtractionRejection {
+        pub fn body_text(&self) -> String {
+            self.to_string()
+        }
+
+        pub fn status(&self) -> http::StatusCode {
+            match self {
+                Self::SyntaxError { status, .. } => *status,
+                Self::DataError { status, .. } => *status,
+                Self::MissingContentType => http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                Self::Other { status, .. } => *status,
+            }
+        }
+    }
+
+    impl std::fmt::Display for JsonExtractionRejection {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::SyntaxError { message, .. } => f.write_str(message),
+                Self::DataError { message, .. } => f.write_str(message),
+                Self::MissingContentType => {
+                    f.write_str("Expected request with `Content-Type: application/json`")
+                }
+                Self::Other { message, .. } => f.write_str(message),
+            }
+        }
+    }
+
+    impl std::error::Error for JsonExtractionRejection {}
+
+    impl IntoResponse for JsonExtractionRejection {
+        fn into_response(self) -> Response {
+            (self.status(), self.body_text()).into_response()
+        }
+    }
+
+    impl From<axum::extract::rejection::JsonRejection> for JsonExtractionRejection {
+        fn from(rej: axum::extract::rejection::JsonRejection) -> Self {
+            use axum::extract::rejection::JsonRejection::*;
+            match rej {
+                JsonDataError(e) => Self::DataError {
+                    status: e.status(),
+                    message: e.body_text(),
+                },
+                JsonSyntaxError(e) => Self::SyntaxError {
+                    status: e.status(),
+                    message: e.body_text(),
+                },
+                MissingJsonContentType(_) => Self::MissingContentType,
+                other => Self::Other {
+                    status: other.status(),
+                    message: other.body_text(),
+                },
+            }
+        }
+    }
 
     impl<S, T> FromRequest<S> for super::Json<T>
     where
         S: Send + Sync,
         T: DeserializeOwned,
     {
-        type Rejection = JsonRejection;
+        type Rejection = JsonExtractionRejection;
 
         async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
-            let axum::Json(value) =
-                <axum::Json<T> as FromRequest<S>>::from_request(req, state).await?;
+            let axum::Json(value) = <axum::Json<T> as FromRequest<S>>::from_request(req, state)
+                .await
+                .map_err(JsonExtractionRejection::from)?;
             Ok(Self(value))
         }
     }
@@ -127,7 +204,7 @@ pub mod extract {
         S: Send + Sync,
         T: DeserializeOwned,
     {
-        type Rejection = JsonRejection;
+        type Rejection = JsonExtractionRejection;
 
         async fn from_request(req: Request, state: &S) -> Result<Option<Self>, Self::Rejection> {
             let Some(ctype) = req.headers().get(http::header::CONTENT_TYPE) else {
@@ -137,15 +214,20 @@ pub mod extract {
                 .as_ref()
                 .is_some_and(crate::mime::is_json)
             {
-                Err(JsonRejection::MissingJsonContentType(Default::default()))?;
+                return Err(JsonExtractionRejection::MissingContentType);
             }
-            let bytes = Bytes::from_request(req, state)
-                .await
-                .map_err(JsonRejection::BytesRejection)?;
+            let bytes = Bytes::from_request(req, state).await.map_err(|e| {
+                JsonExtractionRejection::Other {
+                    status: e.status(),
+                    message: e.body_text(),
+                }
+            })?;
             if bytes.is_empty() {
                 return Ok(None);
             }
-            let value = axum::Json::<T>::from_bytes(&bytes)?.0;
+            let value = axum::Json::<T>::from_bytes(&bytes)
+                .map_err(JsonExtractionRejection::from)?
+                .0;
             Ok(Some(Self(value)))
         }
     }
@@ -159,7 +241,7 @@ pub mod extract {
         S: Send + Sync,
         T: DeserializeOwned,
     {
-        type Rejection = JsonRejection;
+        type Rejection = JsonExtractionRejection;
 
         async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
             match <super::Json<T> as OptionalFromRequest<S>>::from_request(req, state).await {
@@ -201,6 +283,71 @@ pub mod extract {
         async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
             let bytes = Bytes::from_request(req, state).await?;
             Ok(super::Proto(T::decode(bytes)?))
+        }
+    }
+
+    /// Classify a JSON deserialization error via axum's pipeline and return the
+    /// status code from our rejection type. Used in tests to verify error
+    /// classification is consistent.
+    pub fn classify_json_error<T: DeserializeOwned>(
+        json: &[u8],
+    ) -> Result<T, JsonExtractionRejection> {
+        axum::Json::<T>::from_bytes(json)
+            .map(|axum::Json(v)| v)
+            .map_err(JsonExtractionRejection::from)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::v1::stream::AppendInput;
+
+        /// Verify that our rejection wrapper preserves axum's status code
+        /// classification for a variety of invalid JSON payloads. This same
+        /// table will be reused when switching to sonic-rs in PR 2.
+        #[test]
+        fn json_error_classification() {
+            let cases: &[(&[u8], http::StatusCode)] = &[
+                // Syntax errors → 400
+                (b"not json", http::StatusCode::BAD_REQUEST),
+                // `{}` is valid JSON but missing `records` — axum reports data error
+                // before checking trailing chars.
+                (b"{} trailing", http::StatusCode::UNPROCESSABLE_ENTITY),
+                (b"", http::StatusCode::BAD_REQUEST),
+                (b"{truncated", http::StatusCode::BAD_REQUEST),
+                // Data errors → 422
+                (b"{}", http::StatusCode::UNPROCESSABLE_ENTITY),
+                (
+                    br#"{"records": "nope"}"#,
+                    http::StatusCode::UNPROCESSABLE_ENTITY,
+                ),
+                (
+                    br#"{"records": [{"body": 123}]}"#,
+                    http::StatusCode::UNPROCESSABLE_ENTITY,
+                ),
+            ];
+
+            for (input, expected_status) in cases {
+                let err = classify_json_error::<AppendInput>(input).expect_err(&format!(
+                    "expected error for {:?}",
+                    String::from_utf8_lossy(input)
+                ));
+                assert_eq!(
+                    err.status(),
+                    *expected_status,
+                    "wrong status for {:?}: got {}, body: {}",
+                    String::from_utf8_lossy(input),
+                    err.status(),
+                    err.body_text(),
+                );
+            }
+        }
+
+        #[test]
+        fn valid_json_parses_successfully() {
+            let input = br#"{"records": [], "match_seq_num": null}"#;
+            let result = classify_json_error::<AppendInput>(input);
+            assert!(result.is_ok());
         }
     }
 }

--- a/api/src/data.rs
+++ b/api/src/data.rs
@@ -165,7 +165,13 @@ pub mod extract {
     impl IntoResponse for JsonExtractionRejection {
         fn into_response(self) -> Response {
             let status = self.status();
-            (status, self.to_string()).into_response()
+            let message = match self {
+                Self::SyntaxError { message, .. }
+                | Self::DataError { message, .. }
+                | Self::MissingContentType { message, .. }
+                | Self::Other { message, .. } => message,
+            };
+            (status, message.into_owned()).into_response()
         }
     }
 

--- a/api/src/data.rs
+++ b/api/src/data.rs
@@ -98,6 +98,8 @@ pub struct S2FormatHeader {
 
 #[cfg(feature = "axum")]
 pub mod extract {
+    use std::borrow::Cow;
+
     use axum::{
         extract::{FromRequest, OptionalFromRequest, Request, rejection::BytesRejection},
         response::{IntoResponse, Response},
@@ -111,19 +113,19 @@ pub mod extract {
     pub enum JsonExtractionRejection {
         SyntaxError {
             status: http::StatusCode,
-            message: String,
+            message: Cow<'static, str>,
         },
         DataError {
             status: http::StatusCode,
-            message: String,
+            message: Cow<'static, str>,
         },
         MissingContentType {
             status: http::StatusCode,
-            message: String,
+            message: Cow<'static, str>,
         },
         Other {
             status: http::StatusCode,
-            message: String,
+            message: Cow<'static, str>,
         },
     }
 
@@ -133,7 +135,7 @@ pub mod extract {
                 Self::SyntaxError { message, .. }
                 | Self::DataError { message, .. }
                 | Self::MissingContentType { message, .. }
-                | Self::Other { message, .. } => message.clone(),
+                | Self::Other { message, .. } => message.clone().into_owned(),
             }
         }
 
@@ -163,14 +165,7 @@ pub mod extract {
     impl IntoResponse for JsonExtractionRejection {
         fn into_response(self) -> Response {
             let status = self.status();
-            // Destructure to move the String — no clone.
-            let message = match self {
-                Self::SyntaxError { message, .. }
-                | Self::DataError { message, .. }
-                | Self::MissingContentType { message, .. }
-                | Self::Other { message, .. } => message,
-            };
-            (status, message).into_response()
+            (status, self.to_string()).into_response()
         }
     }
 
@@ -180,19 +175,19 @@ pub mod extract {
             match rej {
                 JsonDataError(e) => Self::DataError {
                     status: e.status(),
-                    message: e.body_text(),
+                    message: e.body_text().into(),
                 },
                 JsonSyntaxError(e) => Self::SyntaxError {
                     status: e.status(),
-                    message: e.body_text(),
+                    message: e.body_text().into(),
                 },
                 MissingJsonContentType(e) => Self::MissingContentType {
                     status: e.status(),
-                    message: e.body_text(),
+                    message: e.body_text().into(),
                 },
                 other => Self::Other {
                     status: other.status(),
-                    message: other.body_text(),
+                    message: other.body_text().into(),
                 },
             }
         }
@@ -230,13 +225,15 @@ pub mod extract {
             {
                 return Err(JsonExtractionRejection::MissingContentType {
                     status: http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
-                    message: "Expected request with `Content-Type: application/json`".into(),
+                    message: Cow::Borrowed(
+                        "Expected request with `Content-Type: application/json`",
+                    ),
                 });
             }
             let bytes = Bytes::from_request(req, state).await.map_err(|e| {
                 JsonExtractionRejection::Other {
                     status: e.status(),
-                    message: e.body_text(),
+                    message: e.body_text().into(),
                 }
             })?;
             if bytes.is_empty() {

--- a/api/src/v1/stream/extract.rs
+++ b/api/src/v1/stream/extract.rs
@@ -1,6 +1,5 @@
 use axum::{
-    Json,
-    extract::{FromRequest, FromRequestParts, Request, rejection::JsonRejection},
+    extract::{FromRequest, FromRequestParts, Request},
     response::{IntoResponse, Response},
 };
 use futures::StreamExt as _;
@@ -13,7 +12,10 @@ use tokio_util::{codec::FramedRead, io::StreamReader};
 
 use super::{AppendInput, AppendInputStreamError, AppendRequest, ReadRequest, proto, s2s};
 use crate::{
-    data::{Format, Proto, extract::ProtoRejection},
+    data::{
+        Format, Json, Proto,
+        extract::{JsonExtractionRejection, ProtoRejection},
+    },
     mime::JsonOrProto,
     v1::stream::sse::LastEventId,
 };
@@ -23,7 +25,7 @@ pub enum AppendRequestRejection {
     #[error(transparent)]
     HeaderRejection(#[from] HeaderRejection),
     #[error(transparent)]
-    JsonRejection(#[from] JsonRejection),
+    JsonRejection(#[from] JsonExtractionRejection),
     #[error(transparent)]
     ProtoRejection(#[from] ProtoRejection),
     #[error(transparent)]

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -1,9 +1,9 @@
 use axum::{
-    extract::rejection::{JsonRejection, PathRejection, QueryRejection},
+    extract::rejection::{PathRejection, QueryRejection},
     response::{IntoResponse, Response},
 };
 use s2_api::{
-    data::extract::ProtoRejection,
+    data::extract::{JsonExtractionRejection, ProtoRejection},
     v1::{
         self as v1t,
         error::{ErrorCode, ErrorInfo, ErrorResponse, StandardError},
@@ -27,7 +27,7 @@ pub enum ServiceError {
     #[error(transparent)]
     QueryRejection(#[from] QueryRejection),
     #[error(transparent)]
-    JsonRejection(#[from] JsonRejection),
+    JsonRejection(#[from] JsonExtractionRejection),
     #[error(transparent)]
     ProtoRejection(#[from] ProtoRejection),
     #[error(transparent)]

--- a/sdk/src/api.rs
+++ b/sdk/src/api.rs
@@ -1247,6 +1247,7 @@ mod tests {
 
     #[tokio::test]
     async fn dns_error_message_is_clear() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         let config = crate::types::S2Config::new("test-token".to_owned())
             .with_endpoints(
                 crate::types::S2Endpoints::new(


### PR DESCRIPTION
## Summary

Introduces `JsonExtractionRejection` — an s2-api-owned rejection type replacing direct usage of `axum::extract::rejection::JsonRejection` in the public API. Consumers import from `s2_api::data::extract` instead of `axum`.

## Motivation

Consumers of s2-api with the `axum` feature currently need to import `axum::extract::rejection::JsonRejection` directly. This couples them to axum's internal rejection types, making it harder to evolve the extraction layer independently.

With this change, consumers only depend on `s2_api::data::extract::JsonExtractionRejection`, which exposes the same `body_text()` and `status()` interface.

## Design

- All variants are uniform `{ status: StatusCode, message: Cow<'static, str> }` — no special cases
- `Cow<'static, str>` allows zero-alloc construction for static messages (e.g. `MissingContentType`) while carrying dynamic error strings from the deserializer as `Cow::Owned`
- `From<axum::JsonRejection>` bridge converts at the boundary — `FromRequest` still delegates to `axum::Json` internally
- `IntoResponse` moves the `Cow` and calls `into_owned()` — no-op for `Cow::Owned`, one small alloc for `Cow::Borrowed`
- Enum is `#[non_exhaustive]` for forward compatibility
- Wildcard match arm uses `rej.status()` (not hardcoded) to handle future axum rejection variants

## Allocation impact

`Cow` reduces the worst case (static-literal construction) but there are still extra clones in the downstream response rendering path (e.g. `body_text()` returns `String`, and `lite`'s `ServiceError::to_response` clones when building `ErrorInfo`). That's acceptable for this decoupling PR to keep scope tight — it isn't allocation-neutral yet, but the success path is unchanged and the error path costs are honest.

| Path | Before | After |
|---|---|---|
| Success | zero | zero |
| MissingContentType construction | zero (axum static) | zero (`Cow::Borrowed`) |
| Syntax/Data error construction | 1 alloc (axum `body_text()`) | 1 alloc (`body_text().into()` → `Cow::Owned`) |
| `IntoResponse` rendering | 0 (axum moves internally) | 0 for `Cow::Owned` (`into_owned` unwraps), 1 small alloc for `Cow::Borrowed` |
| `body_text()` caller (e.g. lite) | 1 alloc | 1 alloc (`into_owned()` → `String`) |
| `Display` / logging | 0 | 0 (writes from `Cow` directly) |

## Changes

- **`api/src/data.rs`**: `JsonExtractionRejection` enum with `Cow<'static, str>` messages, `From<axum::JsonRejection>` bridge, `body_text()`/`status()`/`IntoResponse`/`Display`/`Error` impls. `FromRequest` and `OptionalFromRequest` for `Json<T>` now return `JsonExtractionRejection`. Error classification test verifies 400/422 status code parity with axum.
- **`api/src/v1/stream/extract.rs`**: `AppendRequestRejection` wraps `JsonExtractionRejection` instead of `axum::JsonRejection`. Imports `crate::data::Json` instead of `axum::Json`.
- **`lite/src/handlers/v1/error.rs`**: Import swap from `axum::extract::rejection::JsonRejection` to `s2_api::data::extract::JsonExtractionRejection`.
- **`sdk/src/api.rs`**: Fix pre-existing `dns_error_message_is_clear` test failure — install rustls `CryptoProvider` (required since rustls 0.23+).

## Test plan

- [x] `cargo check --workspace` passes
- [x] `just test` — all pass (including previously broken DNS test)
- [x] New `json_error_classification` test: verifies status codes for syntax errors (400) and data errors (422) across 7 input cases
- [x] New `valid_json_parses_successfully` test: verifies happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)