### PR TITLE
test: stabilize follow-mode timing coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4780,6 +4780,7 @@ dependencies = [
  "prost",
  "rand 0.10.0",
  "rcgen",
+ "rstest",
  "rustls",
  "s2-api",
  "s2-common",

--- a/lite/Cargo.toml
+++ b/lite/Cargo.toml
@@ -63,6 +63,7 @@ utoipa = { version = "5.4", optional = true, features = ["time"] }
 
 [dev-dependencies]
 proptest = { workspace = true }
+rstest = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "test-util", "time"] }
 tower = "0.5"
 uuid = { workspace = true, features = ["v4"] }

--- a/lite/tests/backend/data_plane/read_follow.rs
+++ b/lite/tests/backend/data_plane/read_follow.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use futures::StreamExt;
+use rstest::rstest;
 use s2_common::{
     encryption::EncryptionConfig,
     read_extent::{ReadLimit, ReadUntil},
@@ -214,16 +215,15 @@ async fn test_follow_mode_heartbeats() {
     assert!(heartbeat_count > 0);
 }
 
+#[rstest]
+#[case::plaintext("follow-new-data", EncryptionConfig::Plain)]
+#[case::encrypted("follow-enc", aegis256_encryption())]
 #[tokio::test(flavor = "current_thread", start_paused = true)]
-async fn test_follow_mode_receives_new_data() {
-    let encryption = EncryptionConfig::Plain;
-    assert_follow_mode_receives_new_data("follow-new-data", &encryption).await;
-}
-
-#[tokio::test(flavor = "current_thread", start_paused = true)]
-async fn test_follow_mode_receives_new_encrypted_data() {
-    let encryption = aegis256_encryption();
-    assert_follow_mode_receives_new_data("follow-enc", &encryption).await;
+async fn test_follow_mode_receives_new_data(
+    #[case] test_suffix: &str,
+    #[case] encryption: EncryptionConfig,
+) {
+    assert_follow_mode_receives_new_data(test_suffix, &encryption).await;
 }
 
 #[tokio::test]

--- a/lite/tests/backend/data_plane/read_follow.rs
+++ b/lite/tests/backend/data_plane/read_follow.rs
@@ -15,7 +15,7 @@ use s2_lite::backend::FOLLOWER_MAX_LAG;
 
 use super::common::*;
 
-async fn assert_follow_mode_receives_new_data(test_suffix: &str, encryption: &EncryptionConfig) {
+async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &EncryptionConfig) {
     let (backend, basin_name, stream_name) =
         setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await;
 
@@ -223,7 +223,7 @@ async fn test_follow_mode_receives_new_data(
     #[case] test_suffix: &str,
     #[case] encryption: EncryptionConfig,
 ) {
-    assert_follow_mode_receives_new_data(test_suffix, &encryption).await;
+    run_follow_mode_receives_new_data_case(test_suffix, &encryption).await;
 }
 
 #[tokio::test]

--- a/lite/tests/backend/data_plane/read_follow.rs
+++ b/lite/tests/backend/data_plane/read_follow.rs
@@ -70,19 +70,36 @@ async fn assert_follow_mode_receives_new_data(test_suffix: &str, encryption: &En
     });
 
     let mut all_records = Vec::new();
-    let timeout = Duration::from_secs(4);
-    let start_time = tokio::time::Instant::now();
+    while all_records.len() < 3 {
+        let output = {
+            let mut pinned_session = session.as_mut();
+            let next = pinned_session.next();
+            tokio::pin!(next);
+            let mut advanced = Duration::ZERO;
 
-    while start_time.elapsed() < timeout && all_records.len() < 3 {
-        match tokio::time::timeout(Duration::from_millis(500), session.as_mut().next()).await {
-            Ok(Some(Ok(StoredReadSessionOutput::Batch(batch)))) => {
+            loop {
+                tokio::select! {
+                    output = &mut next => break output,
+                    () = tokio::time::advance(Duration::from_millis(100)) => {
+                        advanced += Duration::from_millis(100);
+                        assert!(
+                            advanced <= Duration::from_secs(4),
+                            "timed out waiting for follow-mode output"
+                        );
+                        tokio::task::yield_now().await;
+                    }
+                }
+            }
+        };
+
+        match output {
+            Some(Ok(StoredReadSessionOutput::Batch(batch))) => {
                 let batch = decrypt_batch_for_stream(batch, &basin_name, &stream_name, encryption);
                 all_records.extend(batch.records.iter().cloned());
             }
-            Ok(Some(Ok(StoredReadSessionOutput::Heartbeat(_)))) => continue,
-            Ok(Some(Err(e))) => panic!("Read error: {:?}", e),
-            Ok(None) => break,
-            Err(_) => continue,
+            Some(Ok(StoredReadSessionOutput::Heartbeat(_))) => {}
+            Some(Err(e)) => panic!("Read error: {:?}", e),
+            None => break,
         }
     }
 
@@ -197,13 +214,13 @@ async fn test_follow_mode_heartbeats() {
     assert!(heartbeat_count > 0);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_follow_mode_receives_new_data() {
     let encryption = EncryptionConfig::Plain;
     assert_follow_mode_receives_new_data("follow-new-data", &encryption).await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_follow_mode_receives_new_encrypted_data() {
     let encryption = aegis256_encryption();
     assert_follow_mode_receives_new_data("follow-enc", &encryption).await;


### PR DESCRIPTION
Switch the follow-mode helper to paused Tokio time so the two wrapper tests stop relying on wall-clock sleeps and polling timeouts.

Tests:
- `CARGO_TARGET_DIR=/tmp/s2-codex-target cargo test -p s2-lite test_follow_mode_receives_new_`
- `CARGO_TARGET_DIR=/tmp/s2-codex-target just test`
