### PR TITLE
test(lite): simplify backend integration tests and tighten read coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4092,9 +4092,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -4696,7 +4696,7 @@ dependencies = [
  "mimalloc",
  "predicates",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "ratatui",
  "rcgen",
  "rstest",
@@ -4738,7 +4738,7 @@ dependencies = [
  "enumset",
  "http 1.4.0",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rkyv",
  "rstest",
  "secrecy",
@@ -4778,7 +4778,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "prost",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rcgen",
  "rstest",
  "rustls",
@@ -4818,7 +4818,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "prost",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rstest",
  "rustls",
  "s2-api",
@@ -5466,7 +5466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -6233,7 +6233,7 @@ dependencies = [
  "atomic",
  "getrandom 0.4.2",
  "js-sys",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde_core",
  "wasm-bindgen",
 ]

--- a/common/src/types/stream.rs
+++ b/common/src/types/stream.rs
@@ -574,6 +574,13 @@ mod test {
         }
     }
 
+    #[test]
+    fn append_record_batch_rejects_empty_batches() {
+        let empty_batch: Result<AppendRecordBatch, _> = Vec::<AppendRecord>::new().try_into();
+
+        assert_eq!(empty_batch.unwrap_err(), "record batch must not be empty");
+    }
+
     #[rstest]
     #[case::encrypt(true)]
     #[case::into(false)]

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,7 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "BSL-1.0",
+    "CC0-1.0",
     "CDLA-Permissive-2.0",
     "ISC",
     "MIT",

--- a/lite/src/backend/read.rs
+++ b/lite/src/backend/read.rs
@@ -629,6 +629,7 @@ mod tests {
         };
         assert!(matches!(second, StoredReadSessionOutput::Heartbeat(_)));
 
+        tokio::task::yield_now().await;
         let closed_at = loop {
             match futures::poll!(session.as_mut().next()) {
                 Poll::Ready(Some(Ok(StoredReadSessionOutput::Heartbeat(_)))) => {}

--- a/lite/src/backend/read.rs
+++ b/lite/src/backend/read.rs
@@ -379,7 +379,7 @@ async fn wait_sleep_until(deadline: Option<Instant>) {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{sync::Arc, task::Poll};
 
     use bytesize::ByteSize;
     use futures::StreamExt;
@@ -417,6 +417,41 @@ mod tests {
             records,
             match_seq_num: None,
             fencing_token: None,
+        }
+    }
+
+    fn map_test_output(
+        output: Option<Result<StoredReadSessionOutput, ReadError>>,
+    ) -> Option<StoredReadSessionOutput> {
+        match output {
+            Some(Ok(output)) => Some(output),
+            Some(Err(e)) => panic!("Read error: {e:?}"),
+            None => None,
+        }
+    }
+
+    async fn poll_next_after_advance<S>(
+        session: &mut std::pin::Pin<Box<S>>,
+        advance_by: Duration,
+    ) -> Poll<Option<StoredReadSessionOutput>>
+    where
+        S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+    {
+        let mut pinned_session = session.as_mut();
+        let next = pinned_session.next();
+        tokio::pin!(next);
+
+        assert!(
+            matches!(futures::poll!(&mut next), Poll::Pending),
+            "session unexpectedly yielded before time advanced"
+        );
+
+        tokio::time::advance(advance_by).await;
+        tokio::task::yield_now().await;
+
+        match futures::poll!(&mut next) {
+            Poll::Ready(output) => Poll::Ready(map_test_output(output)),
+            Poll::Pending => Poll::Pending,
         }
     }
 
@@ -538,7 +573,7 @@ mod tests {
         assert!(records.into_iter().all(|r| r.is_ok()));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn read_wait_is_not_extended_by_heartbeats() {
         let object_store = Arc::new(InMemory::new());
         let db = Db::builder("/test", object_store).build().await.unwrap();
@@ -576,21 +611,183 @@ mod tests {
         };
 
         let session = backend.read(basin, stream, start, end).await.unwrap();
-        let started = Instant::now();
-        let outputs = tokio::time::timeout(Duration::from_millis(150), session.collect::<Vec<_>>())
+        let mut session = Box::pin(session);
+        let probe_step = Duration::from_millis(1);
+        let first = session
+            .as_mut()
+            .next()
             .await
-            .expect("read session should close once wait expires");
+            .expect("session should enter follow mode")
+            .expect("session should not error");
+        assert!(matches!(first, StoredReadSessionOutput::Heartbeat(_)));
 
-        assert!(
-            started.elapsed() >= wait,
-            "read session ended before wait elapsed"
+        let started = Instant::now();
+        let second = match poll_next_after_advance(&mut session, wait).await {
+            Poll::Ready(Some(output)) => output,
+            Poll::Ready(None) => panic!("session closed before emitting a follow heartbeat"),
+            Poll::Pending => panic!("expected a follow heartbeat before the wait budget expired"),
+        };
+        assert!(matches!(second, StoredReadSessionOutput::Heartbeat(_)));
+
+        let closed_at = loop {
+            match futures::poll!(session.as_mut().next()) {
+                Poll::Ready(Some(Ok(StoredReadSessionOutput::Heartbeat(_)))) => {}
+                Poll::Ready(Some(Ok(output))) => {
+                    panic!("unexpected output after wait deadline: {output:?}");
+                }
+                Poll::Ready(Some(Err(e))) => panic!("Read error: {e:?}"),
+                Poll::Ready(None) => break Instant::now(),
+                Poll::Pending => panic!("session should close once the wait budget expires"),
+            }
+        };
+
+        assert!(closed_at >= started + wait);
+        assert!(closed_at <= started + wait + probe_step);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn read_wait_is_reset_by_delivered_follow_batch() {
+        let object_store = Arc::new(InMemory::new());
+        let db = Db::builder("/test", object_store).build().await.unwrap();
+        let backend = Backend::new(db, ByteSize::mib(10));
+
+        let basin: BasinName = "test-basin".parse().unwrap();
+        backend
+            .create_basin(
+                basin.clone(),
+                BasinConfig::default(),
+                CreateMode::CreateOnly(None),
+            )
+            .await
+            .unwrap();
+        let stream: s2_common::types::stream::StreamName = "test-stream".parse().unwrap();
+        backend
+            .create_stream(
+                basin.clone(),
+                stream.clone(),
+                OptionalStreamConfig::default(),
+                CreateMode::CreateOnly(None),
+            )
+            .await
+            .unwrap();
+
+        let initial_input = stored_append_input(
+            Record::try_from_parts(vec![], bytes::Bytes::from("initial")).unwrap(),
         );
-        assert!(
-            outputs.len() > 1,
-            "expected heartbeats before wait deadline; got {} output(s)",
-            outputs.len()
+        backend
+            .append(basin.clone(), stream.clone(), initial_input)
+            .await
+            .unwrap();
+
+        let wait = Duration::from_millis(30);
+        let probe_step = Duration::from_millis(1);
+        let start = ReadStart {
+            from: ReadFrom::SeqNum(0),
+            clamp: false,
+        };
+        let end = ReadEnd {
+            limit: ReadLimit::Unbounded,
+            until: ReadUntil::Unbounded,
+            wait: Some(wait),
+        };
+
+        let session = backend
+            .read(basin.clone(), stream.clone(), start, end)
+            .await
+            .unwrap();
+        let mut session = Box::pin(session);
+
+        let first = session
+            .as_mut()
+            .next()
+            .await
+            .expect("session should yield the initial batch")
+            .expect("session should not error");
+        let StoredReadSessionOutput::Batch(batch) = first else {
+            panic!("expected initial batch");
+        };
+        let initial_record = batch
+            .records
+            .first()
+            .expect("batch should contain one record");
+        let StoredRecord::Plaintext(Record::Envelope(initial_envelope)) = initial_record.inner()
+        else {
+            panic!("expected plaintext envelope record");
+        };
+        assert_eq!(initial_envelope.body().as_ref(), b"initial");
+
+        let second = session
+            .as_mut()
+            .next()
+            .await
+            .expect("session should enter follow mode")
+            .expect("session should not error");
+        assert!(matches!(second, StoredReadSessionOutput::Heartbeat(_)));
+
+        tokio::time::advance(Duration::from_millis(20)).await;
+        tokio::task::yield_now().await;
+
+        let follow_input = stored_append_input(
+            Record::try_from_parts(vec![], bytes::Bytes::from("follow-1")).unwrap(),
         );
-        assert!(outputs.into_iter().all(|o| o.is_ok()));
+        backend.append(basin, stream, follow_input).await.unwrap();
+
+        let follow = session
+            .as_mut()
+            .next()
+            .await
+            .expect("session should deliver the live batch")
+            .expect("session should not error");
+        let reset_at = Instant::now();
+        let StoredReadSessionOutput::Batch(batch) = follow else {
+            panic!("expected live batch after append");
+        };
+        let follow_record = batch
+            .records
+            .first()
+            .expect("batch should contain one record");
+        let StoredRecord::Plaintext(Record::Envelope(follow_envelope)) = follow_record.inner()
+        else {
+            panic!("expected plaintext envelope record");
+        };
+        assert_eq!(follow_envelope.body().as_ref(), b"follow-1");
+
+        tokio::time::advance(wait - probe_step).await;
+        tokio::task::yield_now().await;
+
+        loop {
+            match futures::poll!(session.as_mut().next()) {
+                Poll::Ready(Some(Ok(StoredReadSessionOutput::Heartbeat(_)))) => {}
+                Poll::Ready(Some(Ok(output))) => {
+                    panic!("unexpected output before the reset wait deadline: {output:?}");
+                }
+                Poll::Ready(Some(Err(e))) => panic!("Read error: {e:?}"),
+                Poll::Ready(None) => {
+                    panic!("session closed before the reset wait budget expired");
+                }
+                Poll::Pending => break,
+            }
+        }
+
+        tokio::time::advance(probe_step).await;
+        tokio::task::yield_now().await;
+
+        let closed_at = loop {
+            match futures::poll!(session.as_mut().next()) {
+                Poll::Ready(Some(Ok(StoredReadSessionOutput::Heartbeat(_)))) => {}
+                Poll::Ready(Some(Ok(output))) => {
+                    panic!("unexpected output after the reset wait deadline: {output:?}");
+                }
+                Poll::Ready(Some(Err(e))) => panic!("Read error: {e:?}"),
+                Poll::Ready(None) => break Instant::now(),
+                Poll::Pending => {
+                    panic!("session should close once the reset wait budget expires");
+                }
+            }
+        };
+
+        assert!(closed_at >= reset_at + wait);
+        assert!(closed_at <= reset_at + wait + probe_step);
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/lite/tests/backend/common/mod.rs
+++ b/lite/tests/backend/common/mod.rs
@@ -1,0 +1,5 @@
+mod read;
+mod setup;
+
+pub use read::*;
+pub use setup::*;

--- a/lite/tests/backend/common/read.rs
+++ b/lite/tests/backend/common/read.rs
@@ -85,7 +85,7 @@ pub fn decrypt_batch_for_stream(
         .expect("Failed to decode batch")
 }
 
-enum SessionPoll {
+pub enum SessionPoll {
     Output(StoredReadSessionOutput),
     Closed,
     TimedOut,
@@ -104,7 +104,7 @@ fn map_session_output(output: Option<Result<StoredReadSessionOutput, ReadError>>
     }
 }
 
-async fn poll_session_with_deadline<S>(
+pub async fn poll_session_with_deadline<S>(
     session: &mut Pin<Box<S>>,
     deadline: tokio::time::Instant,
     advance_step: Option<Duration>,
@@ -140,6 +140,9 @@ where
         }
     }
 
+    // The wall-clock polling path is only used by `collect_records` and
+    // `collect_records_with_encryption`, which intentionally block without their
+    // own timeout budget. Timed callers should use `advance_step` instead.
     loop {
         let now = tokio::time::Instant::now();
         let Some(remaining) = deadline.checked_duration_since(now) else {

--- a/lite/tests/backend/common/read.rs
+++ b/lite/tests/backend/common/read.rs
@@ -1,0 +1,370 @@
+use std::{pin::Pin, task::Poll, time::Duration};
+
+use futures::StreamExt;
+use s2_common::{
+    encryption::EncryptionSpec,
+    read_extent::{ReadLimit, ReadUntil},
+    record::{Record, SequencedRecord},
+    types::{
+        basin::BasinName,
+        stream::{
+            ReadBatch, ReadEnd, ReadFrom, ReadStart, StoredReadBatch, StoredReadSessionOutput,
+            StreamName,
+        },
+    },
+};
+use s2_lite::backend::{Backend, error::ReadError};
+
+pub fn decrypt_plain_batch(batch: StoredReadBatch) -> ReadBatch {
+    batch
+        .decrypt(&EncryptionSpec::Plain, &[])
+        .expect("Failed to decode batch")
+}
+
+pub fn read_all_bounds() -> (ReadStart, ReadEnd) {
+    (
+        ReadStart {
+            from: ReadFrom::SeqNum(0),
+            clamp: false,
+        },
+        ReadEnd {
+            limit: ReadLimit::Unbounded,
+            until: ReadUntil::Unbounded,
+            wait: Some(Duration::ZERO),
+        },
+    )
+}
+
+pub async fn first_stored_batch(
+    backend: &Backend,
+    basin: &BasinName,
+    stream: &StreamName,
+) -> StoredReadBatch {
+    let (start, end) = read_all_bounds();
+    let read_session = backend
+        .read(basin.clone(), stream.clone(), start, end)
+        .await
+        .expect("Failed to create read session");
+    let mut read_session = Box::pin(read_session);
+    match read_session.next().await {
+        Some(Ok(StoredReadSessionOutput::Batch(batch))) => batch,
+        Some(Ok(other)) => panic!("Unexpected first output: {other:?}"),
+        Some(Err(err)) => panic!("Unexpected backend read error: {err:?}"),
+        None => panic!("Read session ended without delivering batch"),
+    }
+}
+
+pub async fn open_read_session(
+    backend: &Backend,
+    basin: &BasinName,
+    stream: &StreamName,
+    start: ReadStart,
+    end: ReadEnd,
+) -> Pin<Box<impl futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>>> {
+    let read_session = backend
+        .read(basin.clone(), stream.clone(), start, end)
+        .await
+        .expect("Failed to create read session");
+    Box::pin(read_session)
+}
+
+pub async fn advance_time(by: Duration) {
+    tokio::time::advance(by).await;
+    tokio::task::yield_now().await;
+}
+
+pub fn decrypt_batch_for_stream(
+    batch: StoredReadBatch,
+    basin: &BasinName,
+    stream: &StreamName,
+    encryption: &EncryptionSpec,
+) -> ReadBatch {
+    let stream_id = s2_lite::backend::StreamId::new(basin, stream);
+    batch
+        .decrypt(encryption, stream_id.as_bytes())
+        .expect("Failed to decode batch")
+}
+
+enum SessionPoll {
+    Output(StoredReadSessionOutput),
+    Closed,
+    TimedOut,
+}
+
+pub struct ClosedSessionOutputs {
+    pub outputs: Vec<StoredReadSessionOutput>,
+    pub closed_at: tokio::time::Instant,
+}
+
+fn map_session_output(output: Option<Result<StoredReadSessionOutput, ReadError>>) -> SessionPoll {
+    match output {
+        Some(Ok(output)) => SessionPoll::Output(output),
+        Some(Err(e)) => panic!("Read error: {:?}", e),
+        None => SessionPoll::Closed,
+    }
+}
+
+async fn poll_session_with_deadline<S>(
+    session: &mut Pin<Box<S>>,
+    deadline: tokio::time::Instant,
+    advance_step: Option<Duration>,
+) -> SessionPoll
+where
+    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+{
+    if let Some(step) = advance_step {
+        let mut pinned_session = session.as_mut();
+        let next = pinned_session.next();
+        tokio::pin!(next);
+
+        loop {
+            let now = tokio::time::Instant::now();
+            let Some(remaining) = deadline.checked_duration_since(now) else {
+                return SessionPoll::TimedOut;
+            };
+
+            if remaining.is_zero() {
+                return match futures::poll!(&mut next) {
+                    Poll::Ready(output) => map_session_output(output),
+                    Poll::Pending => SessionPoll::TimedOut,
+                };
+            }
+
+            tokio::select! {
+                biased;
+                output = &mut next => return map_session_output(output),
+                () = tokio::time::advance(step.min(remaining)) => {
+                    tokio::task::yield_now().await;
+                }
+            }
+        }
+    }
+
+    loop {
+        let now = tokio::time::Instant::now();
+        let Some(remaining) = deadline.checked_duration_since(now) else {
+            return SessionPoll::TimedOut;
+        };
+
+        match tokio::time::timeout(
+            remaining.min(Duration::from_millis(500)),
+            session.as_mut().next(),
+        )
+        .await
+        {
+            Ok(output) => return map_session_output(output),
+            Err(_) => continue,
+        }
+    }
+}
+
+async fn collect_records_with_decoder<S, D>(
+    session: &mut Pin<Box<S>>,
+    timeout: Option<Duration>,
+    target_count: Option<usize>,
+    advance_step: Option<Duration>,
+    mut decode_batch: D,
+) -> Vec<SequencedRecord>
+where
+    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+    D: FnMut(StoredReadBatch) -> ReadBatch,
+{
+    let deadline = timeout.map(|timeout| tokio::time::Instant::now() + timeout);
+    let mut records = Vec::new();
+
+    loop {
+        if let Some(target_count) = target_count
+            && records.len() >= target_count
+        {
+            break;
+        }
+
+        let polled = if let Some(deadline) = deadline {
+            poll_session_with_deadline(session, deadline, advance_step).await
+        } else {
+            match session.as_mut().next().await {
+                Some(Ok(output)) => SessionPoll::Output(output),
+                Some(Err(e)) => panic!("Read error: {:?}", e),
+                None => SessionPoll::Closed,
+            }
+        };
+
+        match polled {
+            SessionPoll::Output(StoredReadSessionOutput::Batch(batch)) => {
+                let batch = decode_batch(batch);
+                records.extend(batch.records.iter().cloned());
+            }
+            SessionPoll::Output(StoredReadSessionOutput::Heartbeat(_)) => {}
+            SessionPoll::Closed | SessionPoll::TimedOut => break,
+        }
+    }
+
+    records
+}
+
+pub async fn collect_records<S>(session: &mut Pin<Box<S>>) -> Vec<SequencedRecord>
+where
+    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+{
+    collect_records_with_decoder(session, None, None, None, decrypt_plain_batch).await
+}
+
+pub async fn collect_records_until_advanced<S>(
+    session: &mut Pin<Box<S>>,
+    timeout: Duration,
+    target_count: usize,
+    advance_step: Duration,
+) -> Vec<SequencedRecord>
+where
+    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+{
+    collect_records_with_decoder(
+        session,
+        Some(timeout),
+        Some(target_count),
+        Some(advance_step),
+        decrypt_plain_batch,
+    )
+    .await
+}
+
+pub async fn collect_records_with_encryption<S>(
+    session: &mut Pin<Box<S>>,
+    basin: &BasinName,
+    stream: &StreamName,
+    encryption: &EncryptionSpec,
+) -> Vec<SequencedRecord>
+where
+    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+{
+    collect_records_with_decoder(session, None, None, None, |batch| {
+        decrypt_batch_for_stream(batch, basin, stream, encryption)
+    })
+    .await
+}
+
+pub async fn expect_heartbeat_advanced<S>(
+    session: &mut Pin<Box<S>>,
+    timeout: Duration,
+    advance_step: Duration,
+) where
+    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    let output = match poll_session_with_deadline(session, deadline, Some(advance_step)).await {
+        SessionPoll::Output(output) => output,
+        SessionPoll::Closed => panic!("Read session ended unexpectedly"),
+        SessionPoll::TimedOut => panic!("Timed out waiting for heartbeat"),
+    };
+
+    assert!(
+        matches!(output, StoredReadSessionOutput::Heartbeat(_)),
+        "Unexpected first output: {output:?}"
+    );
+}
+
+pub async fn collect_outputs_until_closed_advanced<S>(
+    session: &mut Pin<Box<S>>,
+    timeout: Duration,
+    advance_step: Duration,
+) -> ClosedSessionOutputs
+where
+    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut outputs = Vec::new();
+
+    loop {
+        match poll_session_with_deadline(session, deadline, Some(advance_step)).await {
+            SessionPoll::Output(output) => outputs.push(output),
+            SessionPoll::Closed => {
+                return ClosedSessionOutputs {
+                    outputs,
+                    closed_at: tokio::time::Instant::now(),
+                };
+            }
+            SessionPoll::TimedOut => panic!("Timed out waiting for read session to close"),
+        }
+    }
+}
+
+pub async fn collect_records_until_closed_advanced<S>(
+    session: &mut Pin<Box<S>>,
+    timeout: Duration,
+    advance_step: Duration,
+) -> Vec<SequencedRecord>
+where
+    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+{
+    collect_records_until_closed_with_decoder(session, timeout, advance_step, decrypt_plain_batch)
+        .await
+}
+
+async fn collect_records_until_closed_with_decoder<S, D>(
+    session: &mut Pin<Box<S>>,
+    timeout: Duration,
+    advance_step: Duration,
+    mut decode_batch: D,
+) -> Vec<SequencedRecord>
+where
+    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+    D: FnMut(StoredReadBatch) -> ReadBatch,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut records = Vec::new();
+
+    loop {
+        match poll_session_with_deadline(session, deadline, Some(advance_step)).await {
+            SessionPoll::Output(StoredReadSessionOutput::Batch(batch)) => {
+                let batch = decode_batch(batch);
+                records.extend(batch.records.iter().cloned());
+            }
+            SessionPoll::Output(StoredReadSessionOutput::Heartbeat(_)) => {}
+            SessionPoll::Closed => break,
+            SessionPoll::TimedOut => panic!("Timed out waiting for read session to close"),
+        }
+    }
+
+    records
+}
+
+pub async fn read_records(
+    backend: &Backend,
+    basin: &BasinName,
+    stream: &StreamName,
+    start: ReadStart,
+    end: ReadEnd,
+) -> Vec<SequencedRecord> {
+    let read_session = backend
+        .read(basin.clone(), stream.clone(), start, end)
+        .await
+        .expect("Failed to create read session");
+    let mut read_session = Box::pin(read_session);
+    collect_records(&mut read_session).await
+}
+
+pub async fn read_records_with_encryption(
+    backend: &Backend,
+    basin: &BasinName,
+    stream: &StreamName,
+    start: ReadStart,
+    end: ReadEnd,
+    encryption: &EncryptionSpec,
+) -> Vec<SequencedRecord> {
+    let read_session = backend
+        .read(basin.clone(), stream.clone(), start, end)
+        .await
+        .expect("Failed to create read session");
+    let mut read_session = Box::pin(read_session);
+    collect_records_with_encryption(&mut read_session, basin, stream, encryption).await
+}
+
+pub fn envelope_bodies(records: &[SequencedRecord]) -> Vec<Vec<u8>> {
+    records
+        .iter()
+        .map(|record| match record.inner() {
+            Record::Envelope(envelope) => envelope.body().to_vec(),
+            other => panic!("Unexpected record type: {:?}", other),
+        })
+        .collect()
+}

--- a/lite/tests/backend/common/read.rs
+++ b/lite/tests/backend/common/read.rs
@@ -192,7 +192,15 @@ where
         match polled {
             SessionPoll::Output(StoredReadSessionOutput::Batch(batch)) => {
                 let batch = decode_batch(batch);
-                records.extend(batch.records.iter().cloned());
+                if let Some(target_count) = target_count {
+                    let remaining = target_count.saturating_sub(records.len());
+                    records.extend(batch.records.iter().take(remaining).cloned());
+                    if batch.records.len() >= remaining {
+                        break;
+                    }
+                } else {
+                    records.extend(batch.records.iter().cloned());
+                }
             }
             SessionPoll::Output(StoredReadSessionOutput::Heartbeat(_)) => {}
             SessionPoll::Closed | SessionPoll::TimedOut => break,

--- a/lite/tests/backend/common/read.rs
+++ b/lite/tests/backend/common/read.rs
@@ -142,7 +142,8 @@ where
 
     // The wall-clock polling path is only used by `collect_records` and
     // `collect_records_with_encryption`, which intentionally block without their
-    // own timeout budget. Timed callers should use `advance_step` instead.
+    // own timeout budget. Timed callers should use `advance_step` instead. A
+    // stuck session here will only surface via the outer test-runner timeout.
     loop {
         let now = tokio::time::Instant::now();
         let Some(remaining) = deadline.checked_duration_since(now) else {

--- a/lite/tests/backend/common/setup.rs
+++ b/lite/tests/backend/common/setup.rs
@@ -1,22 +1,21 @@
-use std::{pin::Pin, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use bytes::Bytes;
 use bytesize::ByteSize;
-use futures::StreamExt;
 use s2_common::{
     encryption::EncryptionSpec,
-    record::{CommandRecord, FencingToken, Metered, Record, SequencedRecord, Timestamp},
+    record::{CommandRecord, FencingToken, Metered, Record, Timestamp},
     types::{
         basin::BasinName,
         config::{BasinConfig, OptionalStreamConfig},
         resources::CreateMode,
         stream::{
-            AppendInput, AppendRecord, AppendRecordBatch, AppendRecordParts, ReadBatch,
-            StoredAppendInput, StoredReadBatch, StoredReadSessionOutput, StreamName,
+            AppendInput, AppendRecord, AppendRecordBatch, AppendRecordParts, StoredAppendInput,
+            StreamName,
         },
     },
 };
-use s2_lite::backend::{Backend, error::ReadError};
+use s2_lite::backend::Backend;
 use slatedb::{Db, config::Settings, object_store::memory::InMemory};
 use uuid::Uuid;
 
@@ -166,6 +165,23 @@ pub async fn append_payloads_with_encryption(
         .expect("Failed to append payloads")
 }
 
+pub async fn append_timestamped_payloads(
+    backend: &Backend,
+    basin: &BasinName,
+    stream: &StreamName,
+    payloads: Vec<(Bytes, Timestamp)>,
+) -> s2_common::types::stream::AppendAck {
+    let input = AppendInput {
+        records: create_test_record_batch_with_timestamps(payloads),
+        match_seq_num: None,
+        fencing_token: None,
+    };
+    backend
+        .append(basin.clone(), stream.clone(), input)
+        .await
+        .expect("Failed to append timestamped payloads")
+}
+
 pub fn encrypt_input_for_stream(
     input: AppendInput,
     basin: &BasinName,
@@ -186,73 +202,4 @@ pub async fn append_repeat(
     for _ in 0..count {
         append_payloads(backend, basin, stream, &[payload]).await;
     }
-}
-
-pub fn decrypt_plain_batch(batch: StoredReadBatch) -> ReadBatch {
-    batch
-        .decrypt(&EncryptionSpec::Plain, &[])
-        .expect("Failed to decode batch")
-}
-
-pub fn decrypt_batch_for_stream(
-    batch: StoredReadBatch,
-    basin: &BasinName,
-    stream: &StreamName,
-    encryption: &EncryptionSpec,
-) -> ReadBatch {
-    let stream_id = s2_lite::backend::StreamId::new(basin, stream);
-    batch
-        .decrypt(encryption, stream_id.as_bytes())
-        .expect("Failed to decode batch")
-}
-
-pub async fn collect_records<S>(session: &mut Pin<Box<S>>) -> Vec<SequencedRecord>
-where
-    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
-{
-    let mut records = Vec::new();
-    while let Some(output) = session.as_mut().next().await {
-        match output {
-            Ok(StoredReadSessionOutput::Batch(batch)) => {
-                let batch = decrypt_plain_batch(batch);
-                records.extend(batch.records.iter().cloned());
-            }
-            Ok(StoredReadSessionOutput::Heartbeat(_)) => {}
-            Err(e) => panic!("Read error: {:?}", e),
-        }
-    }
-    records
-}
-
-pub async fn collect_records_with_encryption<S>(
-    session: &mut Pin<Box<S>>,
-    basin: &BasinName,
-    stream: &StreamName,
-    encryption: &EncryptionSpec,
-) -> Vec<SequencedRecord>
-where
-    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
-{
-    let mut records = Vec::new();
-    while let Some(output) = session.as_mut().next().await {
-        match output {
-            Ok(StoredReadSessionOutput::Batch(batch)) => {
-                let batch = decrypt_batch_for_stream(batch, basin, stream, encryption);
-                records.extend(batch.records.iter().cloned());
-            }
-            Ok(StoredReadSessionOutput::Heartbeat(_)) => {}
-            Err(e) => panic!("Read error: {:?}", e),
-        }
-    }
-    records
-}
-
-pub fn envelope_bodies(records: &[SequencedRecord]) -> Vec<Vec<u8>> {
-    records
-        .iter()
-        .map(|record| match record.inner() {
-            Record::Envelope(envelope) => envelope.body().to_vec(),
-            other => panic!("Unexpected record type: {:?}", other),
-        })
-        .collect()
 }

--- a/lite/tests/backend/control_plane/basin.rs
+++ b/lite/tests/backend/control_plane/basin.rs
@@ -362,7 +362,17 @@ async fn test_list_basins_multiple() {
         .await
         .expect("Failed to list basins");
 
-    assert_eq!(page.values.len(), 5);
+    let names: Vec<_> = page.values.iter().map(|info| info.name.as_ref()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "test-basin-list-0",
+            "test-basin-list-1",
+            "test-basin-list-2",
+            "test-basin-list-3",
+            "test-basin-list-4",
+        ]
+    );
     assert!(!page.has_more);
 }
 
@@ -392,10 +402,18 @@ async fn test_list_basins_pagination() {
         .await
         .expect("Failed to list basins page 1");
 
-    assert_eq!(page1.values.len(), 5);
     assert!(page1.has_more);
-    assert_eq!(page1.values[0].name.as_ref(), "test-basin-paginated-00");
-    assert_eq!(page1.values[4].name.as_ref(), "test-basin-paginated-04");
+    let page1_names: Vec<_> = page1.values.iter().map(|info| info.name.as_ref()).collect();
+    assert_eq!(
+        page1_names,
+        vec![
+            "test-basin-paginated-00",
+            "test-basin-paginated-01",
+            "test-basin-paginated-02",
+            "test-basin-paginated-03",
+            "test-basin-paginated-04",
+        ]
+    );
 
     let page2 = backend
         .list_basins(
@@ -410,10 +428,18 @@ async fn test_list_basins_pagination() {
         .await
         .expect("Failed to list basins page 2");
 
-    assert_eq!(page2.values.len(), 5);
     assert!(page2.has_more);
-    assert_eq!(page2.values[0].name.as_ref(), "test-basin-paginated-05");
-    assert_eq!(page2.values[4].name.as_ref(), "test-basin-paginated-09");
+    let page2_names: Vec<_> = page2.values.iter().map(|info| info.name.as_ref()).collect();
+    assert_eq!(
+        page2_names,
+        vec![
+            "test-basin-paginated-05",
+            "test-basin-paginated-06",
+            "test-basin-paginated-07",
+            "test-basin-paginated-08",
+            "test-basin-paginated-09",
+        ]
+    );
 
     let page3 = backend
         .list_basins(
@@ -428,10 +454,18 @@ async fn test_list_basins_pagination() {
         .await
         .expect("Failed to list basins page 3");
 
-    assert_eq!(page3.values.len(), 5);
     assert!(!page3.has_more);
-    assert_eq!(page3.values[0].name.as_ref(), "test-basin-paginated-10");
-    assert_eq!(page3.values[4].name.as_ref(), "test-basin-paginated-14");
+    let page3_names: Vec<_> = page3.values.iter().map(|info| info.name.as_ref()).collect();
+    assert_eq!(
+        page3_names,
+        vec![
+            "test-basin-paginated-10",
+            "test-basin-paginated-11",
+            "test-basin-paginated-12",
+            "test-basin-paginated-13",
+            "test-basin-paginated-14",
+        ]
+    );
 }
 
 #[tokio::test]
@@ -456,12 +490,14 @@ async fn test_list_basins_prefix_filter() {
         .await
         .expect("Failed to list basins with prefix");
 
-    assert_eq!(prod_basins.values.len(), 2);
-    assert!(
-        prod_basins
-            .values
-            .iter()
-            .all(|b| b.name.as_ref().starts_with("test-basin-prod-"))
+    let prod_names: Vec<_> = prod_basins
+        .values
+        .iter()
+        .map(|info| info.name.as_ref())
+        .collect();
+    assert_eq!(
+        prod_names,
+        vec!["test-basin-prod-app-1", "test-basin-prod-app-2"]
     );
 }
 
@@ -492,13 +528,16 @@ async fn test_list_basins_prefix_with_pagination() {
         .await
         .expect("Failed to list basins");
 
-    assert_eq!(page1.values.len(), 4);
     assert!(page1.has_more);
-    assert!(
-        page1
-            .values
-            .iter()
-            .all(|b| b.name.as_ref().starts_with("test-basin-prefixed-"))
+    let page1_names: Vec<_> = page1.values.iter().map(|info| info.name.as_ref()).collect();
+    assert_eq!(
+        page1_names,
+        vec![
+            "test-basin-prefixed-00",
+            "test-basin-prefixed-01",
+            "test-basin-prefixed-02",
+            "test-basin-prefixed-03",
+        ]
     );
 
     let page2 = backend
@@ -514,8 +553,17 @@ async fn test_list_basins_prefix_with_pagination() {
         .await
         .expect("Failed to list basins");
 
-    assert_eq!(page2.values.len(), 4);
     assert!(page2.has_more);
+    let page2_names: Vec<_> = page2.values.iter().map(|info| info.name.as_ref()).collect();
+    assert_eq!(
+        page2_names,
+        vec![
+            "test-basin-prefixed-04",
+            "test-basin-prefixed-05",
+            "test-basin-prefixed-06",
+            "test-basin-prefixed-07",
+        ]
+    );
 
     let page3 = backend
         .list_basins(
@@ -530,6 +578,10 @@ async fn test_list_basins_prefix_with_pagination() {
         .await
         .expect("Failed to list basins");
 
-    assert_eq!(page3.values.len(), 2);
     assert!(!page3.has_more);
+    let page3_names: Vec<_> = page3.values.iter().map(|info| info.name.as_ref()).collect();
+    assert_eq!(
+        page3_names,
+        vec!["test-basin-prefixed-08", "test-basin-prefixed-09"]
+    );
 }

--- a/lite/tests/backend/control_plane/stream.rs
+++ b/lite/tests/backend/control_plane/stream.rs
@@ -523,7 +523,17 @@ async fn test_list_streams_multiple() {
         .await
         .expect("Failed to list streams");
 
-    assert_eq!(page.values.len(), 5);
+    let names: Vec<_> = page.values.iter().map(|info| info.name.as_ref()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "test-stream-list-0",
+            "test-stream-list-1",
+            "test-stream-list-2",
+            "test-stream-list-3",
+            "test-stream-list-4",
+        ]
+    );
     assert!(!page.has_more);
 }
 
@@ -556,8 +566,18 @@ async fn test_list_streams_pagination() {
         .await
         .expect("Failed to list streams page 1");
 
-    assert_eq!(page1.values.len(), 5);
     assert!(page1.has_more);
+    let page1_names: Vec<_> = page1.values.iter().map(|info| info.name.as_ref()).collect();
+    assert_eq!(
+        page1_names,
+        vec![
+            "test-stream-stream-00",
+            "test-stream-stream-01",
+            "test-stream-stream-02",
+            "test-stream-stream-03",
+            "test-stream-stream-04",
+        ]
+    );
 
     let page2 = backend
         .list_streams(
@@ -573,8 +593,18 @@ async fn test_list_streams_pagination() {
         .await
         .expect("Failed to list streams page 2");
 
-    assert_eq!(page2.values.len(), 5);
     assert!(page2.has_more);
+    let page2_names: Vec<_> = page2.values.iter().map(|info| info.name.as_ref()).collect();
+    assert_eq!(
+        page2_names,
+        vec![
+            "test-stream-stream-05",
+            "test-stream-stream-06",
+            "test-stream-stream-07",
+            "test-stream-stream-08",
+            "test-stream-stream-09",
+        ]
+    );
 
     let page3 = backend
         .list_streams(
@@ -590,8 +620,12 @@ async fn test_list_streams_pagination() {
         .await
         .expect("Failed to list streams page 3");
 
-    assert_eq!(page3.values.len(), 2);
     assert!(!page3.has_more);
+    let page3_names: Vec<_> = page3.values.iter().map(|info| info.name.as_ref()).collect();
+    assert_eq!(
+        page3_names,
+        vec!["test-stream-stream-10", "test-stream-stream-11"]
+    );
 }
 
 #[tokio::test]
@@ -642,11 +676,13 @@ async fn test_list_streams_prefix_filter() {
         .await
         .expect("Failed to list streams with prefix");
 
-    assert_eq!(metrics_streams.values.len(), 2);
-    assert!(
-        metrics_streams
-            .values
-            .iter()
-            .all(|s| s.name.as_ref().starts_with("test-stream-metrics-"))
+    let metric_names: Vec<_> = metrics_streams
+        .values
+        .iter()
+        .map(|info| info.name.as_ref())
+        .collect();
+    assert_eq!(
+        metric_names,
+        vec!["test-stream-metrics-cpu", "test-stream-metrics-memory"]
     );
 }

--- a/lite/tests/backend/data_plane/append.rs
+++ b/lite/tests/backend/data_plane/append.rs
@@ -1,20 +1,19 @@
-use std::time::Duration;
-
 use bytes::Bytes;
 use futures::StreamExt;
+use rstest::rstest;
 use s2_common::{
     encryption::EncryptionSpec,
-    read_extent::{ReadLimit, ReadUntil},
     record::FencingToken,
     types::{
+        basin::BasinName,
         config::{BasinConfig, OptionalStreamConfig, OptionalTimestampingConfig, TimestampingMode},
-        stream::{
-            AppendInput, AppendRecord, AppendRecordBatch, ListStreamsRequest, ReadEnd, ReadFrom,
-            ReadStart,
-        },
+        stream::{AppendInput, AppendRecordBatch, ListStreamsRequest, StreamName},
     },
 };
-use s2_lite::backend::error::{AppendConditionFailedError, AppendError};
+use s2_lite::backend::{
+    Backend,
+    error::{AppendConditionFailedError, AppendError},
+};
 
 use super::common::*;
 
@@ -64,24 +63,161 @@ async fn assert_append_session_roundtrip(test_suffix: &str, encryption: &Encrypt
         .expect("Failed to check tail");
     assert_eq!(tail.seq_num, expected_bodies.len() as u64);
 
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Unbounded,
-        until: ReadUntil::Unbounded,
-        wait: Some(Duration::ZERO),
-    };
-    let read_session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut read_session = Box::pin(read_session);
+    let (start, end) = read_all_bounds();
     let records =
-        collect_records_with_encryption(&mut read_session, &basin_name, &stream_name, encryption)
+        read_records_with_encryption(&backend, &basin_name, &stream_name, start, end, encryption)
             .await;
     assert_eq!(envelope_bodies(&records), expected_bodies);
+}
+
+async fn append_with_optional_encryption(
+    backend: &Backend,
+    basin: &BasinName,
+    stream: &StreamName,
+    input: AppendInput,
+    encryption: Option<&EncryptionSpec>,
+) -> Result<s2_common::types::stream::AppendAck, AppendError> {
+    match encryption {
+        Some(encryption) => {
+            let input = encrypt_input_for_stream(input, basin, stream, encryption);
+            backend.append(basin.clone(), stream.clone(), input).await
+        }
+        None => backend.append(basin.clone(), stream.clone(), input).await,
+    }
+}
+
+#[derive(Clone, Copy)]
+enum FencingBootstrap {
+    SeedWithData,
+    CommandFirst,
+}
+
+async fn issue_fencing_command(
+    backend: &Backend,
+    basin_name: &BasinName,
+    stream_name: &StreamName,
+    matching_token: &FencingToken,
+    new_token: &FencingToken,
+    encryption: Option<&EncryptionSpec>,
+    bootstrap: FencingBootstrap,
+) -> s2_common::types::stream::AppendAck {
+    let command_match_seq_num = match bootstrap {
+        FencingBootstrap::SeedWithData => {
+            let matching_input = AppendInput {
+                records: create_test_record_batch(vec![Bytes::from_static(b"matched token")]),
+                match_seq_num: None,
+                fencing_token: Some(matching_token.clone()),
+            };
+
+            let ack = append_with_optional_encryption(
+                backend,
+                basin_name,
+                stream_name,
+                matching_input,
+                encryption,
+            )
+            .await
+            .expect("append should succeed with matching fencing token");
+
+            assert_eq!(ack.start.seq_num, 0);
+            assert_eq!(ack.end.seq_num, 1);
+            Some(ack.end.seq_num)
+        }
+        FencingBootstrap::CommandFirst => None,
+    };
+
+    let command_batch: AppendRecordBatch = vec![create_fencing_command_record(new_token.clone())]
+        .try_into()
+        .unwrap();
+    let command_input = AppendInput {
+        records: command_batch,
+        match_seq_num: command_match_seq_num,
+        fencing_token: Some(matching_token.clone()),
+    };
+
+    let command_ack = append_with_optional_encryption(
+        backend,
+        basin_name,
+        stream_name,
+        command_input,
+        encryption,
+    )
+    .await
+    .expect("fencing command should succeed");
+
+    let expected_start = command_match_seq_num.unwrap_or(0);
+    assert_eq!(command_ack.start.seq_num, expected_start);
+    assert_eq!(command_ack.end.seq_num, expected_start + 1);
+    command_ack
+}
+
+async fn assert_fencing_command_controls_stream_state(
+    test_suffix: &str,
+    encryption: Option<EncryptionSpec>,
+    bootstrap: FencingBootstrap,
+) {
+    let (backend, basin_name, stream_name) =
+        setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await;
+
+    let encryption = encryption.as_ref();
+    let matching_token = FencingToken::default();
+    let new_token: FencingToken = "updated-token".parse().unwrap();
+
+    let command_ack = issue_fencing_command(
+        &backend,
+        &basin_name,
+        &stream_name,
+        &matching_token,
+        &new_token,
+        encryption,
+        bootstrap,
+    )
+    .await;
+
+    let mismatched_input = AppendInput {
+        records: create_test_record_batch(vec![Bytes::from_static(b"mismatched token")]),
+        match_seq_num: Some(command_ack.end.seq_num),
+        fencing_token: Some(matching_token.clone()),
+    };
+
+    let result = append_with_optional_encryption(
+        &backend,
+        &basin_name,
+        &stream_name,
+        mismatched_input,
+        encryption,
+    )
+    .await;
+
+    let Err(AppendError::ConditionFailed(AppendConditionFailedError::FencingTokenMismatch {
+        expected,
+        actual,
+        ..
+    })) = result
+    else {
+        panic!("expected fencing token mismatch");
+    };
+    assert_eq!(expected, matching_token);
+    assert_eq!(actual, new_token);
+
+    let refreshed_input = AppendInput {
+        records: create_test_record_batch(vec![Bytes::from_static(b"updated token accepted")]),
+        match_seq_num: Some(command_ack.end.seq_num),
+        fencing_token: Some(new_token.clone()),
+    };
+
+    let refreshed_ack = append_with_optional_encryption(
+        &backend,
+        &basin_name,
+        &stream_name,
+        refreshed_input,
+        encryption,
+    )
+    .await
+    .expect("append should succeed with refreshed fencing token");
+
+    assert_eq!(refreshed_ack.start.seq_num, command_ack.end.seq_num);
+    assert_eq!(refreshed_ack.end.seq_num, command_ack.end.seq_num + 1);
 }
 
 #[tokio::test]
@@ -105,163 +241,25 @@ async fn test_append_multiple_records() {
     assert_eq!(ack.end.seq_num, 3);
 }
 
+#[rstest]
+#[case::plaintext_seeded("append-fencing", None, FencingBootstrap::SeedWithData)]
+#[case::encrypted_seeded(
+    "append-fencing-encrypted",
+    Some(aegis256_encryption()),
+    FencingBootstrap::SeedWithData
+)]
+#[case::encrypted_command_first(
+    "fence-enc-first",
+    Some(aegis256_encryption()),
+    FencingBootstrap::CommandFirst
+)]
 #[tokio::test]
-async fn test_append_empty_batch() {
-    let empty_batch: Result<AppendRecordBatch, _> = Vec::<AppendRecord>::new().try_into();
-
-    assert!(
-        empty_batch.is_err(),
-        "Empty batches should be rejected by AppendRecordBatch"
-    );
-}
-
-#[tokio::test]
-async fn test_append_fencing_token_conditions() {
-    let (backend, basin_name, stream_name) = setup_backend_with_stream(
-        "append-fencing",
-        "mismatch",
-        OptionalStreamConfig::default(),
-    )
-    .await;
-
-    let matching_token = FencingToken::default();
-
-    let matching_input = AppendInput {
-        records: create_test_record_batch(vec![Bytes::from_static(b"matched token")]),
-        match_seq_num: None,
-        fencing_token: Some(matching_token.clone()),
-    };
-
-    let ack = backend
-        .append(basin_name.clone(), stream_name.clone(), matching_input)
-        .await
-        .expect("Expected append to succeed with matching fencing token");
-
-    assert_eq!(ack.start.seq_num, 0);
-    assert_eq!(ack.end.seq_num, 1);
-
-    let new_token: FencingToken = "updated-token".parse().unwrap();
-    let command_batch: AppendRecordBatch = vec![create_fencing_command_record(new_token.clone())]
-        .try_into()
-        .unwrap();
-
-    let command_input = AppendInput {
-        records: command_batch,
-        match_seq_num: Some(ack.end.seq_num),
-        fencing_token: Some(matching_token.clone()),
-    };
-
-    let command_ack = backend
-        .append(basin_name.clone(), stream_name.clone(), command_input)
-        .await
-        .expect("Expected fencing command to succeed");
-
-    assert_eq!(command_ack.start.seq_num, ack.end.seq_num);
-    assert_eq!(command_ack.end.seq_num, ack.end.seq_num + 1);
-
-    let mismatched_input = AppendInput {
-        records: create_test_record_batch(vec![Bytes::from_static(b"mismatched token")]),
-        match_seq_num: Some(command_ack.end.seq_num),
-        fencing_token: Some(matching_token.clone()),
-    };
-
-    let result = backend
-        .append(basin_name.clone(), stream_name.clone(), mismatched_input)
-        .await;
-
-    let Err(AppendError::ConditionFailed(AppendConditionFailedError::FencingTokenMismatch {
-        expected,
-        actual,
-        ..
-    })) = result
-    else {
-        panic!("Expected fencing token mismatch");
-    };
-    assert_eq!(expected, matching_token);
-    assert_eq!(actual, new_token);
-
-    let refreshed_input = AppendInput {
-        records: create_test_record_batch(vec![Bytes::from_static(b"updated token accepted")]),
-        match_seq_num: Some(command_ack.end.seq_num),
-        fencing_token: Some(new_token.clone()),
-    };
-
-    let refreshed_ack = backend
-        .append(basin_name, stream_name, refreshed_input)
-        .await
-        .expect("Expected append to succeed with updated fencing token");
-
-    assert_eq!(refreshed_ack.start.seq_num, command_ack.end.seq_num);
-    assert_eq!(refreshed_ack.end.seq_num, command_ack.end.seq_num + 1);
-}
-
-#[tokio::test]
-async fn test_encrypted_fencing_command_controls_stream_state() {
-    let (backend, basin_name, stream_name) = setup_backend_with_stream(
-        "append-fencing-encrypted",
-        "stream",
-        OptionalStreamConfig::default(),
-    )
-    .await;
-
-    let encryption = aegis256_encryption();
-    let matching_token = FencingToken::default();
-    let new_token: FencingToken = "updated-token".parse().unwrap();
-
-    let command_batch: AppendRecordBatch = vec![create_fencing_command_record(new_token.clone())]
-        .try_into()
-        .unwrap();
-    let command_input = AppendInput {
-        records: command_batch,
-        match_seq_num: None,
-        fencing_token: Some(matching_token.clone()),
-    };
-    let command_input =
-        encrypt_input_for_stream(command_input, &basin_name, &stream_name, &encryption);
-
-    let command_ack = backend
-        .append(basin_name.clone(), stream_name.clone(), command_input)
-        .await
-        .expect("encrypted fencing command should succeed");
-
-    let mismatched_input = AppendInput {
-        records: create_test_record_batch(vec![Bytes::from_static(b"mismatched token")]),
-        match_seq_num: Some(command_ack.end.seq_num),
-        fencing_token: Some(matching_token.clone()),
-    };
-    let mismatched_input =
-        encrypt_input_for_stream(mismatched_input, &basin_name, &stream_name, &encryption);
-
-    let result = backend
-        .append(basin_name.clone(), stream_name.clone(), mismatched_input)
-        .await;
-
-    let Err(AppendError::ConditionFailed(AppendConditionFailedError::FencingTokenMismatch {
-        expected,
-        actual,
-        ..
-    })) = result
-    else {
-        panic!("expected encrypted fencing token mismatch");
-    };
-    assert_eq!(expected, matching_token);
-    assert_eq!(actual, new_token);
-
-    let refreshed_input = AppendInput {
-        records: create_test_record_batch(vec![Bytes::from_static(b"updated token accepted")]),
-        match_seq_num: Some(command_ack.end.seq_num),
-        fencing_token: Some(new_token.clone()),
-    };
-    let refreshed_input =
-        encrypt_input_for_stream(refreshed_input, &basin_name, &stream_name, &encryption);
-
-    let refreshed_ack = backend
-        .append(basin_name, stream_name, refreshed_input)
-        .await
-        .expect("encrypted append should succeed with updated token");
-
-    assert_eq!(refreshed_ack.start.seq_num, command_ack.end.seq_num);
-    assert_eq!(refreshed_ack.end.seq_num, command_ack.end.seq_num + 1);
+async fn test_fencing_command_controls_stream_state(
+    #[case] test_suffix: &str,
+    #[case] encryption: Option<EncryptionSpec>,
+    #[case] bootstrap: FencingBootstrap,
+) {
+    assert_fencing_command_controls_stream_state(test_suffix, encryption, bootstrap).await;
 }
 
 #[tokio::test]
@@ -377,16 +375,15 @@ async fn test_append_with_seq_num_mismatch() {
     ));
 }
 
+#[rstest]
+#[case::plaintext("append-session-basic", EncryptionSpec::Plain)]
+#[case::encrypted("appsess-enc", aegis256_encryption())]
 #[tokio::test]
-async fn test_append_session_basic() {
-    let encryption = EncryptionSpec::Plain;
-    assert_append_session_roundtrip("append-session-basic", &encryption).await;
-}
-
-#[tokio::test]
-async fn test_append_session_basic_with_encryption() {
-    let encryption = aegis256_encryption();
-    assert_append_session_roundtrip("appsess-enc", &encryption).await;
+async fn test_append_session_roundtrip(
+    #[case] test_suffix: &str,
+    #[case] encryption: EncryptionSpec,
+) {
+    assert_append_session_roundtrip(test_suffix, &encryption).await;
 }
 
 #[tokio::test]
@@ -403,7 +400,7 @@ async fn test_append_session_auto_create_stream() {
         .list_streams(basin_name.clone(), ListStreamsRequest::default())
         .await
         .expect("Failed to list streams");
-    assert_eq!(stream_list.values.len(), 0);
+    assert!(stream_list.values.is_empty());
 
     let inputs = futures::stream::iter(vec![AppendInput {
         records: create_test_record_batch(vec![Bytes::from_static(b"auto created")]),
@@ -431,8 +428,12 @@ async fn test_append_session_auto_create_stream() {
         .list_streams(basin_name, ListStreamsRequest::default())
         .await
         .expect("Failed to list streams");
-    assert_eq!(stream_list.values.len(), 1);
-    assert_eq!(stream_list.values[0].name, stream_name);
+    let stream_names: Vec<_> = stream_list
+        .values
+        .iter()
+        .map(|info| info.name.as_ref())
+        .collect();
+    assert_eq!(stream_names, vec![stream_name.as_ref()]);
 }
 
 #[tokio::test]
@@ -521,24 +522,19 @@ async fn test_append_session_multiple_records_per_batch() {
         .expect("Failed to check tail");
     assert_eq!(tail.seq_num, 5);
 
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Unbounded,
-        until: ReadUntil::Unbounded,
-        wait: Some(Duration::ZERO),
-    };
+    let (start, end) = read_all_bounds();
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
 
-    let read_session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut read_session = Box::pin(read_session);
-    let records = collect_records(&mut read_session).await;
-
-    assert_eq!(records.len(), 5);
+    assert_eq!(
+        envelope_bodies(&records),
+        vec![
+            b"record 1".to_vec(),
+            b"record 2".to_vec(),
+            b"record 3".to_vec(),
+            b"record 4".to_vec(),
+            b"record 5".to_vec(),
+        ]
+    );
 }
 
 #[tokio::test]
@@ -609,6 +605,71 @@ async fn test_append_session_seq_num_mismatch() {
 
     let result = session.next().await.expect("Should have result");
     assert!(matches!(result, Err(AppendError::ConditionFailed(_))));
+}
+
+#[tokio::test]
+async fn test_append_session_stops_after_condition_failure() {
+    let (backend, basin_name, stream_name) = setup_backend_with_stream(
+        "append-session-stop-after-error",
+        "stream",
+        OptionalStreamConfig::default(),
+    )
+    .await;
+
+    let inputs = futures::stream::iter(vec![
+        AppendInput {
+            records: create_test_record_batch(vec![Bytes::from_static(b"first")]),
+            match_seq_num: Some(0),
+            fencing_token: None,
+        },
+        AppendInput {
+            records: create_test_record_batch(vec![Bytes::from_static(b"bad")]),
+            match_seq_num: Some(0),
+            fencing_token: None,
+        },
+        AppendInput {
+            records: create_test_record_batch(vec![Bytes::from_static(b"after-error")]),
+            match_seq_num: Some(1),
+            fencing_token: None,
+        },
+    ]);
+
+    let session = backend
+        .clone()
+        .append_session(basin_name.clone(), stream_name.clone(), inputs)
+        .await
+        .expect("Failed to create append session");
+    tokio::pin!(session);
+
+    let ack = session
+        .next()
+        .await
+        .expect("Should have first ack")
+        .expect("First append should succeed");
+    assert_eq!(ack.start.seq_num, 0);
+    assert_eq!(ack.end.seq_num, 1);
+
+    let result = session
+        .next()
+        .await
+        .expect("Should have a condition failure");
+    assert!(matches!(
+        result,
+        Err(AppendError::ConditionFailed(
+            AppendConditionFailedError::SeqNumMismatch { .. }
+        ))
+    ));
+    assert!(session.next().await.is_none());
+
+    let tail = backend
+        .check_tail(basin_name.clone(), stream_name.clone())
+        .await
+        .expect("Failed to check tail");
+    assert_eq!(tail.seq_num, 1);
+
+    let (start, end) = read_all_bounds();
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
+    assert_eq!(envelope_bodies(&records), vec![b"first".to_vec()]);
 }
 
 #[tokio::test]
@@ -752,21 +813,7 @@ async fn test_append_session_pipeline_preserves_ack_tail_and_read_order() {
         .expect("Failed to check tail");
     assert_eq!(tail.seq_num, expected_bodies.len() as u64);
 
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Unbounded,
-        until: ReadUntil::Unbounded,
-        wait: Some(Duration::ZERO),
-    };
-    let read_session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut read_session = Box::pin(read_session);
-    let records = collect_records(&mut read_session).await;
-    assert_eq!(records.len(), expected_bodies.len());
+    let (start, end) = read_all_bounds();
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
     assert_eq!(envelope_bodies(&records), expected_bodies);
 }

--- a/lite/tests/backend/data_plane/auto_create.rs
+++ b/lite/tests/backend/data_plane/auto_create.rs
@@ -9,9 +9,11 @@ use s2_common::{
         stream::{AppendInput, ListStreamsRequest, ReadEnd, ReadFrom, ReadStart},
     },
 };
-use s2_lite::backend::error::{AppendError, ReadError};
+use s2_lite::backend::error::{AppendError, CheckTailError, ReadError};
 
 use super::common::*;
+
+const MAX_AUTO_CREATE_ATTEMPTS: usize = 50;
 
 #[tokio::test]
 async fn test_auto_create_stream_on_append() {
@@ -27,7 +29,7 @@ async fn test_auto_create_stream_on_append() {
         .list_streams(basin_name.clone(), ListStreamsRequest::default())
         .await
         .expect("Failed to list streams");
-    assert_eq!(stream_list.values.len(), 0);
+    assert!(stream_list.values.is_empty());
 
     let ack = append_payloads(&backend, &basin_name, &stream_name, &[b"auto created"]).await;
     assert_eq!(ack.start.seq_num, 0);
@@ -36,8 +38,12 @@ async fn test_auto_create_stream_on_append() {
         .list_streams(basin_name.clone(), ListStreamsRequest::default())
         .await
         .expect("Failed to list streams");
-    assert_eq!(stream_list.values.len(), 1);
-    assert_eq!(stream_list.values[0].name, stream_name);
+    let stream_names: Vec<_> = stream_list
+        .values
+        .iter()
+        .map(|info| info.name.as_ref())
+        .collect();
+    assert_eq!(stream_names, vec![stream_name.as_ref()]);
 
     let config = backend
         .get_stream_config(basin_name, stream_name)
@@ -60,32 +66,22 @@ async fn test_auto_create_stream_on_read() {
         .list_streams(basin_name.clone(), ListStreamsRequest::default())
         .await
         .expect("Failed to list streams");
-    assert_eq!(stream_list.values.len(), 0);
+    assert!(stream_list.values.is_empty());
 
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Unbounded,
-        until: ReadUntil::Unbounded,
-        wait: Some(Duration::ZERO),
-    };
-
-    let session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
-    assert_eq!(records.len(), 0);
+    let (start, end) = read_all_bounds();
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
+    assert!(records.is_empty());
 
     let stream_list = backend
         .list_streams(basin_name.clone(), ListStreamsRequest::default())
         .await
         .expect("Failed to list streams");
-    assert_eq!(stream_list.values.len(), 1);
-    assert_eq!(stream_list.values[0].name, stream_name);
+    let stream_names: Vec<_> = stream_list
+        .values
+        .iter()
+        .map(|info| info.name.as_ref())
+        .collect();
+    assert_eq!(stream_names, vec![stream_name.as_ref()]);
 }
 
 #[tokio::test]
@@ -131,6 +127,21 @@ async fn test_auto_create_disabled_read_fails() {
 }
 
 #[tokio::test]
+async fn test_auto_create_disabled_check_tail_fails() {
+    let backend = create_backend().await;
+    let basin_config = BasinConfig {
+        create_stream_on_read: false,
+        ..Default::default()
+    };
+    let basin_name = create_test_basin(&backend, "no-auto-create-tail", basin_config).await;
+    let stream_name = test_stream_name("missing");
+
+    let result = backend.check_tail(basin_name, stream_name).await;
+
+    assert!(matches!(result, Err(CheckTailError::StreamNotFound(_))));
+}
+
+#[tokio::test]
 async fn test_auto_create_check_tail() {
     let backend = create_backend().await;
     let basin_config = BasinConfig {
@@ -147,11 +158,15 @@ async fn test_auto_create_check_tail() {
     assert_eq!(tail, StreamPosition::MIN);
 
     let stream_list = backend
-        .list_streams(basin_name, ListStreamsRequest::default())
+        .list_streams(basin_name.clone(), ListStreamsRequest::default())
         .await
         .expect("Failed to list streams");
-    assert_eq!(stream_list.values.len(), 1);
-    assert_eq!(stream_list.values[0].name, stream_name);
+    let stream_names: Vec<_> = stream_list
+        .values
+        .iter()
+        .map(|info| info.name.as_ref())
+        .collect();
+    assert_eq!(stream_names, vec![stream_name.as_ref()]);
 }
 
 #[tokio::test]
@@ -164,18 +179,20 @@ async fn test_auto_create_race_condition_append() {
     let basin_name = create_test_basin(&backend, "auto-race-append", basin_config).await;
     let stream_name = test_stream_name("racing");
 
+    let expected_bodies: Vec<_> = (0..10).map(|i| format!("racer-{i}").into_bytes()).collect();
     let mut handles = vec![];
-    for i in 0..10 {
+    for body in &expected_bodies {
         let backend = backend.clone();
         let basin_name = basin_name.clone();
         let stream_name = stream_name.clone();
+        let body = body.clone();
         let handle = tokio::spawn(async move {
             let input = AppendInput {
-                records: create_test_record_batch(vec![Bytes::from(format!("racer-{}", i))]),
+                records: create_test_record_batch(vec![Bytes::from(body)]),
                 match_seq_num: None,
                 fencing_token: None,
             };
-            for _ in 0..5 {
+            for _ in 0..MAX_AUTO_CREATE_ATTEMPTS {
                 match backend
                     .append(basin_name.clone(), stream_name.clone(), input.clone())
                     .await
@@ -183,7 +200,7 @@ async fn test_auto_create_race_condition_append() {
                     Ok(ack) => return Ok(ack),
                     Err(AppendError::TransactionConflict(_))
                     | Err(AppendError::StreamNotFound(_)) => {
-                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        tokio::task::yield_now().await;
                         continue;
                     }
                     Err(e) => return Err(e),
@@ -194,19 +211,12 @@ async fn test_auto_create_race_condition_append() {
         handles.push(handle);
     }
 
-    let mut success_count = 0;
-    let mut errors = vec![];
     for handle in handles {
-        match handle.await.unwrap() {
-            Ok(_) => success_count += 1,
-            Err(e) => errors.push(format!("{:?}", e)),
-        }
+        handle
+            .await
+            .unwrap()
+            .expect("Auto-create append racer should succeed");
     }
-
-    if success_count != 10 {
-        eprintln!("Success count: {}, errors: {:?}", success_count, errors);
-    }
-    assert_eq!(success_count, 10);
 
     let tail = backend
         .check_tail(basin_name.clone(), stream_name.clone())
@@ -215,10 +225,23 @@ async fn test_auto_create_race_condition_append() {
     assert_eq!(tail.seq_num, 10);
 
     let stream_list = backend
-        .list_streams(basin_name, ListStreamsRequest::default())
+        .list_streams(basin_name.clone(), ListStreamsRequest::default())
         .await
         .expect("Failed to list streams");
-    assert_eq!(stream_list.values.len(), 1);
+    let stream_names: Vec<_> = stream_list
+        .values
+        .iter()
+        .map(|info| info.name.as_ref())
+        .collect();
+    assert_eq!(stream_names, vec![stream_name.as_ref()]);
+
+    let (start, end) = read_all_bounds();
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
+    let mut actual_bodies = envelope_bodies(&records);
+    let mut expected_bodies = expected_bodies;
+    actual_bodies.sort();
+    expected_bodies.sort();
+    assert_eq!(actual_bodies, expected_bodies);
 }
 
 #[tokio::test]
@@ -246,7 +269,7 @@ async fn test_auto_create_race_condition_read() {
                 until: ReadUntil::Unbounded,
                 wait: Some(Duration::ZERO),
             };
-            for _ in 0..5 {
+            for _ in 0..MAX_AUTO_CREATE_ATTEMPTS {
                 match backend
                     .read(basin_name.clone(), stream_name.clone(), start, end)
                     .await
@@ -256,7 +279,7 @@ async fn test_auto_create_race_condition_read() {
                         return Ok::<(), ReadError>(());
                     }
                     Err(ReadError::TransactionConflict(_)) | Err(ReadError::StreamNotFound(_)) => {
-                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        tokio::task::yield_now().await;
                         continue;
                     }
                     Err(e) => return Err(e),
@@ -273,23 +296,31 @@ async fn test_auto_create_race_condition_read() {
         handles.push(handle);
     }
 
-    let mut success_count = 0;
-    let mut errors = vec![];
     for handle in handles {
-        match handle.await.unwrap() {
-            Ok(_) => success_count += 1,
-            Err(e) => errors.push(format!("{:?}", e)),
-        }
+        handle
+            .await
+            .unwrap()
+            .expect("Auto-create read racer should succeed");
     }
-
-    if success_count != 10 {
-        eprintln!("Success count: {}, errors: {:?}", success_count, errors);
-    }
-    assert_eq!(success_count, 10);
 
     let stream_list = backend
-        .list_streams(basin_name, ListStreamsRequest::default())
+        .list_streams(basin_name.clone(), ListStreamsRequest::default())
         .await
         .expect("Failed to list streams");
-    assert_eq!(stream_list.values.len(), 1);
+    let stream_names: Vec<_> = stream_list
+        .values
+        .iter()
+        .map(|info| info.name.as_ref())
+        .collect();
+    assert_eq!(stream_names, vec![stream_name.as_ref()]);
+
+    let tail = backend
+        .check_tail(basin_name.clone(), stream_name.clone())
+        .await
+        .expect("Failed to check tail after auto-create reads");
+    assert_eq!(tail, StreamPosition::MIN);
+
+    let (start, end) = read_all_bounds();
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
+    assert!(records.is_empty());
 }

--- a/lite/tests/backend/data_plane/mixed.rs
+++ b/lite/tests/backend/data_plane/mixed.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use bytes::Bytes;
 use s2_common::{
@@ -9,6 +9,7 @@ use s2_common::{
     },
 };
 use s2_lite::backend::error::{AppendError, CheckTailError, ReadError};
+use tokio::sync::Notify;
 
 use super::common::*;
 
@@ -59,14 +60,18 @@ async fn test_concurrent_appends_to_same_stream() {
     )
     .await;
 
+    let expected_bodies: Vec<_> = (0..20)
+        .map(|i| format!("concurrent-{i}").into_bytes())
+        .collect();
     let mut handles = vec![];
-    for i in 0..20 {
+    for body in &expected_bodies {
         let backend = backend.clone();
         let basin_name = basin_name.clone();
         let stream_name = stream_name.clone();
+        let body = body.clone();
         let handle = tokio::spawn(async move {
             let input = AppendInput {
-                records: create_test_record_batch(vec![Bytes::from(format!("concurrent-{}", i))]),
+                records: create_test_record_batch(vec![Bytes::from(body)]),
                 match_seq_num: None,
                 fencing_token: None,
             };
@@ -75,14 +80,12 @@ async fn test_concurrent_appends_to_same_stream() {
         handles.push(handle);
     }
 
-    let mut success_count = 0;
     for handle in handles {
-        if handle.await.unwrap().is_ok() {
-            success_count += 1;
-        }
+        handle
+            .await
+            .unwrap()
+            .expect("Concurrent append should succeed");
     }
-
-    assert_eq!(success_count, 20);
 
     let tail = backend
         .check_tail(basin_name.clone(), stream_name.clone())
@@ -106,65 +109,11 @@ async fn test_concurrent_appends_to_same_stream() {
         .expect("Failed to create read session");
     let mut session = Box::pin(session);
     let records = collect_records(&mut session).await;
-    assert_eq!(records.len(), 20);
-}
-
-#[tokio::test]
-async fn test_read_while_appending() {
-    let (backend, basin_name, stream_name) = setup_backend_with_stream(
-        "read-while-append",
-        "stream",
-        OptionalStreamConfig::default(),
-    )
-    .await;
-
-    append_payloads(&backend, &basin_name, &stream_name, &[b"initial"]).await;
-
-    let backend_clone = backend.clone();
-    let basin_clone = basin_name.clone();
-    let stream_clone = stream_name.clone();
-
-    let append_handle = tokio::spawn(async move {
-        for i in 0..10 {
-            append_payloads(
-                &backend_clone,
-                &basin_clone,
-                &stream_clone,
-                &[format!("append-{}", i).as_bytes()],
-            )
-            .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    });
-
-    tokio::time::sleep(Duration::from_millis(20)).await;
-
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Count(5),
-        until: ReadUntil::Unbounded,
-        wait: None,
-    };
-
-    let session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
-    assert!(!records.is_empty());
-    assert!(records.len() <= 5);
-
-    append_handle.await.unwrap();
-
-    let tail = backend
-        .check_tail(basin_name, stream_name)
-        .await
-        .expect("Failed to check tail");
-    assert_eq!(tail.seq_num, 11);
+    let mut actual_bodies = envelope_bodies(&records);
+    let mut expected_bodies = expected_bodies;
+    actual_bodies.sort();
+    expected_bodies.sort();
+    assert_eq!(actual_bodies, expected_bodies);
 }
 
 #[tokio::test]
@@ -179,7 +128,9 @@ async fn test_concurrent_reconfigure_during_append() {
     let backend_append = backend.clone();
     let basin_append = basin_name.clone();
     let stream_append = stream_name.clone();
+    let ready = Arc::new(Notify::new());
 
+    let ready_clone = ready.clone();
     let append_handle = tokio::spawn(async move {
         for i in 0..10 {
             append_payloads(
@@ -189,11 +140,14 @@ async fn test_concurrent_reconfigure_during_append() {
                 &[format!("data-{}", i).as_bytes()],
             )
             .await;
-            tokio::time::sleep(Duration::from_millis(5)).await;
+            if i == 0 {
+                ready_clone.notify_one();
+            }
+            tokio::task::yield_now().await;
         }
     });
 
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    ready.notified().await;
 
     let reconfig = StreamReconfiguration {
         storage_class: s2_common::maybe::Maybe::from(Some(StorageClass::Express)),
@@ -211,10 +165,19 @@ async fn test_concurrent_reconfigure_during_append() {
     append_handle.await.unwrap();
 
     let tail = backend
-        .check_tail(basin_name, stream_name)
+        .check_tail(basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to check tail");
     assert_eq!(tail.seq_num, 10);
+
+    let (start, end) = read_all_bounds();
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
+    assert_eq!(
+        envelope_bodies(&records),
+        (0..10)
+            .map(|i| format!("data-{i}").into_bytes())
+            .collect::<Vec<_>>()
+    );
 }
 
 #[tokio::test]
@@ -254,13 +217,16 @@ async fn test_concurrent_reads_same_stream() {
             let session = backend.read(basin_name, stream_name, start, end).await?;
             let mut session = Box::pin(session);
             let records = collect_records(&mut session).await;
-            Ok::<usize, ReadError>(records.len())
+            Ok::<Vec<Vec<u8>>, ReadError>(envelope_bodies(&records))
         });
         handles.push(handle);
     }
 
+    let expected_bodies: Vec<_> = (0..20)
+        .map(|i| format!("record-{i}").into_bytes())
+        .collect();
     for handle in handles {
-        let count = handle.await.unwrap().expect("Read should succeed");
-        assert_eq!(count, 20);
+        let bodies = handle.await.unwrap().expect("Read should succeed");
+        assert_eq!(bodies, expected_bodies);
     }
 }

--- a/lite/tests/backend/data_plane/read.rs
+++ b/lite/tests/backend/data_plane/read.rs
@@ -2,15 +2,15 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use futures::StreamExt;
+use rstest::rstest;
 use s2_common::{
     encryption::{EncryptionMode, EncryptionSpec},
     read_extent::{ReadLimit, ReadUntil},
     record::{MeteredSize, RecordDecryptionError, StreamPosition},
     types::{
+        basin::BasinName,
         config::{OptionalStreamConfig, OptionalTimestampingConfig, TimestampingMode},
-        stream::{
-            AppendInput, ReadEnd, ReadFrom, ReadStart, StoredReadBatch, StoredReadSessionOutput,
-        },
+        stream::{ReadEnd, ReadFrom, ReadStart, StoredReadSessionOutput, StreamName},
     },
 };
 use s2_lite::backend::{
@@ -20,37 +20,75 @@ use s2_lite::backend::{
 
 use super::common::*;
 
-fn read_all_bounds() -> (ReadStart, ReadEnd) {
-    (
-        ReadStart {
-            from: ReadFrom::SeqNum(0),
-            clamp: false,
+#[derive(Clone, Copy, Debug)]
+enum TailStartCase {
+    TailOffset,
+    SeqNumAtEnd,
+    TimestampAfterEnd,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum TailEndCase {
+    CountNoWait,
+    CountZeroWait,
+    TimestampMax,
+}
+
+fn tail_read_from(case: TailStartCase, tail: &StreamPosition) -> ReadFrom {
+    match case {
+        TailStartCase::TailOffset => ReadFrom::TailOffset(0),
+        TailStartCase::SeqNumAtEnd => ReadFrom::SeqNum(tail.seq_num),
+        TailStartCase::TimestampAfterEnd => ReadFrom::Timestamp(tail.timestamp + 1),
+    }
+}
+
+fn tail_read_end(case: TailEndCase) -> ReadEnd {
+    match case {
+        TailEndCase::CountNoWait => ReadEnd {
+            limit: ReadLimit::Count(10),
+            until: ReadUntil::Unbounded,
+            wait: None,
         },
-        ReadEnd {
-            limit: ReadLimit::Unbounded,
+        TailEndCase::CountZeroWait => ReadEnd {
+            limit: ReadLimit::Count(10),
             until: ReadUntil::Unbounded,
             wait: Some(Duration::ZERO),
         },
-    )
+        TailEndCase::TimestampMax => ReadEnd {
+            limit: ReadLimit::Unbounded,
+            until: ReadUntil::Timestamp(u64::MAX),
+            wait: None,
+        },
+    }
 }
 
-async fn first_stored_batch(
-    backend: &Backend,
-    basin: &s2_common::types::basin::BasinName,
-    stream: &s2_common::types::stream::StreamName,
-) -> StoredReadBatch {
-    let (start, end) = read_all_bounds();
-    let read_session = backend
-        .read(basin.clone(), stream.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut read_session = Box::pin(read_session);
-    match read_session.next().await {
-        Some(Ok(StoredReadSessionOutput::Batch(batch))) => batch,
-        Some(Ok(other)) => panic!("Unexpected first output: {other:?}"),
-        Some(Err(err)) => panic!("Unexpected backend read error: {err:?}"),
-        None => panic!("Read session ended without delivering batch"),
-    }
+fn body_vecs(bodies: &[&[u8]]) -> Vec<Vec<u8>> {
+    bodies.iter().map(|body| body.to_vec()).collect()
+}
+
+fn timestamped_payloads(records: &[(&[u8], u64)]) -> Vec<(Bytes, u64)> {
+    records
+        .iter()
+        .map(|(body, timestamp)| (Bytes::copy_from_slice(body), *timestamp))
+        .collect()
+}
+
+async fn seed_timestamped_stream(
+    basin_suffix: &str,
+    stream_suffix: &str,
+    stream_config: OptionalStreamConfig,
+    records: &[(&[u8], u64)],
+) -> (Backend, BasinName, StreamName) {
+    let (backend, basin_name, stream_name) =
+        setup_backend_with_stream(basin_suffix, stream_suffix, stream_config).await;
+    append_timestamped_payloads(
+        &backend,
+        &basin_name,
+        &stream_name,
+        timestamped_payloads(records),
+    )
+    .await;
+    (backend, basin_name, stream_name)
 }
 
 #[tokio::test]
@@ -97,24 +135,10 @@ async fn test_read_from_beginning() {
 
     append_repeat(&backend, &basin_name, &stream_name, b"test data", 5).await;
 
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Unbounded,
-        until: ReadUntil::Unbounded,
-        wait: Some(Duration::ZERO),
-    };
+    let (start, end) = read_all_bounds();
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
 
-    let session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
-
-    assert_eq!(records.len(), 5);
+    assert_eq!(envelope_bodies(&records), vec![b"test data".to_vec(); 5]);
 }
 
 #[tokio::test]
@@ -133,13 +157,8 @@ async fn test_read_encrypted_roundtrip() {
     .await;
 
     let (start, end) = read_all_bounds();
-    let read_session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create encrypted read session");
-    let mut read_session = Box::pin(read_session);
     let records =
-        collect_records_with_encryption(&mut read_session, &basin_name, &stream_name, &encryption)
+        read_records_with_encryption(&backend, &basin_name, &stream_name, start, end, &encryption)
             .await;
     assert_eq!(
         envelope_bodies(&records),
@@ -182,7 +201,12 @@ async fn test_read_with_limit() {
         setup_backend_with_stream("read-with-limit", "limit", OptionalStreamConfig::default())
             .await;
 
-    append_repeat(&backend, &basin_name, &stream_name, b"test data", 10).await;
+    let expected_bodies: Vec<_> = (0..10)
+        .map(|i| format!("record-{i}").into_bytes())
+        .collect();
+    for body in &expected_bodies {
+        append_payloads(&backend, &basin_name, &stream_name, &[body.as_slice()]).await;
+    }
 
     let start = ReadStart {
         from: ReadFrom::SeqNum(0),
@@ -194,14 +218,12 @@ async fn test_read_with_limit() {
         wait: None,
     };
 
-    let session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
 
-    assert!(records.len() <= 5);
+    assert_eq!(
+        envelope_bodies(&records),
+        expected_bodies.into_iter().take(5).collect::<Vec<_>>()
+    );
 }
 
 #[tokio::test]
@@ -240,16 +262,25 @@ async fn test_read_unwritten_clamp_behavior() {
         until: ReadUntil::Unbounded,
         wait: Some(Duration::ZERO),
     };
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("should succeed with clamp");
-    let records = collect_records(&mut Box::pin(session)).await;
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
     assert!(records.is_empty());
 }
 
+#[rstest]
+#[case::tail_offset_no_wait(TailStartCase::TailOffset, TailEndCase::CountNoWait, false)]
+#[case::tail_seq_num_zero_wait(TailStartCase::SeqNumAtEnd, TailEndCase::CountZeroWait, false)]
+#[case::tail_timestamp_max(TailStartCase::TimestampAfterEnd, TailEndCase::TimestampMax, false)]
+#[case::timestamp_after_end_with_clamp(
+    TailStartCase::TimestampAfterEnd,
+    TailEndCase::CountNoWait,
+    true
+)]
 #[tokio::test]
-async fn test_read_at_tail_without_follow_returns_unwritten() {
+async fn test_read_at_tail_without_follow_returns_unwritten(
+    #[case] start_case: TailStartCase,
+    #[case] end_case: TailEndCase,
+    #[case] clamp: bool,
+) {
     let (backend, basin_name, stream_name) = setup_backend_with_stream(
         "read-at-tail-no-follow",
         "stream",
@@ -257,62 +288,36 @@ async fn test_read_at_tail_without_follow_returns_unwritten() {
     )
     .await;
 
-    let input = AppendInput {
-        records: create_test_record_batch_with_timestamps(vec![
+    let ack = append_timestamped_payloads(
+        &backend,
+        &basin_name,
+        &stream_name,
+        vec![
             (Bytes::from_static(b"record 1"), 1000),
             (Bytes::from_static(b"record 2"), 2000),
-        ]),
-        match_seq_num: None,
-        fencing_token: None,
+        ],
+    )
+    .await;
+
+    let start = ReadStart {
+        from: tail_read_from(start_case, &ack.end),
+        clamp,
     };
-    let ack = backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("append");
+    let end = tail_read_end(end_case);
+    let result = backend
+        .read(basin_name.clone(), stream_name.clone(), start, end)
+        .await;
 
-    let starts = [
-        ReadFrom::TailOffset(0),
-        ReadFrom::SeqNum(ack.end.seq_num),
-        ReadFrom::Timestamp(ack.end.timestamp + 1),
-    ];
-    let ends = [
-        ReadEnd {
-            limit: ReadLimit::Count(10),
-            until: ReadUntil::Unbounded,
-            wait: None,
-        },
-        ReadEnd {
-            limit: ReadLimit::Count(10),
-            until: ReadUntil::Unbounded,
-            wait: Some(Duration::ZERO),
-        },
-        ReadEnd {
-            limit: ReadLimit::Unbounded,
-            until: ReadUntil::Timestamp(u64::MAX),
-            wait: None,
-        },
-    ];
-
-    for from in starts {
-        for end in ends {
-            for clamp in [false, true] {
-                let start = ReadStart { from, clamp };
-                let result = backend
-                    .read(basin_name.clone(), stream_name.clone(), start, end)
-                    .await;
-                match result {
-                    Err(ReadError::Unwritten(UnwrittenError(tail))) => {
-                        assert_eq!(tail, ack.end);
-                    }
-                    Ok(_) => panic!(
-                        "Expected Unwritten error for {from:?} / clamp={clamp} / {end:?}, got Ok"
-                    ),
-                    Err(e) => panic!(
-                        "Expected Unwritten error for {from:?} / clamp={clamp} / {end:?}, got: {e:?}"
-                    ),
-                }
-            }
+    match result {
+        Err(ReadError::Unwritten(UnwrittenError(tail))) => {
+            assert_eq!(tail, ack.end);
         }
+        Ok(_) => panic!(
+            "Expected Unwritten error for {start_case:?} / clamp={clamp} / {end_case:?}, got Ok"
+        ),
+        Err(e) => panic!(
+            "Expected Unwritten error for {start_case:?} / clamp={clamp} / {end_case:?}, got: {e:?}"
+        ),
     }
 }
 
@@ -339,78 +344,10 @@ async fn test_read_from_tail_offset() {
         wait: Some(Duration::ZERO),
     };
 
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
     let bodies = envelope_bodies(&records);
 
     assert_eq!(bodies, vec![b"record 4".to_vec(), b"record 5".to_vec()]);
-}
-
-#[tokio::test]
-async fn test_read_timestamp_range() {
-    let (backend, basin_name, stream_name) =
-        setup_backend_with_stream("read-timestamp", "range", OptionalStreamConfig::default()).await;
-
-    let timestamped_records = vec![
-        (Bytes::from_static(b"ts-100"), 100),
-        (Bytes::from_static(b"ts-200"), 200),
-        (Bytes::from_static(b"ts-300"), 300),
-    ];
-
-    let input = AppendInput {
-        records: create_test_record_batch_with_timestamps(timestamped_records),
-        match_seq_num: None,
-        fencing_token: None,
-    };
-
-    backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("Failed to append records with timestamps");
-
-    let start = ReadStart {
-        from: ReadFrom::Timestamp(150),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Unbounded,
-        until: ReadUntil::Timestamp(300),
-        wait: Some(Duration::ZERO),
-    };
-
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-
-    let mut session = Box::pin(session);
-    let records: Vec<_> = loop {
-        let output = tokio::time::timeout(Duration::from_secs(1), session.as_mut().next())
-            .await
-            .expect("Timed out waiting for read output");
-        match output {
-            Some(Ok(StoredReadSessionOutput::Batch(batch))) => {
-                break decrypt_plain_batch(batch).records.iter().cloned().collect();
-            }
-            Some(Ok(StoredReadSessionOutput::Heartbeat(_))) => continue,
-            Some(Err(e)) => panic!("Read error: {:?}", e),
-            None => panic!("Read session ended without delivering expected batch"),
-        }
-    };
-    drop(session);
-
-    let bodies = envelope_bodies(&records);
-
-    assert_eq!(bodies, vec![b"ts-200".to_vec()]);
-    assert!(
-        records
-            .iter()
-            .all(|record| record.position().timestamp < 300)
-    );
 }
 
 #[tokio::test]
@@ -423,24 +360,18 @@ async fn test_read_from_timestamp_includes_duplicate_timestamps() {
         ..Default::default()
     };
 
-    let (backend, basin_name, stream_name) =
-        setup_backend_with_stream("read-dupe-timestamp", "stream", stream_config).await;
-
     let timestamp = 1000;
-    let input = AppendInput {
-        records: create_test_record_batch_with_timestamps(vec![
-            (Bytes::from_static(b"dup-1"), timestamp),
-            (Bytes::from_static(b"dup-2"), timestamp),
-            (Bytes::from_static(b"dup-3"), timestamp),
-        ]),
-        match_seq_num: None,
-        fencing_token: None,
-    };
-
-    backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("Failed to append duplicate timestamp records");
+    let (backend, basin_name, stream_name) = seed_timestamped_stream(
+        "read-dupe-timestamp",
+        "stream",
+        stream_config,
+        &[
+            (b"dup-1", timestamp),
+            (b"dup-2", timestamp),
+            (b"dup-3", timestamp),
+        ],
+    )
+    .await;
 
     let start = ReadStart {
         from: ReadFrom::Timestamp(timestamp),
@@ -452,21 +383,15 @@ async fn test_read_from_timestamp_includes_duplicate_timestamps() {
         wait: Some(Duration::ZERO),
     };
 
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
 
-    let bodies = envelope_bodies(&records);
     assert_eq!(
-        bodies,
-        vec![b"dup-1".to_vec(), b"dup-2".to_vec(), b"dup-3".to_vec()]
+        envelope_bodies(&records),
+        body_vecs(&[b"dup-1", b"dup-2", b"dup-3"])
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_read_from_tail_times_out_without_new_data() {
     let (backend, basin_name, stream_name) =
         setup_backend_with_stream("read-tail-wait", "idle", OptionalStreamConfig::default()).await;
@@ -483,34 +408,88 @@ async fn test_read_from_tail_times_out_without_new_data() {
         wait: Some(Duration::from_millis(100)),
     };
 
-    let session = backend
-        .read(basin_name, stream_name, start, end)
+    let mut session = open_read_session(&backend, &basin_name, &stream_name, start, end).await;
+    let probe_step = Duration::from_millis(1);
+
+    let started = tokio::time::Instant::now();
+    let outputs =
+        collect_outputs_until_closed_advanced(&mut session, Duration::from_secs(1), probe_step)
+            .await;
+
+    assert_eq!(outputs.outputs.len(), 1);
+    assert!(matches!(
+        outputs.outputs.first(),
+        Some(StoredReadSessionOutput::Heartbeat(_))
+    ));
+    let wait = Duration::from_millis(100);
+    assert!(outputs.closed_at >= started + wait);
+    assert!(outputs.closed_at <= started + wait + probe_step);
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_read_from_tail_wait_is_reset_by_new_data() {
+    let (backend, basin_name, stream_name) =
+        setup_backend_with_stream("read-tail-reset", "stream", OptionalStreamConfig::default())
+            .await;
+
+    append_payloads(&backend, &basin_name, &stream_name, &[b"seed data"]).await;
+
+    let wait = Duration::from_millis(100);
+    let follow_delay = Duration::from_millis(40);
+    let probe_step = Duration::from_millis(1);
+    let start = ReadStart {
+        from: ReadFrom::TailOffset(0),
+        clamp: false,
+    };
+    let end = ReadEnd {
+        limit: ReadLimit::Unbounded,
+        until: ReadUntil::Unbounded,
+        wait: Some(wait),
+    };
+
+    let mut session = open_read_session(&backend, &basin_name, &stream_name, start, end).await;
+
+    let first = session
+        .as_mut()
+        .next()
         .await
-        .expect("Failed to create read session");
-    tokio::pin!(session);
+        .expect("session should enter follow mode")
+        .expect("session should not error");
+    assert!(matches!(first, StoredReadSessionOutput::Heartbeat(_)));
 
-    let first_output = tokio::time::timeout(Duration::from_secs(1), session.next())
+    advance_time(follow_delay).await;
+
+    append_payloads(&backend, &basin_name, &stream_name, &[b"follow data"]).await;
+
+    let follow = session
+        .as_mut()
+        .next()
         .await
-        .expect("Timed out waiting for initial heartbeat")
-        .expect("Read session ended unexpectedly");
-
-    match first_output {
-        Ok(StoredReadSessionOutput::Heartbeat(_)) => {}
-        other => panic!("Unexpected first output: {:?}", other),
-    }
-
-    let second_output = tokio::time::timeout(Duration::from_secs(1), session.next())
-        .await
-        .expect("Timed out waiting for read session to finish");
-
-    assert!(
-        second_output.is_none(),
-        "Read session produced unexpected additional output"
+        .expect("session should yield the live tail batch")
+        .expect("session should not error");
+    let reset_at = tokio::time::Instant::now();
+    let StoredReadSessionOutput::Batch(batch) = follow else {
+        panic!("expected a batch after appending past tail");
+    };
+    let batch = decrypt_plain_batch(batch);
+    assert_eq!(
+        envelope_bodies(&batch.records),
+        vec![b"follow data".to_vec()]
     );
+
+    let outputs = collect_outputs_until_closed_advanced(
+        &mut session,
+        wait + Duration::from_secs(1),
+        probe_step,
+    )
+    .await;
+
+    assert!(outputs.closed_at >= reset_at + wait);
+    assert!(outputs.closed_at <= reset_at + wait + probe_step);
 }
 
 #[tokio::test]
-async fn test_read_with_bytes_limit() {
+async fn test_read_with_bytes_limit_exact_fit() {
     let (backend, basin_name, stream_name) = setup_backend_with_stream(
         "read-bytes-limit",
         "stream",
@@ -518,33 +497,62 @@ async fn test_read_with_bytes_limit() {
     )
     .await;
 
-    let large_body = vec![b'X'; 5000];
-    for _i in 0..10 {
-        append_payloads(&backend, &basin_name, &stream_name, &[&large_body]).await;
-    }
+    append_payloads(
+        &backend,
+        &basin_name,
+        &stream_name,
+        &[b"record-1", b"record-2", b"record-3"],
+    )
+    .await;
+
+    let stored_batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
+    let exact_limit =
+        stored_batch.records[0].metered_size() + stored_batch.records[1].metered_size();
 
     let start = ReadStart {
         from: ReadFrom::SeqNum(0),
         clamp: false,
     };
     let end = ReadEnd {
-        limit: ReadLimit::Bytes(15000),
+        limit: ReadLimit::Bytes(exact_limit),
         until: ReadUntil::Unbounded,
         wait: None,
     };
 
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
+    assert_eq!(
+        envelope_bodies(&records),
+        vec![b"record-1".to_vec(), b"record-2".to_vec()]
+    );
+}
 
-    assert!(records.len() >= 2);
-    assert!(records.len() <= 4);
+#[tokio::test]
+async fn test_read_with_bytes_limit_smaller_than_first_record_returns_empty() {
+    let (backend, basin_name, stream_name) = setup_backend_with_stream(
+        "read-bytes-too-small",
+        "stream",
+        OptionalStreamConfig::default(),
+    )
+    .await;
 
-    let total_bytes: usize = records.iter().map(|r| r.inner().metered_size()).sum();
-    assert!(total_bytes <= 20000);
+    append_payloads(&backend, &basin_name, &stream_name, &[b"oversized"]).await;
+
+    let stored_batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
+    let first_size = stored_batch.records[0].metered_size();
+    assert!(first_size > 0);
+
+    let start = ReadStart {
+        from: ReadFrom::SeqNum(0),
+        clamp: false,
+    };
+    let end = ReadEnd {
+        limit: ReadLimit::Bytes(first_size - 1),
+        until: ReadUntil::Unbounded,
+        wait: None,
+    };
+
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
+    assert!(records.is_empty());
 }
 
 #[tokio::test]
@@ -556,9 +564,9 @@ async fn test_read_with_count_or_bytes_limit_count_wins() {
     )
     .await;
 
-    let small_body = vec![b'Y'; 100];
-    for _i in 0..20 {
-        append_payloads(&backend, &basin_name, &stream_name, &[&small_body]).await;
+    let expected_bodies: Vec<_> = (0..20).map(|i| format!("count-{i}").into_bytes()).collect();
+    for body in &expected_bodies {
+        append_payloads(&backend, &basin_name, &stream_name, &[body.as_slice()]).await;
     }
 
     let start = ReadStart {
@@ -571,14 +579,12 @@ async fn test_read_with_count_or_bytes_limit_count_wins() {
         wait: None,
     };
 
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
 
-    assert_eq!(records.len(), 5);
+    assert_eq!(
+        envelope_bodies(&records),
+        expected_bodies.into_iter().take(5).collect::<Vec<_>>()
+    );
 }
 
 #[tokio::test]
@@ -590,506 +596,197 @@ async fn test_read_with_count_or_bytes_limit_bytes_wins() {
     )
     .await;
 
-    let large_body = vec![b'Z'; 10000];
-    for _i in 0..20 {
-        append_payloads(&backend, &basin_name, &stream_name, &[&large_body]).await;
-    }
+    append_payloads(
+        &backend,
+        &basin_name,
+        &stream_name,
+        &[b"slot-0", b"slot-1", b"slot-2", b"slot-3", b"slot-4"],
+    )
+    .await;
+
+    let stored_batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
+    let per_record_bytes = stored_batch.records[0].metered_size();
 
     let start = ReadStart {
         from: ReadFrom::SeqNum(0),
         clamp: false,
     };
     let end = ReadEnd {
-        limit: ReadLimit::from_count_and_bytes(Some(100), Some(35000)),
+        limit: ReadLimit::from_count_and_bytes(Some(100), Some(per_record_bytes * 3)),
         until: ReadUntil::Unbounded,
         wait: None,
     };
 
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
-
-    assert!(records.len() >= 2);
-    assert!(records.len() <= 5);
-    assert!(records.len() < 100);
-
-    let total_bytes: usize = records.iter().map(|r| r.inner().metered_size()).sum();
-    assert!(total_bytes <= 50000);
-}
-
-#[tokio::test]
-async fn test_read_until_timestamp_basic() {
-    let (backend, basin_name, stream_name) = setup_backend_with_stream(
-        "read-until-timestamp",
-        "basic",
-        OptionalStreamConfig::default(),
-    )
-    .await;
-
-    let timestamped_records = vec![
-        (Bytes::from_static(b"ts-1000"), 1000),
-        (Bytes::from_static(b"ts-2000"), 2000),
-        (Bytes::from_static(b"ts-3000"), 3000),
-        (Bytes::from_static(b"ts-4000"), 4000),
-        (Bytes::from_static(b"ts-5000"), 5000),
-    ];
-
-    let input = AppendInput {
-        records: create_test_record_batch_with_timestamps(timestamped_records),
-        match_seq_num: None,
-        fencing_token: None,
-    };
-
-    backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("Failed to append timestamped records");
-
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Unbounded,
-        until: ReadUntil::Timestamp(3500),
-        wait: None,
-    };
-
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
-
-    let bodies = envelope_bodies(&records);
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
     assert_eq!(
-        bodies,
-        vec![
-            b"ts-1000".to_vec(),
-            b"ts-2000".to_vec(),
-            b"ts-3000".to_vec()
-        ]
-    );
-    assert!(
-        records
-            .iter()
-            .all(|record| record.position().timestamp < 3500)
+        envelope_bodies(&records),
+        vec![b"slot-0".to_vec(), b"slot-1".to_vec(), b"slot-2".to_vec()]
     );
 }
 
 #[tokio::test]
-async fn test_read_until_timestamp_exact_boundary() {
-    let (backend, basin_name, stream_name) = setup_backend_with_stream(
-        "read-until-boundary",
-        "exact",
+async fn test_read_until_timestamp_boundaries() {
+    let boundary_records = [
+        (b"ts-1000".as_ref(), 1000),
+        (b"ts-2000-a".as_ref(), 2000),
+        (b"ts-2000-b".as_ref(), 2000),
+        (b"ts-3000".as_ref(), 3000),
+    ];
+    let cases = vec![
+        ("read-until-before", 500, body_vecs(&[])),
+        (
+            "read-until-exact-duplicate-boundary",
+            2000,
+            body_vecs(&[b"ts-1000"]),
+        ),
+        (
+            "read-until-after",
+            5000,
+            body_vecs(&[b"ts-1000", b"ts-2000-a", b"ts-2000-b", b"ts-3000"]),
+        ),
+    ];
+
+    for (suffix, cutoff, expected) in cases {
+        let (backend, basin_name, stream_name) = seed_timestamped_stream(
+            suffix,
+            "boundary",
+            OptionalStreamConfig::default(),
+            &boundary_records,
+        )
+        .await;
+
+        let records = read_records(
+            &backend,
+            &basin_name,
+            &stream_name,
+            ReadStart {
+                from: ReadFrom::SeqNum(0),
+                clamp: false,
+            },
+            ReadEnd {
+                limit: ReadLimit::Unbounded,
+                until: ReadUntil::Timestamp(cutoff),
+                wait: None,
+            },
+        )
+        .await;
+
+        assert_eq!(envelope_bodies(&records), expected, "case {suffix}");
+        assert!(
+            records
+                .iter()
+                .all(|record| record.position().timestamp < cutoff),
+            "case {suffix}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_read_until_with_additional_limits() {
+    let timestamped_records = [
+        (b"ts-1000".as_ref(), 1000),
+        (b"ts-2000".as_ref(), 2000),
+        (b"ts-3000".as_ref(), 3000),
+        (b"ts-4000".as_ref(), 4000),
+        (b"ts-5000".as_ref(), 5000),
+    ];
+    let (backend, basin_name, stream_name) = seed_timestamped_stream(
+        "read-until-limits",
+        "stream",
         OptionalStreamConfig::default(),
+        &timestamped_records,
     )
     .await;
 
-    let timestamped_records = vec![
-        (Bytes::from_static(b"ts-1000"), 1000),
-        (Bytes::from_static(b"ts-2000"), 2000),
-        (Bytes::from_static(b"ts-3000"), 3000),
-        (Bytes::from_static(b"ts-4000"), 4000),
+    let stored_batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
+    let per_record_bytes = stored_batch.records[0].metered_size();
+    let cases = vec![
+        (
+            "count wins",
+            ReadLimit::Count(2),
+            5_000,
+            body_vecs(&[b"ts-1000", b"ts-2000"]),
+        ),
+        (
+            "timestamp beats count",
+            ReadLimit::Count(10),
+            3_500,
+            body_vecs(&[b"ts-1000", b"ts-2000", b"ts-3000"]),
+        ),
+        (
+            "bytes win",
+            ReadLimit::Bytes(per_record_bytes * 2),
+            5_000,
+            body_vecs(&[b"ts-1000", b"ts-2000"]),
+        ),
+        (
+            "timestamp beats bytes",
+            ReadLimit::Bytes(per_record_bytes * 100),
+            3_500,
+            body_vecs(&[b"ts-1000", b"ts-2000", b"ts-3000"]),
+        ),
     ];
 
-    let input = AppendInput {
-        records: create_test_record_batch_with_timestamps(timestamped_records),
-        match_seq_num: None,
-        fencing_token: None,
-    };
+    for (label, limit, cutoff, expected) in cases {
+        let records = read_records(
+            &backend,
+            &basin_name,
+            &stream_name,
+            ReadStart {
+                from: ReadFrom::SeqNum(0),
+                clamp: false,
+            },
+            ReadEnd {
+                limit,
+                until: ReadUntil::Timestamp(cutoff),
+                wait: None,
+            },
+        )
+        .await;
 
-    backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("Failed to append timestamped records");
-
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Unbounded,
-        until: ReadUntil::Timestamp(3000),
-        wait: None,
-    };
-
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
-
-    let bodies = envelope_bodies(&records);
-    assert_eq!(bodies, vec![b"ts-1000".to_vec(), b"ts-2000".to_vec()]);
-    assert!(
-        records
-            .iter()
-            .all(|record| record.position().timestamp < 3000)
-    );
-}
-
-#[tokio::test]
-async fn test_read_until_timestamp_before_all_records() {
-    let (backend, basin_name, stream_name) =
-        setup_backend_with_stream("read-until-before", "all", OptionalStreamConfig::default())
-            .await;
-
-    let timestamped_records = vec![
-        (Bytes::from_static(b"ts-1000"), 1000),
-        (Bytes::from_static(b"ts-2000"), 2000),
-        (Bytes::from_static(b"ts-3000"), 3000),
-    ];
-
-    let input = AppendInput {
-        records: create_test_record_batch_with_timestamps(timestamped_records),
-        match_seq_num: None,
-        fencing_token: None,
-    };
-
-    backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("Failed to append timestamped records");
-
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Unbounded,
-        until: ReadUntil::Timestamp(500),
-        wait: None,
-    };
-
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
-
-    assert_eq!(records.len(), 0);
-}
-
-#[tokio::test]
-async fn test_read_until_timestamp_after_all_records() {
-    let (backend, basin_name, stream_name) =
-        setup_backend_with_stream("read-until-after", "all", OptionalStreamConfig::default()).await;
-
-    let timestamped_records = vec![
-        (Bytes::from_static(b"ts-1000"), 1000),
-        (Bytes::from_static(b"ts-2000"), 2000),
-        (Bytes::from_static(b"ts-3000"), 3000),
-    ];
-
-    let input = AppendInput {
-        records: create_test_record_batch_with_timestamps(timestamped_records),
-        match_seq_num: None,
-        fencing_token: None,
-    };
-
-    backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("Failed to append timestamped records");
-
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Unbounded,
-        until: ReadUntil::Timestamp(5000),
-        wait: None,
-    };
-
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
-
-    let bodies = envelope_bodies(&records);
-    assert_eq!(
-        bodies,
-        vec![
-            b"ts-1000".to_vec(),
-            b"ts-2000".to_vec(),
-            b"ts-3000".to_vec()
-        ]
-    );
-}
-
-#[tokio::test]
-async fn test_read_until_with_count_limit_count_wins() {
-    let (backend, basin_name, stream_name) = setup_backend_with_stream(
-        "read-until-count",
-        "count-wins",
-        OptionalStreamConfig::default(),
-    )
-    .await;
-
-    let timestamped_records = vec![
-        (Bytes::from_static(b"ts-1000"), 1000),
-        (Bytes::from_static(b"ts-2000"), 2000),
-        (Bytes::from_static(b"ts-3000"), 3000),
-        (Bytes::from_static(b"ts-4000"), 4000),
-        (Bytes::from_static(b"ts-5000"), 5000),
-    ];
-
-    let input = AppendInput {
-        records: create_test_record_batch_with_timestamps(timestamped_records),
-        match_seq_num: None,
-        fencing_token: None,
-    };
-
-    backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("Failed to append timestamped records");
-
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Count(2),
-        until: ReadUntil::Timestamp(5000),
-        wait: None,
-    };
-
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
-
-    assert_eq!(records.len(), 2);
-    let bodies = envelope_bodies(&records);
-    assert_eq!(bodies, vec![b"ts-1000".to_vec(), b"ts-2000".to_vec()]);
-}
-
-#[tokio::test]
-async fn test_read_until_with_count_limit_timestamp_wins() {
-    let (backend, basin_name, stream_name) = setup_backend_with_stream(
-        "read-until-count",
-        "timestamp-wins",
-        OptionalStreamConfig::default(),
-    )
-    .await;
-
-    let timestamped_records = vec![
-        (Bytes::from_static(b"ts-1000"), 1000),
-        (Bytes::from_static(b"ts-2000"), 2000),
-        (Bytes::from_static(b"ts-3000"), 3000),
-        (Bytes::from_static(b"ts-4000"), 4000),
-        (Bytes::from_static(b"ts-5000"), 5000),
-    ];
-
-    let input = AppendInput {
-        records: create_test_record_batch_with_timestamps(timestamped_records),
-        match_seq_num: None,
-        fencing_token: None,
-    };
-
-    backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("Failed to append timestamped records");
-
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Count(10),
-        until: ReadUntil::Timestamp(3500),
-        wait: None,
-    };
-
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
-
-    assert_eq!(records.len(), 3);
-    let bodies = envelope_bodies(&records);
-    assert_eq!(
-        bodies,
-        vec![
-            b"ts-1000".to_vec(),
-            b"ts-2000".to_vec(),
-            b"ts-3000".to_vec()
-        ]
-    );
-}
-
-#[tokio::test]
-async fn test_read_until_with_bytes_limit_bytes_wins() {
-    let (backend, basin_name, stream_name) = setup_backend_with_stream(
-        "read-until-bytes",
-        "bytes-wins",
-        OptionalStreamConfig::default(),
-    )
-    .await;
-
-    let large_body = vec![b'X'; 5000];
-    let timestamped_records = vec![
-        (Bytes::from(large_body.clone()), 1000),
-        (Bytes::from(large_body.clone()), 2000),
-        (Bytes::from(large_body.clone()), 3000),
-        (Bytes::from(large_body.clone()), 4000),
-        (Bytes::from(large_body), 5000),
-    ];
-
-    let input = AppendInput {
-        records: create_test_record_batch_with_timestamps(timestamped_records),
-        match_seq_num: None,
-        fencing_token: None,
-    };
-
-    backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("Failed to append timestamped records");
-
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Bytes(12000),
-        until: ReadUntil::Timestamp(5000),
-        wait: None,
-    };
-
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
-
-    assert!(records.len() >= 2);
-    assert!(records.len() <= 3);
-
-    let total_bytes: usize = records.iter().map(|r| r.inner().metered_size()).sum();
-    assert!(total_bytes <= 15000);
-}
-
-#[tokio::test]
-async fn test_read_until_with_bytes_limit_timestamp_wins() {
-    let (backend, basin_name, stream_name) = setup_backend_with_stream(
-        "read-until-bytes",
-        "timestamp-wins",
-        OptionalStreamConfig::default(),
-    )
-    .await;
-
-    let small_body = vec![b'Y'; 100];
-    let timestamped_records = vec![
-        (Bytes::from(small_body.clone()), 1000),
-        (Bytes::from(small_body.clone()), 2000),
-        (Bytes::from(small_body.clone()), 3000),
-        (Bytes::from(small_body.clone()), 4000),
-        (Bytes::from(small_body), 5000),
-    ];
-
-    let input = AppendInput {
-        records: create_test_record_batch_with_timestamps(timestamped_records),
-        match_seq_num: None,
-        fencing_token: None,
-    };
-
-    backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("Failed to append timestamped records");
-
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Bytes(100000),
-        until: ReadUntil::Timestamp(3500),
-        wait: None,
-    };
-
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
-
-    assert_eq!(records.len(), 3);
-    assert!(
-        records
-            .iter()
-            .all(|record| record.position().timestamp < 3500)
-    );
+        assert_eq!(envelope_bodies(&records), expected, "{label}");
+    }
 }
 
 #[tokio::test]
 async fn test_read_timestamp_range_with_from_and_until() {
-    let (backend, basin_name, stream_name) = setup_backend_with_stream(
+    let timestamped_records = [
+        (b"ts-500".as_ref(), 500),
+        (b"ts-2000-a".as_ref(), 2000),
+        (b"ts-2000-b".as_ref(), 2000),
+        (b"ts-2500".as_ref(), 2500),
+        (b"ts-3500".as_ref(), 3500),
+        (b"ts-4500".as_ref(), 4500),
+        (b"ts-5500".as_ref(), 5500),
+    ];
+    let (backend, basin_name, stream_name) = seed_timestamped_stream(
         "read-timestamp-range",
         "from-until",
         OptionalStreamConfig::default(),
+        &timestamped_records,
     )
     .await;
 
-    let timestamped_records = vec![
-        (Bytes::from_static(b"ts-500"), 500),
-        (Bytes::from_static(b"ts-1500"), 1500),
-        (Bytes::from_static(b"ts-2500"), 2500),
-        (Bytes::from_static(b"ts-3500"), 3500),
-        (Bytes::from_static(b"ts-4500"), 4500),
-        (Bytes::from_static(b"ts-5500"), 5500),
-    ];
+    let records = read_records(
+        &backend,
+        &basin_name,
+        &stream_name,
+        ReadStart {
+            from: ReadFrom::Timestamp(2000),
+            clamp: false,
+        },
+        ReadEnd {
+            limit: ReadLimit::Unbounded,
+            until: ReadUntil::Timestamp(4500),
+            wait: None,
+        },
+    )
+    .await;
 
-    let input = AppendInput {
-        records: create_test_record_batch_with_timestamps(timestamped_records),
-        match_seq_num: None,
-        fencing_token: None,
-    };
-
-    backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("Failed to append timestamped records");
-
-    let start = ReadStart {
-        from: ReadFrom::Timestamp(2000),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Unbounded,
-        until: ReadUntil::Timestamp(4500),
-        wait: None,
-    };
-
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-    let records = collect_records(&mut session).await;
-
-    assert_eq!(records.len(), 2);
-    let bodies = envelope_bodies(&records);
-    assert_eq!(bodies, vec![b"ts-2500".to_vec(), b"ts-3500".to_vec()]);
+    assert_eq!(
+        envelope_bodies(&records),
+        body_vecs(&[b"ts-2000-a", b"ts-2000-b", b"ts-2500", b"ts-3500"])
+    );
     assert!(records.iter().all(|record| {
         let position = record.position();
         position.timestamp >= 2000 && position.timestamp < 4500

--- a/lite/tests/backend/data_plane/read.rs
+++ b/lite/tests/backend/data_plane/read.rs
@@ -73,6 +73,16 @@ fn timestamped_payloads(records: &[(&[u8], u64)]) -> Vec<(Bytes, u64)> {
         .collect()
 }
 
+fn client_timestamp_stream_config() -> OptionalStreamConfig {
+    OptionalStreamConfig {
+        timestamping: OptionalTimestampingConfig {
+            mode: Some(TimestampingMode::ClientRequire),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
 async fn seed_timestamped_stream(
     basin_suffix: &str,
     stream_suffix: &str,
@@ -352,19 +362,11 @@ async fn test_read_from_tail_offset() {
 
 #[tokio::test]
 async fn test_read_from_timestamp_includes_duplicate_timestamps() {
-    let stream_config = OptionalStreamConfig {
-        timestamping: OptionalTimestampingConfig {
-            mode: Some(TimestampingMode::ClientRequire),
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-
     let timestamp = 1000;
     let (backend, basin_name, stream_name) = seed_timestamped_stream(
         "read-dupe-timestamp",
         "stream",
-        stream_config,
+        client_timestamp_stream_config(),
         &[
             (b"dup-1", timestamp),
             (b"dup-2", timestamp),
@@ -652,7 +654,7 @@ async fn test_read_until_timestamp_boundaries() {
         let (backend, basin_name, stream_name) = seed_timestamped_stream(
             suffix,
             "boundary",
-            OptionalStreamConfig::default(),
+            client_timestamp_stream_config(),
             &boundary_records,
         )
         .await;
@@ -695,7 +697,7 @@ async fn test_read_until_with_additional_limits() {
     let (backend, basin_name, stream_name) = seed_timestamped_stream(
         "read-until-limits",
         "stream",
-        OptionalStreamConfig::default(),
+        client_timestamp_stream_config(),
         &timestamped_records,
     )
     .await;
@@ -764,7 +766,7 @@ async fn test_read_timestamp_range_with_from_and_until() {
     let (backend, basin_name, stream_name) = seed_timestamped_stream(
         "read-timestamp-range",
         "from-until",
-        OptionalStreamConfig::default(),
+        client_timestamp_stream_config(),
         &timestamped_records,
     )
     .await;

--- a/lite/tests/backend/data_plane/read.rs
+++ b/lite/tests/backend/data_plane/read.rs
@@ -416,11 +416,13 @@ async fn test_read_from_tail_times_out_without_new_data() {
         collect_outputs_until_closed_advanced(&mut session, Duration::from_secs(1), probe_step)
             .await;
 
-    assert_eq!(outputs.outputs.len(), 1);
-    assert!(matches!(
-        outputs.outputs.first(),
-        Some(StoredReadSessionOutput::Heartbeat(_))
-    ));
+    assert!(!outputs.outputs.is_empty());
+    assert!(
+        outputs
+            .outputs
+            .iter()
+            .all(|output| matches!(output, StoredReadSessionOutput::Heartbeat(_)))
+    );
     let wait = Duration::from_millis(100);
     assert!(outputs.closed_at >= started + wait);
     assert!(outputs.closed_at <= started + wait + probe_step);

--- a/lite/tests/backend/data_plane/read.rs
+++ b/lite/tests/backend/data_plane/read.rs
@@ -628,61 +628,67 @@ async fn test_read_with_count_or_bytes_limit_bytes_wins() {
     );
 }
 
+#[rstest]
+#[case::before("read-until-before", 500, vec![])]
+#[case::exact_duplicate_boundary(
+    "read-until-exact-duplicate-boundary",
+    2000,
+    vec![b"ts-1000".to_vec()]
+)]
+#[case::after(
+    "read-until-after",
+    5000,
+    vec![
+        b"ts-1000".to_vec(),
+        b"ts-2000-a".to_vec(),
+        b"ts-2000-b".to_vec(),
+        b"ts-3000".to_vec(),
+    ]
+)]
 #[tokio::test]
-async fn test_read_until_timestamp_boundaries() {
+async fn test_read_until_timestamp_boundaries(
+    #[case] suffix: &str,
+    #[case] cutoff: u64,
+    #[case] expected: Vec<Vec<u8>>,
+) {
     let boundary_records = [
         (b"ts-1000".as_ref(), 1000),
         (b"ts-2000-a".as_ref(), 2000),
         (b"ts-2000-b".as_ref(), 2000),
         (b"ts-3000".as_ref(), 3000),
     ];
-    let cases = vec![
-        ("read-until-before", 500, body_vecs(&[])),
-        (
-            "read-until-exact-duplicate-boundary",
-            2000,
-            body_vecs(&[b"ts-1000"]),
-        ),
-        (
-            "read-until-after",
-            5000,
-            body_vecs(&[b"ts-1000", b"ts-2000-a", b"ts-2000-b", b"ts-3000"]),
-        ),
-    ];
 
-    for (suffix, cutoff, expected) in cases {
-        let (backend, basin_name, stream_name) = seed_timestamped_stream(
-            suffix,
-            "boundary",
-            client_timestamp_stream_config(),
-            &boundary_records,
-        )
-        .await;
+    let (backend, basin_name, stream_name) = seed_timestamped_stream(
+        suffix,
+        "boundary",
+        client_timestamp_stream_config(),
+        &boundary_records,
+    )
+    .await;
 
-        let records = read_records(
-            &backend,
-            &basin_name,
-            &stream_name,
-            ReadStart {
-                from: ReadFrom::SeqNum(0),
-                clamp: false,
-            },
-            ReadEnd {
-                limit: ReadLimit::Unbounded,
-                until: ReadUntil::Timestamp(cutoff),
-                wait: None,
-            },
-        )
-        .await;
+    let records = read_records(
+        &backend,
+        &basin_name,
+        &stream_name,
+        ReadStart {
+            from: ReadFrom::SeqNum(0),
+            clamp: false,
+        },
+        ReadEnd {
+            limit: ReadLimit::Unbounded,
+            until: ReadUntil::Timestamp(cutoff),
+            wait: None,
+        },
+    )
+    .await;
 
-        assert_eq!(envelope_bodies(&records), expected, "case {suffix}");
-        assert!(
-            records
-                .iter()
-                .all(|record| record.position().timestamp < cutoff),
-            "case {suffix}"
-        );
-    }
+    assert_eq!(envelope_bodies(&records), expected, "case {suffix}");
+    assert!(
+        records
+            .iter()
+            .all(|record| record.position().timestamp < cutoff),
+        "case {suffix}"
+    );
 }
 
 #[tokio::test]

--- a/lite/tests/backend/data_plane/read_follow.rs
+++ b/lite/tests/backend/data_plane/read_follow.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{task::Poll, time::Duration};
 
 use bytes::Bytes;
 use futures::StreamExt;
@@ -6,14 +6,17 @@ use rstest::rstest;
 use s2_common::{
     encryption::EncryptionSpec,
     read_extent::{ReadLimit, ReadUntil},
+    record::MeteredSize,
     types::{
-        config::OptionalStreamConfig,
+        config::{OptionalStreamConfig, OptionalTimestampingConfig, TimestampingMode},
         stream::{AppendInput, ReadEnd, ReadFrom, ReadStart, StoredReadSessionOutput},
     },
 };
 use s2_lite::backend::FOLLOWER_MAX_LAG;
 
 use super::common::*;
+
+const VIRTUAL_TIME_STEP: Duration = Duration::from_millis(50);
 
 async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &EncryptionSpec) {
     let (backend, basin_name, stream_name) =
@@ -32,10 +35,13 @@ async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &
         from: ReadFrom::SeqNum(0),
         clamp: false,
     };
+    let wait_duration = Duration::from_millis(200);
+    let first_follow_delay = Duration::from_millis(100);
+    let second_follow_delay = Duration::from_millis(50);
     let end = ReadEnd {
         limit: ReadLimit::Unbounded,
         until: ReadUntil::Unbounded,
-        wait: Some(Duration::from_secs(3)),
+        wait: Some(wait_duration),
     };
 
     let session = backend
@@ -50,7 +56,7 @@ async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &
     let encryption_clone = encryption.clone();
 
     let append_handle = tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        tokio::time::sleep(first_follow_delay).await;
         append_payloads_with_encryption(
             &backend_clone,
             &basin_clone,
@@ -59,7 +65,7 @@ async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &
             &encryption_clone,
         )
         .await;
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        tokio::time::sleep(second_follow_delay).await;
         append_payloads_with_encryption(
             &backend_clone,
             &basin_clone,
@@ -70,42 +76,31 @@ async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &
         .await;
     });
 
-    let mut all_records = Vec::new();
-    while all_records.len() < 3 {
-        let output = {
-            let mut pinned_session = session.as_mut();
-            let next = pinned_session.next();
-            tokio::pin!(next);
-            let mut advanced = Duration::ZERO;
-
-            loop {
-                tokio::select! {
-                    output = &mut next => break output,
-                    () = tokio::time::advance(Duration::from_millis(100)) => {
-                        advanced += Duration::from_millis(100);
-                        assert!(
-                            advanced <= Duration::from_secs(4),
-                            "timed out waiting for follow-mode output"
-                        );
-                        tokio::task::yield_now().await;
-                    }
-                }
-            }
-        };
-
-        match output {
-            Some(Ok(StoredReadSessionOutput::Batch(batch))) => {
-                let batch = decrypt_batch_for_stream(batch, &basin_name, &stream_name, encryption);
-                all_records.extend(batch.records.iter().cloned());
-            }
-            Some(Ok(StoredReadSessionOutput::Heartbeat(_))) => {}
-            Some(Err(e)) => panic!("Read error: {:?}", e),
-            None => break,
-        }
-    }
+    let probe_step = Duration::from_millis(1);
+    let started = tokio::time::Instant::now();
+    let outputs = collect_outputs_until_closed_advanced(
+        &mut session,
+        wait_duration + first_follow_delay + second_follow_delay + Duration::from_secs(1),
+        probe_step,
+    )
+    .await;
+    let closed_at = outputs.closed_at;
 
     append_handle.await.unwrap();
 
+    let all_records = outputs
+        .outputs
+        .into_iter()
+        .filter_map(|output| match output {
+            StoredReadSessionOutput::Batch(batch) => Some(batch),
+            StoredReadSessionOutput::Heartbeat(_) => None,
+        })
+        .flat_map(|batch| {
+            decrypt_batch_for_stream(batch, &basin_name, &stream_name, encryption)
+                .records
+                .into_iter()
+        })
+        .collect::<Vec<_>>();
     let bodies = envelope_bodies(&all_records);
     assert_eq!(
         bodies,
@@ -115,67 +110,276 @@ async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &
             b"follow-2".to_vec()
         ]
     );
+    let final_delivery_at = started + first_follow_delay + second_follow_delay;
+    let close_jitter = Duration::from_millis(20);
+    assert!(closed_at >= final_delivery_at + wait_duration);
+    assert!(closed_at <= final_delivery_at + wait_duration + close_jitter);
 }
 
-#[tokio::test]
-async fn test_follow_mode_wait_duration() {
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_follow_mode_broadcast_lag_resets_wait_after_db_catchup() {
     let (backend, basin_name, stream_name) = setup_backend_with_stream(
-        "follow-wait-duration",
+        "follow-broadcast-lag",
         "stream",
         OptionalStreamConfig::default(),
     )
     .await;
 
-    append_payloads(&backend, &basin_name, &stream_name, &[b"initial"]).await;
+    let message_count = FOLLOWER_MAX_LAG + 25;
+    let wait_duration = Duration::from_millis(200);
+    let pre_lag_delay = Duration::from_millis(100);
+    let probe_step = Duration::from_millis(1);
 
     let start = ReadStart {
         from: ReadFrom::SeqNum(0),
         clamp: false,
     };
-    let wait_duration = Duration::from_millis(500);
     let end = ReadEnd {
         limit: ReadLimit::Unbounded,
         until: ReadUntil::Unbounded,
         wait: Some(wait_duration),
     };
 
-    let start_time = tokio::time::Instant::now();
     let session = backend
-        .read(basin_name, stream_name, start, end)
+        .read(basin_name.clone(), stream_name.clone(), start, end)
         .await
         .expect("Failed to create read session");
     let mut session = Box::pin(session);
 
-    let mut batch_count = 0;
+    expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
+    advance_time(pre_lag_delay).await;
 
-    while let Some(result) = session.as_mut().next().await {
-        match result {
-            Ok(StoredReadSessionOutput::Batch(_)) => batch_count += 1,
-            Ok(StoredReadSessionOutput::Heartbeat(_)) => {}
-            Err(e) => panic!("Read error: {:?}", e),
-        }
+    let mut expected = Vec::with_capacity(message_count);
+    for i in 0..message_count {
+        let payload = format!("msg-{}", i);
+        expected.push(payload.as_bytes().to_vec());
+        append_payloads(&backend, &basin_name, &stream_name, &[payload.as_bytes()]).await;
     }
 
-    let elapsed = start_time.elapsed();
-    assert_eq!(batch_count, 1);
-    assert!(elapsed >= wait_duration, "Session ended too quickly");
-    assert!(
-        elapsed < wait_duration + Duration::from_secs(1),
-        "Session took too long to end"
-    );
+    let follow = session
+        .as_mut()
+        .next()
+        .await
+        .expect("session should deliver the lagged catchup batch")
+        .expect("session should not error");
+    let reset_at = tokio::time::Instant::now();
+    let StoredReadSessionOutput::Batch(batch) = follow else {
+        panic!("expected catchup batch after lagged follow");
+    };
+    let batch = decrypt_plain_batch(batch);
+    assert_eq!(envelope_bodies(&batch.records), expected);
+
+    let outputs = collect_outputs_until_closed_advanced(
+        &mut session,
+        wait_duration + Duration::from_secs(1),
+        probe_step,
+    )
+    .await;
+
+    assert!(outputs.closed_at >= reset_at + wait_duration);
+    assert!(outputs.closed_at <= reset_at + wait_duration + probe_step);
 }
 
-#[tokio::test]
-async fn test_follow_mode_heartbeats() {
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_follow_mode_broadcast_lag_respects_count_limit() {
     let (backend, basin_name, stream_name) = setup_backend_with_stream(
-        "follow-heartbeat",
+        "follow-broadcast-lag-count-limit",
         "stream",
         OptionalStreamConfig::default(),
     )
     .await;
 
-    append_payloads(&backend, &basin_name, &stream_name, &[b"initial"]).await;
+    let message_count = FOLLOWER_MAX_LAG + 25;
+    let count_limit = 3;
 
+    let start = ReadStart {
+        from: ReadFrom::SeqNum(0),
+        clamp: false,
+    };
+    let end = ReadEnd {
+        limit: ReadLimit::Count(count_limit),
+        until: ReadUntil::Unbounded,
+        wait: Some(Duration::from_secs(3)),
+    };
+
+    let session = backend
+        .read(basin_name.clone(), stream_name.clone(), start, end)
+        .await
+        .expect("Failed to create read session");
+    let mut session = Box::pin(session);
+
+    expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
+    advance_time(Duration::from_millis(100)).await;
+
+    let mut expected = Vec::with_capacity(message_count);
+    for i in 0..message_count {
+        let payload = format!("msg-{}", i);
+        expected.push(payload.as_bytes().to_vec());
+        append_payloads(&backend, &basin_name, &stream_name, &[payload.as_bytes()]).await;
+    }
+
+    let records = collect_records_until_closed_advanced(
+        &mut session,
+        Duration::from_secs(2),
+        VIRTUAL_TIME_STEP,
+    )
+    .await;
+    assert_eq!(
+        envelope_bodies(&records),
+        expected.into_iter().take(count_limit).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_follow_mode_broadcast_lag_respects_bytes_limit() {
+    let (backend, basin_name, stream_name) = setup_backend_with_stream(
+        "follow-broadcast-lag-bytes-limit",
+        "stream",
+        OptionalStreamConfig::default(),
+    )
+    .await;
+
+    append_payloads(&backend, &basin_name, &stream_name, &[b"item-00"]).await;
+
+    let stored_batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
+    let per_record_bytes = stored_batch.records[0].metered_size();
+    let message_count = FOLLOWER_MAX_LAG + 25;
+    let bytes_limit = per_record_bytes * 3;
+
+    let session = backend
+        .read(
+            basin_name.clone(),
+            stream_name.clone(),
+            ReadStart {
+                from: ReadFrom::TailOffset(0),
+                clamp: false,
+            },
+            ReadEnd {
+                limit: ReadLimit::Bytes(bytes_limit),
+                until: ReadUntil::Unbounded,
+                wait: Some(Duration::from_secs(3)),
+            },
+        )
+        .await
+        .expect("Failed to create read session");
+    let mut session = Box::pin(session);
+
+    expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
+    advance_time(Duration::from_millis(100)).await;
+
+    let expected: Vec<_> = (1..=message_count)
+        .map(|i| format!("item-{i:02}").into_bytes())
+        .collect();
+    for body in &expected {
+        append_payloads(&backend, &basin_name, &stream_name, &[body.as_slice()]).await;
+    }
+
+    let records = collect_records_until_closed_advanced(
+        &mut session,
+        Duration::from_secs(2),
+        VIRTUAL_TIME_STEP,
+    )
+    .await;
+
+    assert_eq!(
+        envelope_bodies(&records),
+        expected.into_iter().take(3).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_follow_mode_broadcast_lag_respects_timestamp_until() {
+    let stream_config = OptionalStreamConfig {
+        timestamping: OptionalTimestampingConfig {
+            mode: Some(TimestampingMode::ClientRequire),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let (backend, basin_name, stream_name) =
+        setup_backend_with_stream("follow-broadcast-lag-until", "stream", stream_config).await;
+
+    let message_count = FOLLOWER_MAX_LAG + 25;
+    let cutoff = 4_000;
+
+    let session = backend
+        .read(
+            basin_name.clone(),
+            stream_name.clone(),
+            ReadStart {
+                from: ReadFrom::SeqNum(0),
+                clamp: false,
+            },
+            ReadEnd {
+                limit: ReadLimit::Unbounded,
+                until: ReadUntil::Timestamp(cutoff),
+                wait: Some(Duration::from_secs(3)),
+            },
+        )
+        .await
+        .expect("Failed to create read session");
+    let mut session = Box::pin(session);
+
+    expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
+    advance_time(Duration::from_millis(100)).await;
+
+    let expected: Vec<_> = (1..=message_count)
+        .map(|i| (format!("ts-{i:03}").into_bytes(), i as u64 * 1_000))
+        .collect();
+    for (body, timestamp) in &expected {
+        append_timestamped_payloads(
+            &backend,
+            &basin_name,
+            &stream_name,
+            vec![(Bytes::from(body.clone()), *timestamp)],
+        )
+        .await;
+    }
+
+    let catchup = session
+        .as_mut()
+        .next()
+        .await
+        .expect("session should deliver the lagged catchup batch")
+        .expect("session should not error");
+    let StoredReadSessionOutput::Batch(batch) = catchup else {
+        panic!("expected lagged catchup batch");
+    };
+    let batch = decrypt_plain_batch(batch);
+    assert_eq!(
+        envelope_bodies(&batch.records),
+        expected
+            .iter()
+            .take_while(|(_, timestamp)| *timestamp < cutoff)
+            .map(|(body, _)| body.clone())
+            .collect::<Vec<_>>()
+    );
+
+    tokio::task::yield_now().await;
+    match futures::poll!(session.as_mut().next()) {
+        Poll::Ready(None) => {}
+        Poll::Ready(Some(Ok(output))) => {
+            panic!("unexpected output after timestamp cutoff catchup: {output:?}");
+        }
+        Poll::Ready(Some(Err(e))) => panic!("Read error: {e:?}"),
+        Poll::Pending => {
+            panic!(
+                "session should close immediately once lagged catchup crosses the timestamp cutoff"
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_follow_mode_broadcast_lag_resumes_live_follow_after_catchup() {
+    let (backend, basin_name, stream_name) = setup_backend_with_stream(
+        "follow-broadcast-lag-live",
+        "stream",
+        OptionalStreamConfig::default(),
+    )
+    .await;
+
+    let message_count = FOLLOWER_MAX_LAG + 25;
     let start = ReadStart {
         from: ReadFrom::SeqNum(0),
         clamp: false,
@@ -183,36 +387,61 @@ async fn test_follow_mode_heartbeats() {
     let end = ReadEnd {
         limit: ReadLimit::Unbounded,
         until: ReadUntil::Unbounded,
-        wait: Some(Duration::from_secs(1)),
+        wait: Some(Duration::from_millis(300)),
     };
 
     let session = backend
-        .read(basin_name, stream_name, start, end)
+        .read(basin_name.clone(), stream_name.clone(), start, end)
         .await
         .expect("Failed to create read session");
     let mut session = Box::pin(session);
 
-    let mut heartbeat_count = 0;
-    let mut batch_count = 0;
-    let timeout = Duration::from_secs(2);
-    let start_time = tokio::time::Instant::now();
+    expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
+    advance_time(Duration::from_millis(100)).await;
 
-    while start_time.elapsed() < timeout {
-        match tokio::time::timeout(Duration::from_millis(500), session.as_mut().next()).await {
-            Ok(Some(Ok(StoredReadSessionOutput::Batch(_)))) => {
-                batch_count += 1;
-            }
-            Ok(Some(Ok(StoredReadSessionOutput::Heartbeat(_)))) => {
-                heartbeat_count += 1;
-            }
-            Ok(Some(Err(e))) => panic!("Read error: {:?}", e),
-            Ok(None) => break,
-            Err(_) => continue,
-        }
+    let mut expected_catchup = Vec::with_capacity(message_count);
+    for i in 0..message_count {
+        let payload = format!("lag-{}", i);
+        expected_catchup.push(payload.as_bytes().to_vec());
+        append_payloads(&backend, &basin_name, &stream_name, &[payload.as_bytes()]).await;
     }
 
-    assert_eq!(batch_count, 1);
-    assert!(heartbeat_count > 0);
+    let catchup = session
+        .as_mut()
+        .next()
+        .await
+        .expect("session should deliver the lagged catchup batch")
+        .expect("session should not error");
+    let StoredReadSessionOutput::Batch(batch) = catchup else {
+        panic!("expected catchup batch after lagged follow");
+    };
+    let batch = decrypt_plain_batch(batch);
+    assert_eq!(envelope_bodies(&batch.records), expected_catchup);
+
+    let backend_clone = backend.clone();
+    let basin_clone = basin_name.clone();
+    let stream_clone = stream_name.clone();
+    let append_handle = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        append_payloads(
+            &backend_clone,
+            &basin_clone,
+            &stream_clone,
+            &[b"live-after-lag"],
+        )
+        .await;
+    });
+
+    let live_records =
+        collect_records_until_advanced(&mut session, Duration::from_secs(1), 1, VIRTUAL_TIME_STEP)
+            .await;
+
+    append_handle.await.unwrap();
+
+    assert_eq!(
+        envelope_bodies(&live_records),
+        vec![b"live-after-lag".to_vec()]
+    );
 }
 
 #[rstest]
@@ -226,134 +455,7 @@ async fn test_follow_mode_receives_new_data(
     run_follow_mode_receives_new_data_case(test_suffix, &encryption).await;
 }
 
-#[tokio::test]
-async fn test_follow_mode_with_multiple_appends() {
-    let (backend, basin_name, stream_name) =
-        setup_backend_with_stream("follow-multiple", "stream", OptionalStreamConfig::default())
-            .await;
-
-    append_payloads(&backend, &basin_name, &stream_name, &[b"initial"]).await;
-
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Unbounded,
-        until: ReadUntil::Unbounded,
-        wait: Some(Duration::from_secs(3)),
-    };
-
-    let session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-
-    let backend_clone = backend.clone();
-    let basin_clone = basin_name.clone();
-    let stream_clone = stream_name.clone();
-
-    let append_handle = tokio::spawn(async move {
-        for i in 0..5 {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            let payload = format!("follow-{}", i);
-            append_payloads(
-                &backend_clone,
-                &basin_clone,
-                &stream_clone,
-                &[payload.as_bytes()],
-            )
-            .await;
-        }
-    });
-
-    let mut all_records = Vec::new();
-    let timeout = Duration::from_secs(4);
-    let start_time = tokio::time::Instant::now();
-
-    while start_time.elapsed() < timeout && all_records.len() < 6 {
-        match tokio::time::timeout(Duration::from_millis(500), session.as_mut().next()).await {
-            Ok(Some(Ok(StoredReadSessionOutput::Batch(batch)))) => {
-                let batch = decrypt_plain_batch(batch);
-                all_records.extend(batch.records.iter().cloned());
-            }
-            Ok(Some(Ok(StoredReadSessionOutput::Heartbeat(_)))) => continue,
-            Ok(Some(Err(e))) => panic!("Read error: {:?}", e),
-            Ok(None) => break,
-            Err(_) => continue,
-        }
-    }
-
-    append_handle.await.unwrap();
-
-    let bodies = envelope_bodies(&all_records);
-    assert_eq!(
-        bodies,
-        vec![
-            b"initial".to_vec(),
-            b"follow-0".to_vec(),
-            b"follow-1".to_vec(),
-            b"follow-2".to_vec(),
-            b"follow-3".to_vec(),
-            b"follow-4".to_vec(),
-        ]
-    );
-}
-
-#[tokio::test]
-async fn test_follow_mode_broadcast_lag_falls_back_to_db_catchup() {
-    let (backend, basin_name, stream_name) = setup_backend_with_stream(
-        "follow-broadcast-lag",
-        "stream",
-        OptionalStreamConfig::default(),
-    )
-    .await;
-
-    let message_count = FOLLOWER_MAX_LAG + 25;
-
-    let start = ReadStart {
-        from: ReadFrom::SeqNum(0),
-        clamp: false,
-    };
-    let end = ReadEnd {
-        limit: ReadLimit::Count(message_count),
-        until: ReadUntil::Unbounded,
-        wait: Some(Duration::from_secs(3)),
-    };
-
-    let session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut session = Box::pin(session);
-
-    let first_output = tokio::time::timeout(Duration::from_secs(1), session.as_mut().next())
-        .await
-        .expect("Timed out waiting for initial heartbeat")
-        .expect("Read session ended unexpectedly")
-        .expect("Read session error");
-    assert!(matches!(
-        first_output,
-        StoredReadSessionOutput::Heartbeat(_)
-    ));
-
-    let mut expected = Vec::with_capacity(message_count);
-    for i in 0..message_count {
-        let payload = format!("msg-{}", i);
-        expected.push(payload.as_bytes().to_vec());
-        append_payloads(&backend, &basin_name, &stream_name, &[payload.as_bytes()]).await;
-    }
-
-    let records = tokio::time::timeout(Duration::from_secs(5), collect_records(&mut session))
-        .await
-        .expect("Timed out waiting for records");
-    let bodies = envelope_bodies(&records);
-
-    assert_eq!(bodies, expected);
-}
-
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_transition_from_catchup_to_follow() {
     let (backend, basin_name, stream_name) = setup_backend_with_stream(
         "catchup-to-follow",
@@ -397,22 +499,9 @@ async fn test_transition_from_catchup_to_follow() {
         append_payloads(&backend_clone, &basin_clone, &stream_clone, &[b"live-2"]).await;
     });
 
-    let mut all_records = Vec::new();
-    let timeout = Duration::from_secs(4);
-    let start_time = tokio::time::Instant::now();
-
-    while start_time.elapsed() < timeout && all_records.len() < 5 {
-        match tokio::time::timeout(Duration::from_millis(500), session.as_mut().next()).await {
-            Ok(Some(Ok(StoredReadSessionOutput::Batch(batch)))) => {
-                let batch = decrypt_plain_batch(batch);
-                all_records.extend(batch.records.iter().cloned());
-            }
-            Ok(Some(Ok(StoredReadSessionOutput::Heartbeat(_)))) => continue,
-            Ok(Some(Err(e))) => panic!("Read error: {:?}", e),
-            Ok(None) => break,
-            Err(_) => continue,
-        }
-    }
+    let all_records =
+        collect_records_until_advanced(&mut session, Duration::from_secs(4), 5, VIRTUAL_TIME_STEP)
+            .await;
 
     append_handle.await.unwrap();
 
@@ -429,7 +518,7 @@ async fn test_transition_from_catchup_to_follow() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_follow_mode_with_count_limit() {
     let (backend, basin_name, stream_name) = setup_backend_with_stream(
         "follow-count-limit",
@@ -471,26 +560,15 @@ async fn test_follow_mode_with_count_limit() {
         .await;
     });
 
-    let mut all_records = Vec::new();
-    let timeout = Duration::from_secs(4);
-    let start_time = tokio::time::Instant::now();
-
-    while start_time.elapsed() < timeout {
-        match tokio::time::timeout(Duration::from_millis(500), session.as_mut().next()).await {
-            Ok(Some(Ok(StoredReadSessionOutput::Batch(batch)))) => {
-                let batch = decrypt_plain_batch(batch);
-                all_records.extend(batch.records.iter().cloned());
-            }
-            Ok(Some(Ok(StoredReadSessionOutput::Heartbeat(_)))) => continue,
-            Ok(Some(Err(e))) => panic!("Read error: {:?}", e),
-            Ok(None) => break,
-            Err(_) => continue,
-        }
-    }
+    let all_records = collect_records_until_closed_advanced(
+        &mut session,
+        Duration::from_secs(4),
+        VIRTUAL_TIME_STEP,
+    )
+    .await;
 
     append_handle.await.unwrap();
 
-    assert_eq!(all_records.len(), 3);
     let bodies = envelope_bodies(&all_records);
     assert_eq!(
         bodies,
@@ -502,7 +580,7 @@ async fn test_follow_mode_with_count_limit() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_follow_mode_with_exact_count_limit() {
     let (backend, basin_name, stream_name) = setup_backend_with_stream(
         "follow-exact-count-limit",
@@ -542,31 +620,149 @@ async fn test_follow_mode_with_exact_count_limit() {
         .await;
     });
 
-    let mut all_records = Vec::new();
-    let timeout = Duration::from_secs(3);
-    let start_time = tokio::time::Instant::now();
-
-    while start_time.elapsed() < timeout {
-        match tokio::time::timeout(Duration::from_millis(500), session.as_mut().next()).await {
-            Ok(Some(Ok(StoredReadSessionOutput::Batch(batch)))) => {
-                let batch = decrypt_plain_batch(batch);
-                all_records.extend(batch.records.iter().cloned());
-            }
-            Ok(Some(Ok(StoredReadSessionOutput::Heartbeat(_)))) => continue,
-            Ok(Some(Err(e))) => panic!("Read error: {:?}", e),
-            Ok(None) => break,
-            Err(_) => continue,
-        }
-    }
+    let all_records = collect_records_until_closed_advanced(
+        &mut session,
+        Duration::from_secs(3),
+        VIRTUAL_TIME_STEP,
+    )
+    .await;
 
     append_handle.await.unwrap();
 
-    assert_eq!(all_records.len(), 2);
     let bodies = envelope_bodies(&all_records);
     assert_eq!(bodies, vec![b"follow-1".to_vec(), b"follow-2".to_vec()]);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_follow_mode_with_bytes_limit_truncates_live_batch() {
+    let (backend, basin_name, stream_name) = setup_backend_with_stream(
+        "follow-bytes-limit",
+        "stream",
+        OptionalStreamConfig::default(),
+    )
+    .await;
+
+    append_payloads(&backend, &basin_name, &stream_name, &[b"item-00"]).await;
+
+    let stored_batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
+    let per_record_bytes = stored_batch.records[0].metered_size();
+
+    let session = backend
+        .read(
+            basin_name.clone(),
+            stream_name.clone(),
+            ReadStart {
+                from: ReadFrom::TailOffset(0),
+                clamp: false,
+            },
+            ReadEnd {
+                limit: ReadLimit::Bytes(per_record_bytes * 2),
+                until: ReadUntil::Unbounded,
+                wait: Some(Duration::from_secs(2)),
+            },
+        )
+        .await
+        .expect("Failed to create follow read session");
+    let mut session = Box::pin(session);
+
+    expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
+
+    let backend_clone = backend.clone();
+    let basin_clone = basin_name.clone();
+    let stream_clone = stream_name.clone();
+    let append_handle = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let input = AppendInput {
+            records: create_test_record_batch(vec![
+                Bytes::from_static(b"item-01"),
+                Bytes::from_static(b"item-02"),
+                Bytes::from_static(b"item-03"),
+            ]),
+            match_seq_num: None,
+            fencing_token: None,
+        };
+        backend_clone
+            .append(basin_clone, stream_clone, input)
+            .await
+            .expect("live append should succeed");
+    });
+
+    let records = collect_records_until_closed_advanced(
+        &mut session,
+        Duration::from_secs(3),
+        VIRTUAL_TIME_STEP,
+    )
+    .await;
+
+    append_handle.await.unwrap();
+
+    assert_eq!(
+        envelope_bodies(&records),
+        vec![b"item-01".to_vec(), b"item-02".to_vec()]
+    );
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_follow_mode_with_bytes_limit_smaller_than_first_live_record_closes_without_batch() {
+    let (backend, basin_name, stream_name) = setup_backend_with_stream(
+        "follow-bytes-too-small",
+        "stream",
+        OptionalStreamConfig::default(),
+    )
+    .await;
+
+    append_payloads(&backend, &basin_name, &stream_name, &[b"item-00"]).await;
+
+    let stored_batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
+    let per_record_bytes = stored_batch.records[0].metered_size();
+
+    let session = backend
+        .read(
+            basin_name.clone(),
+            stream_name.clone(),
+            ReadStart {
+                from: ReadFrom::TailOffset(0),
+                clamp: false,
+            },
+            ReadEnd {
+                limit: ReadLimit::Bytes(per_record_bytes - 1),
+                until: ReadUntil::Unbounded,
+                wait: Some(Duration::from_secs(2)),
+            },
+        )
+        .await
+        .expect("Failed to create follow read session");
+    let mut session = Box::pin(session);
+
+    expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
+
+    let backend_clone = backend.clone();
+    let basin_clone = basin_name.clone();
+    let stream_clone = stream_name.clone();
+    let append_handle = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        append_payloads(&backend_clone, &basin_clone, &stream_clone, &[b"item-01"]).await;
+    });
+
+    let outputs = collect_outputs_until_closed_advanced(
+        &mut session,
+        Duration::from_secs(1),
+        VIRTUAL_TIME_STEP,
+    )
+    .await;
+
+    append_handle.await.unwrap();
+
+    assert!(
+        outputs
+            .outputs
+            .iter()
+            .all(|output| matches!(output, StoredReadSessionOutput::Heartbeat(_))),
+        "live oversize record should close the session without yielding a batch"
+    );
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_follow_mode_with_timestamp_until() {
     let (backend, basin_name, stream_name) = setup_backend_with_stream(
         "follow-timestamp-until",
@@ -575,16 +771,13 @@ async fn test_follow_mode_with_timestamp_until() {
     )
     .await;
 
-    let initial_records = vec![(Bytes::from_static(b"initial"), 1000)];
-    let input = AppendInput {
-        records: create_test_record_batch_with_timestamps(initial_records),
-        match_seq_num: None,
-        fencing_token: None,
-    };
-    backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("Failed to append initial record");
+    append_timestamped_payloads(
+        &backend,
+        &basin_name,
+        &stream_name,
+        vec![(Bytes::from_static(b"initial"), 1000)],
+    )
+    .await;
 
     let start = ReadStart {
         from: ReadFrom::SeqNum(0),
@@ -608,50 +801,33 @@ async fn test_follow_mode_with_timestamp_until() {
 
     let append_handle = tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(300)).await;
-        let timestamped_records = vec![(Bytes::from_static(b"before-cutoff"), 2000)];
-        let input = AppendInput {
-            records: create_test_record_batch_with_timestamps(timestamped_records),
-            match_seq_num: None,
-            fencing_token: None,
-        };
-        backend_clone
-            .append(basin_clone.clone(), stream_clone.clone(), input)
-            .await
-            .unwrap();
+        append_timestamped_payloads(
+            &backend_clone,
+            &basin_clone,
+            &stream_clone,
+            vec![(Bytes::from_static(b"before-cutoff"), 2000)],
+        )
+        .await;
 
         tokio::time::sleep(Duration::from_millis(200)).await;
-        let timestamped_records = vec![(Bytes::from_static(b"after-cutoff"), 3000)];
-        let input = AppendInput {
-            records: create_test_record_batch_with_timestamps(timestamped_records),
-            match_seq_num: None,
-            fencing_token: None,
-        };
-        backend_clone
-            .append(basin_clone, stream_clone, input)
-            .await
-            .unwrap();
+        append_timestamped_payloads(
+            &backend_clone,
+            &basin_clone,
+            &stream_clone,
+            vec![(Bytes::from_static(b"after-cutoff"), 3000)],
+        )
+        .await;
     });
 
-    let mut all_records = Vec::new();
-    let timeout = Duration::from_secs(3);
-    let start_time = tokio::time::Instant::now();
-
-    while start_time.elapsed() < timeout && all_records.len() < 3 {
-        match tokio::time::timeout(Duration::from_millis(500), session.as_mut().next()).await {
-            Ok(Some(Ok(StoredReadSessionOutput::Batch(batch)))) => {
-                let batch = decrypt_plain_batch(batch);
-                all_records.extend(batch.records.iter().cloned());
-            }
-            Ok(Some(Ok(StoredReadSessionOutput::Heartbeat(_)))) => continue,
-            Ok(Some(Err(e))) => panic!("Read error: {:?}", e),
-            Ok(None) => break,
-            Err(_) => continue,
-        }
-    }
+    let all_records = collect_records_until_closed_advanced(
+        &mut session,
+        Duration::from_secs(3),
+        VIRTUAL_TIME_STEP,
+    )
+    .await;
 
     append_handle.await.unwrap();
 
-    assert_eq!(all_records.len(), 2);
     let bodies = envelope_bodies(&all_records);
     assert_eq!(bodies, vec![b"initial".to_vec(), b"before-cutoff".to_vec()]);
 }

--- a/lite/tests/backend/data_plane/read_follow.rs
+++ b/lite/tests/backend/data_plane/read_follow.rs
@@ -634,6 +634,63 @@ async fn test_follow_mode_with_exact_count_limit() {
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_collect_records_until_advanced_stops_at_target_count_with_multi_record_batch() {
+    let (backend, basin_name, stream_name) = setup_backend_with_stream(
+        "follow-target-count",
+        "stream",
+        OptionalStreamConfig::default(),
+    )
+    .await;
+
+    append_payloads(&backend, &basin_name, &stream_name, &[b"seed"]).await;
+
+    let session = backend
+        .read(
+            basin_name.clone(),
+            stream_name.clone(),
+            ReadStart {
+                from: ReadFrom::TailOffset(0),
+                clamp: false,
+            },
+            ReadEnd {
+                limit: ReadLimit::Unbounded,
+                until: ReadUntil::Unbounded,
+                wait: Some(Duration::from_secs(2)),
+            },
+        )
+        .await
+        .expect("Failed to create follow read session");
+    let mut session = Box::pin(session);
+
+    expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
+
+    let backend_clone = backend.clone();
+    let basin_clone = basin_name.clone();
+    let stream_clone = stream_name.clone();
+    let append_handle = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        append_payloads(
+            &backend_clone,
+            &basin_clone,
+            &stream_clone,
+            &[b"follow-1", b"follow-2", b"follow-3"],
+        )
+        .await;
+    });
+
+    let records =
+        collect_records_until_advanced(&mut session, Duration::from_secs(1), 2, VIRTUAL_TIME_STEP)
+            .await;
+
+    append_handle.await.unwrap();
+
+    assert_eq!(
+        envelope_bodies(&records),
+        vec![b"follow-1".to_vec(), b"follow-2".to_vec()]
+    );
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_follow_mode_with_bytes_limit_truncates_live_batch() {
     let (backend, basin_name, stream_name) = setup_backend_with_stream(
         "follow-bytes-limit",

--- a/lite/tests/backend/data_plane/read_follow.rs
+++ b/lite/tests/backend/data_plane/read_follow.rs
@@ -77,19 +77,29 @@ async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &
     });
 
     let probe_step = Duration::from_millis(1);
-    let started = tokio::time::Instant::now();
-    let outputs = collect_outputs_until_closed_advanced(
-        &mut session,
-        wait_duration + first_follow_delay + second_follow_delay + Duration::from_secs(1),
-        probe_step,
-    )
-    .await;
-    let closed_at = outputs.closed_at;
+    let deadline = tokio::time::Instant::now()
+        + wait_duration
+        + first_follow_delay
+        + second_follow_delay
+        + Duration::from_secs(1);
+    let mut outputs = Vec::new();
+    let mut final_delivery_at = None;
+    let closed_at = loop {
+        match poll_session_with_deadline(&mut session, deadline, Some(probe_step)).await {
+            SessionPoll::Output(output) => {
+                if matches!(output, StoredReadSessionOutput::Batch(_)) {
+                    final_delivery_at = Some(tokio::time::Instant::now());
+                }
+                outputs.push(output);
+            }
+            SessionPoll::Closed => break tokio::time::Instant::now(),
+            SessionPoll::TimedOut => panic!("Timed out waiting for read session to close"),
+        }
+    };
 
     append_handle.await.unwrap();
 
     let all_records = outputs
-        .outputs
         .into_iter()
         .filter_map(|output| match output {
             StoredReadSessionOutput::Batch(batch) => Some(batch),
@@ -110,10 +120,10 @@ async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &
             b"follow-2".to_vec()
         ]
     );
-    let final_delivery_at = started + first_follow_delay + second_follow_delay;
-    let close_jitter = Duration::from_millis(20);
+    let final_delivery_at =
+        final_delivery_at.expect("read session should deliver the initial and follow batches");
     assert!(closed_at >= final_delivery_at + wait_duration);
-    assert!(closed_at <= final_delivery_at + wait_duration + close_jitter);
+    assert!(closed_at <= final_delivery_at + wait_duration + probe_step);
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]


### PR DESCRIPTION
- consolidate shared backend test helpers for session setup, virtual-time polling, and timestamped appends
- replace repetitive low-signal read cases with focused table-driven coverage for tail, count, byte, and timestamp boundaries
- make follow-mode timing assertions deterministic under paused time while preserving coverage for lag catchup and wait-reset behavior
- keep coverage around encryption, fencing, auto-create, and append session flows while reducing boilerplate
