### PR TITLE
test: exercise encrypted append input coverage

### DIFF
--- a/common/src/types/stream.rs
+++ b/common/src/types/stream.rs
@@ -555,12 +555,6 @@ mod test {
 
     const TEST_AAD: &[u8] = b"test-stream-aad";
 
-    #[derive(Clone, Copy)]
-    enum StoredAppendInputCase {
-        Encrypt,
-        Into,
-    }
-
     fn sample_append_input() -> AppendInput {
         let record = Record::Envelope(
             EnvelopeRecord::try_from_parts(vec![], Bytes::from_static(b"hello")).unwrap(),
@@ -581,13 +575,14 @@ mod test {
     }
 
     #[rstest]
-    #[case::encrypt(StoredAppendInputCase::Encrypt)]
-    #[case::into(StoredAppendInputCase::Into)]
-    fn append_input_to_stored_preserves_metadata(#[case] case: StoredAppendInputCase) {
+    #[case::encrypt(true)]
+    #[case::into(false)]
+    fn append_input_to_stored_preserves_metadata(#[case] encrypt: bool) {
         let encryption = EncryptionConfig::aegis256([0x42; 32]);
-        let mapped = match case {
-            StoredAppendInputCase::Encrypt => sample_append_input().encrypt(&encryption, TEST_AAD),
-            StoredAppendInputCase::Into => sample_append_input().into(),
+        let mapped = if encrypt {
+            sample_append_input().encrypt(&encryption, TEST_AAD)
+        } else {
+            sample_append_input().into()
         };
 
         assert_eq!(mapped.match_seq_num, Some(7));
@@ -605,14 +600,7 @@ mod test {
         assert_eq!(append_record.timestamp, Some(42));
 
         let stored_record = append_record.record.into_inner();
-        match case {
-            StoredAppendInputCase::Encrypt => {
-                assert!(matches!(&stored_record, StoredRecord::Encrypted { .. }));
-            }
-            StoredAppendInputCase::Into => {
-                assert!(matches!(&stored_record, StoredRecord::Plaintext(_)));
-            }
-        }
+        assert_eq!(matches!(&stored_record, StoredRecord::Encrypted { .. }), encrypt);
 
         let decrypted = decrypt_stored_record(stored_record, &encryption, TEST_AAD).unwrap();
         let Record::Envelope(record) = decrypted.into_inner() else {

--- a/common/src/types/stream.rs
+++ b/common/src/types/stream.rs
@@ -555,7 +555,11 @@ mod test {
 
     const TEST_AAD: &[u8] = b"test-stream-aad";
 
-    type StoredAppendInputMapper = fn(AppendInput, &EncryptionConfig, &[u8]) -> StoredAppendInput;
+    #[derive(Clone, Copy)]
+    enum StoredAppendInputCase {
+        Encrypt,
+        Into,
+    }
 
     fn sample_append_input() -> AppendInput {
         let record = Record::Envelope(
@@ -576,46 +580,21 @@ mod test {
         }
     }
 
-    fn encrypt_append_input(
-        input: AppendInput,
-        encryption: &EncryptionConfig,
-        aad: &[u8],
-    ) -> StoredAppendInput {
-        input.encrypt(encryption, aad)
-    }
+    #[rstest]
+    #[case::encrypt(StoredAppendInputCase::Encrypt)]
+    #[case::into(StoredAppendInputCase::Into)]
+    fn append_input_to_stored_preserves_metadata(#[case] case: StoredAppendInputCase) {
+        let encryption = EncryptionConfig::aegis256([0x42; 32]);
+        let mapped = match case {
+            StoredAppendInputCase::Encrypt => sample_append_input().encrypt(&encryption, TEST_AAD),
+            StoredAppendInputCase::Into => sample_append_input().into(),
+        };
 
-    fn into_stored_append_input(
-        input: AppendInput,
-        _encryption: &EncryptionConfig,
-        _aad: &[u8],
-    ) -> StoredAppendInput {
-        input.into()
-    }
-
-    fn assert_stored_append_input_metadata(mapped: &StoredAppendInput) {
         assert_eq!(mapped.match_seq_num, Some(7));
         assert_eq!(
             mapped.fencing_token.as_ref().map(|token| token.as_ref()),
             Some("fence")
         );
-        let record = mapped
-            .records
-            .first()
-            .expect("sample append input should contain a single record")
-            .parts();
-        assert_eq!(record.timestamp, Some(42));
-    }
-
-    #[rstest]
-    #[case::encrypt(encrypt_append_input as StoredAppendInputMapper, true)]
-    #[case::into(into_stored_append_input as StoredAppendInputMapper, false)]
-    fn append_input_to_stored_preserves_metadata(
-        #[case] map: StoredAppendInputMapper,
-        #[case] expect_encrypted: bool,
-    ) {
-        let encryption = EncryptionConfig::aegis256([0x42; 32]);
-        let mapped = map(sample_append_input(), &encryption, TEST_AAD);
-        assert_stored_append_input_metadata(&mapped);
 
         let append_record: AppendRecordParts<StoredRecord> = mapped
             .records
@@ -623,11 +602,17 @@ mod test {
             .next()
             .expect("sample append input should contain a single record")
             .into_parts();
+        assert_eq!(append_record.timestamp, Some(42));
+
         let stored_record = append_record.record.into_inner();
-        assert_eq!(
-            matches!(&stored_record, StoredRecord::Encrypted { .. }),
-            expect_encrypted
-        );
+        match case {
+            StoredAppendInputCase::Encrypt => {
+                assert!(matches!(&stored_record, StoredRecord::Encrypted { .. }));
+            }
+            StoredAppendInputCase::Into => {
+                assert!(matches!(&stored_record, StoredRecord::Plaintext(_)));
+            }
+        }
 
         let decrypted = decrypt_stored_record(stored_record, &encryption, TEST_AAD).unwrap();
         let Record::Envelope(record) = decrypted.into_inner() else {

--- a/common/src/types/stream.rs
+++ b/common/src/types/stream.rs
@@ -600,7 +600,10 @@ mod test {
         assert_eq!(append_record.timestamp, Some(42));
 
         let stored_record = append_record.record.into_inner();
-        assert_eq!(matches!(&stored_record, StoredRecord::Encrypted { .. }), encrypt);
+        assert_eq!(
+            matches!(&stored_record, StoredRecord::Encrypted { .. }),
+            encrypt
+        );
 
         let decrypted = decrypt_stored_record(stored_record, &encryption, TEST_AAD).unwrap();
         let Record::Envelope(record) = decrypted.into_inner() else {

--- a/common/src/types/stream.rs
+++ b/common/src/types/stream.rs
@@ -553,7 +553,9 @@ mod test {
             .expect_err("expected validation error");
     }
 
-    type StoredAppendInputMapper = fn(AppendInput) -> StoredAppendInput;
+    const TEST_AAD: &[u8] = b"test-stream-aad";
+
+    type StoredAppendInputMapper = fn(AppendInput, &EncryptionConfig, &[u8]) -> StoredAppendInput;
 
     fn sample_append_input() -> AppendInput {
         let record = Record::Envelope(
@@ -574,34 +576,64 @@ mod test {
         }
     }
 
-    fn encrypt_append_input(input: AppendInput) -> StoredAppendInput {
-        input.encrypt(&crate::encryption::EncryptionConfig::Plain, &[])
+    fn encrypt_append_input(
+        input: AppendInput,
+        encryption: &EncryptionConfig,
+        aad: &[u8],
+    ) -> StoredAppendInput {
+        input.encrypt(encryption, aad)
     }
 
-    fn into_stored_append_input(input: AppendInput) -> StoredAppendInput {
+    fn into_stored_append_input(
+        input: AppendInput,
+        _encryption: &EncryptionConfig,
+        _aad: &[u8],
+    ) -> StoredAppendInput {
         input.into()
     }
 
-    fn assert_stored_append_input_metadata(mapped: StoredAppendInput) {
+    fn assert_stored_append_input_metadata(mapped: &StoredAppendInput) {
         assert_eq!(mapped.match_seq_num, Some(7));
         assert_eq!(
             mapped.fencing_token.as_ref().map(|token| token.as_ref()),
             Some("fence")
         );
-        let record: AppendRecordParts<StoredRecord> =
-            mapped.records.into_iter().next().unwrap().into_parts();
+        let record = mapped
+            .records
+            .first()
+            .expect("sample append input should contain a single record")
+            .parts();
         assert_eq!(record.timestamp, Some(42));
-        assert!(matches!(
-            record.record.into_inner(),
-            StoredRecord::Plaintext(_)
-        ));
     }
 
     #[rstest]
-    #[case::encrypt(encrypt_append_input as StoredAppendInputMapper)]
-    #[case::into(into_stored_append_input as StoredAppendInputMapper)]
-    fn append_input_to_stored_preserves_metadata(#[case] map: StoredAppendInputMapper) {
-        assert_stored_append_input_metadata(map(sample_append_input()));
+    #[case::encrypt(encrypt_append_input as StoredAppendInputMapper, true)]
+    #[case::into(into_stored_append_input as StoredAppendInputMapper, false)]
+    fn append_input_to_stored_preserves_metadata(
+        #[case] map: StoredAppendInputMapper,
+        #[case] expect_encrypted: bool,
+    ) {
+        let encryption = EncryptionConfig::aegis256([0x42; 32]);
+        let mapped = map(sample_append_input(), &encryption, TEST_AAD);
+        assert_stored_append_input_metadata(&mapped);
+
+        let append_record: AppendRecordParts<StoredRecord> = mapped
+            .records
+            .into_iter()
+            .next()
+            .expect("sample append input should contain a single record")
+            .into_parts();
+        let stored_record = append_record.record.into_inner();
+        assert_eq!(
+            matches!(&stored_record, StoredRecord::Encrypted { .. }),
+            expect_encrypted
+        );
+
+        let decrypted = decrypt_stored_record(stored_record, &encryption, TEST_AAD).unwrap();
+        let Record::Envelope(record) = decrypted.into_inner() else {
+            panic!("expected envelope record");
+        };
+        assert_eq!(record.body().as_ref(), b"hello");
     }
 
     #[test]


### PR DESCRIPTION
Make the stored append input test exercise a real encrypted mapping instead of `EncryptionConfig::Plain`, and assert the encrypted branch plus a decrypt roundtrip.

Tests:
- `CARGO_TARGET_DIR=/tmp/s2-codex-target cargo test -p s2-common`
- `CARGO_TARGET_DIR=/tmp/s2-codex-target just test`
