### PR TITLE
fix(common): return error instead of panicking on truncated record bytes

### DIFF
--- a/common/src/record/mod.rs
+++ b/common/src/record/mod.rs
@@ -497,6 +497,16 @@ mod test {
     }
 
     #[test]
+    fn metered_record_truncated_after_magic_byte_returns_error() {
+        // Magic byte: Envelope (0b0000_0010), metered_size_varlen = 1 → expects 1 more byte.
+        let truncated = Bytes::from_static(&[0b0000_0010]);
+        assert_eq!(
+            Metered::<Record>::try_from(truncated),
+            Err(InternalRecordError::Truncated("MeteredSize"))
+        );
+    }
+
+    #[test]
     fn test_read_varint() {
         let data = [0u8, 0, 0, 1, 0, 0, 0];
 


### PR DESCRIPTION
## Summary
- Replace `get_uint` with `try_get_uint` when parsing metered size in `TryFrom<Bytes> for Metered<Record>`, returning `InternalRecordError::Truncated("MeteredSize")` instead of panicking.
- Consistent with the safe parsing pattern already used in `envelope.rs` and `decode_if_command_record`.

Closes #355

## Test plan
- [ ] Verify `cargo check` passes
- [ ] Confirm truncated input (valid magic byte but missing metered size bytes) returns `Err` instead of panicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)