### PR TITLE
refactor: clarify encryption spec, mode, and format semantics

### DIFF
--- a/api/src/v1/stream/extract.rs
+++ b/api/src/v1/stream/extract.rs
@@ -6,7 +6,7 @@ use axum::{
 use futures::StreamExt as _;
 use http::{StatusCode, request::Parts};
 use s2_common::{
-    encryption::EncryptionConfig,
+    encryption::EncryptionSpec,
     http::{ParseableHeader, extract::HeaderRejection},
     types,
 };
@@ -52,7 +52,7 @@ where
 
     async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
         let content_type = crate::mime::content_type(req.headers());
-        let encryption = parse_header_opt::<EncryptionConfig>(req.headers())?.unwrap_or_default();
+        let encryption = parse_header_opt::<EncryptionSpec>(req.headers())?.unwrap_or_default();
 
         if content_type.as_ref().is_some_and(crate::mime::is_s2s_proto) {
             let response_compression =
@@ -130,7 +130,7 @@ where
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         let content_type = crate::mime::content_type(&parts.headers);
-        let encryption = parse_header_opt::<EncryptionConfig>(&parts.headers)?.unwrap_or_default();
+        let encryption = parse_header_opt::<EncryptionSpec>(&parts.headers)?.unwrap_or_default();
 
         if content_type.as_ref().is_some_and(crate::mime::is_s2s_proto) {
             let response_compression =

--- a/api/src/v1/stream/mod.rs
+++ b/api/src/v1/stream/mod.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use futures::stream::BoxStream;
 use itertools::Itertools as _;
 use s2_common::{
-    encryption::EncryptionConfig,
+    encryption::EncryptionSpec,
     record,
     types::{
         self,
@@ -212,19 +212,19 @@ impl From<ReadEnd> for types::stream::ReadEnd {
 pub enum ReadRequest {
     /// Unary
     Unary {
-        encryption: EncryptionConfig,
+        encryption: EncryptionSpec,
         format: Format,
         response_mime: JsonOrProto,
     },
     /// Server-Sent Events streaming response
     EventStream {
-        encryption: EncryptionConfig,
+        encryption: EncryptionSpec,
         format: Format,
         last_event_id: Option<sse::LastEventId>,
     },
     /// S2S streaming response
     S2s {
-        encryption: EncryptionConfig,
+        encryption: EncryptionSpec,
         response_compression: s2s::CompressionAlgorithm,
     },
 }
@@ -232,13 +232,13 @@ pub enum ReadRequest {
 pub enum AppendRequest {
     /// Unary
     Unary {
-        encryption: EncryptionConfig,
+        encryption: EncryptionSpec,
         input: types::stream::AppendInput,
         response_mime: JsonOrProto,
     },
     /// S2S bi-directional streaming
     S2s {
-        encryption: EncryptionConfig,
+        encryption: EncryptionSpec,
         inputs: BoxStream<'static, Result<types::stream::AppendInput, AppendInputStreamError>>,
         response_compression: s2s::CompressionAlgorithm,
     },

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -3,7 +3,7 @@ use std::{num::NonZeroU64, path::PathBuf};
 use clap::{Args, Parser, Subcommand, builder::styling};
 use s2_sdk::types::{
     AccessTokenId, AccessTokenIdPrefix, AccessTokenIdStartAfter, BasinNamePrefix,
-    BasinNameStartAfter, EncryptionConfig, FencingToken, StreamNamePrefix, StreamNameStartAfter,
+    BasinNameStartAfter, EncryptionSpec, FencingToken, StreamNamePrefix, StreamNameStartAfter,
 };
 
 use crate::{
@@ -480,7 +480,7 @@ pub struct EncryptionArgs {
         value_name = "SPEC",
         group = "encryption_source"
     )]
-    pub encryption: Option<EncryptionConfig>,
+    pub encryption: Option<EncryptionSpec>,
 
     /// Read an encryption spec from file.
     #[arg(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -33,7 +33,7 @@ use s2_sdk::{
     S2,
     types::{
         AppendRetryPolicy, CreateStreamInput, DeleteOnEmptyConfig, DeleteStreamInput,
-        EncryptionConfig, MeteredBytes, Metric, RetentionPolicy, RetryConfig,
+        EncryptionSpec, MeteredBytes, Metric, RetentionPolicy, RetryConfig,
         StreamConfig as SdkStreamConfig, StreamName, TimestampingConfig, TimestampingMode,
     },
 };
@@ -801,14 +801,14 @@ fn print_metrics(metrics: &[Metric]) {
     }
 }
 
-fn resolve_encryption(args: &cli::EncryptionArgs) -> Result<Option<EncryptionConfig>, CliError> {
+fn resolve_encryption(args: &cli::EncryptionArgs) -> Result<Option<EncryptionSpec>, CliError> {
     match (&args.encryption, &args.encryption_file) {
         (Some(config), _) => Ok(Some(config.clone())),
         (_, Some(path)) => {
             let contents = std::fs::read_to_string(path).map_err(|e| {
                 CliError::InvalidArgs(miette::miette!("cannot read encryption spec file: {e}"))
             })?;
-            Ok(Some(contents.trim().parse::<EncryptionConfig>().map_err(
+            Ok(Some(contents.trim().parse::<EncryptionSpec>().map_err(
                 |e| CliError::InvalidArgs(miette::miette!("{e}")),
             )?))
         }

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -9,7 +9,7 @@ use s2_sdk::{
         AccessTokenId, AccessTokenInfo, AccessTokenScopeInput, AccountMetricSet, AppendAck,
         AppendInput, AppendRecord, AppendRecordBatch, BasinInfo, BasinMetricSet, BasinName,
         BasinReconfiguration, CommandRecord, CreateBasinInput, CreateStreamInput, DeleteBasinInput,
-        DeleteStreamInput, EncryptionConfig, FencingToken, GetAccountMetricsInput,
+        DeleteStreamInput, EncryptionSpec, FencingToken, GetAccountMetricsInput,
         GetBasinMetricsInput, GetStreamMetricsInput, IssueAccessTokenInput, ListAccessTokensInput,
         ListAllAccessTokensInput, ListAllBasinsInput, ListAllStreamsInput, ListBasinsInput,
         ListStreamsInput, MeteredBytes, Metric, ReadBatch, ReadFrom, ReadInput, ReadLimits,
@@ -22,7 +22,7 @@ use s2_sdk::{
 fn stream_with_encryption(
     s2: &S2,
     uri: S2BasinAndStreamUri,
-    encryption: Option<&EncryptionConfig>,
+    encryption: Option<&EncryptionSpec>,
 ) -> S2Stream {
     let stream = s2.basin(uri.basin).stream(uri.stream);
     match encryption {
@@ -439,7 +439,7 @@ pub async fn fence(s2: &S2, args: FenceArgs) -> Result<AppendAck, CliError> {
 pub async fn read(
     s2: &S2,
     args: &ReadArgs,
-    encryption: Option<&EncryptionConfig>,
+    encryption: Option<&EncryptionSpec>,
 ) -> Result<Streaming<ReadBatch>, CliError> {
     use std::time::SystemTime;
 
@@ -488,7 +488,7 @@ pub fn append<'a, S, E>(
     s2: &'a S2,
     records: S,
     uri: S2BasinAndStreamUri,
-    encryption: Option<&'a EncryptionConfig>,
+    encryption: Option<&'a EncryptionSpec>,
     fencing_token: Option<FencingToken>,
     match_seq_num: Option<u64>,
     linger: Duration,
@@ -586,7 +586,7 @@ where
 pub async fn tail(
     s2: &S2,
     args: &TailArgs,
-    encryption: Option<&EncryptionConfig>,
+    encryption: Option<&EncryptionSpec>,
 ) -> Result<Pin<Box<dyn Stream<Item = Result<SequencedRecord, CliError>> + Send>>, CliError> {
     let stream = stream_with_encryption(s2, args.uri.clone(), encryption);
 

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -1,4 +1,4 @@
-//! Encryption configuration, header parsing, and key parsing.
+//! Encryption spec parsing, header parsing, and key parsing.
 
 use core::str::FromStr;
 use std::sync::Arc;
@@ -34,7 +34,7 @@ impl Aegis256Key {
         Self(Arc::new(SecretBox::new(Box::new(key))))
     }
 
-    pub fn from_base64(key_b64: &str) -> Result<Self, EncryptionConfigError> {
+    pub fn from_base64(key_b64: &str) -> Result<Self, EncryptionSpecError> {
         parse_encryption_key::<32>(key_b64).map(Self)
     }
 
@@ -51,7 +51,7 @@ impl Aes256GcmKey {
         Self(Arc::new(SecretBox::new(Box::new(key))))
     }
 
-    pub fn from_base64(key_b64: &str) -> Result<Self, EncryptionConfigError> {
+    pub fn from_base64(key_b64: &str) -> Result<Self, EncryptionSpecError> {
         parse_encryption_key::<32>(key_b64).map(Self)
     }
 
@@ -61,20 +61,20 @@ impl Aes256GcmKey {
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
-pub enum EncryptionConfigError {
-    #[error("Invalid encryption config: {0}")]
+pub enum EncryptionSpecError {
+    #[error("Invalid encryption spec: {0}")]
     InvalidConfig(String),
 }
 
 #[derive(Debug, Clone, Default)]
-pub enum EncryptionConfig {
+pub enum EncryptionSpec {
     #[default]
     Plain,
     Aegis256(Aegis256Key),
     Aes256Gcm(Aes256GcmKey),
 }
 
-impl EncryptionConfig {
+impl EncryptionSpec {
     pub fn aegis256(key: [u8; 32]) -> Self {
         Self::Aegis256(Aegis256Key::new(key))
     }
@@ -98,8 +98,8 @@ impl EncryptionConfig {
     }
 }
 
-impl FromStr for EncryptionConfig {
-    type Err = EncryptionConfigError;
+impl FromStr for EncryptionSpec {
+    type Err = EncryptionSpecError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.trim();
@@ -107,13 +107,13 @@ impl FromStr for EncryptionConfig {
         let alg_str = parts.next().unwrap_or_default().trim();
         let key_b64 = parts.next().map(str::trim);
         if parts.next().is_some() {
-            return Err(EncryptionConfigError::InvalidConfig(
+            return Err(EncryptionSpecError::InvalidConfig(
                 "expected '<alg>; <key>' or 'plain'".to_owned(),
             ));
         }
 
         if alg_str.is_empty() {
-            return Err(EncryptionConfigError::InvalidConfig(
+            return Err(EncryptionSpecError::InvalidConfig(
                 "missing algorithm".to_owned(),
             ));
         }
@@ -121,26 +121,26 @@ impl FromStr for EncryptionConfig {
         let key_b64 = key_b64.filter(|key| !key.is_empty());
         match (parse_algorithm(alg_str)?, key_b64) {
             (None, None) => Ok(Self::Plain),
-            (None, Some(_)) => Err(EncryptionConfigError::InvalidConfig(
+            (None, Some(_)) => Err(EncryptionSpecError::InvalidConfig(
                 "key is not allowed when algorithm is 'plain'".to_owned(),
             )),
             (Some(EncryptionAlgorithm::Aegis256), Some(key_b64)) => {
                 Ok(Self::Aegis256(Aegis256Key::from_base64(key_b64)?))
             }
-            (Some(EncryptionAlgorithm::Aegis256), None) => Err(
-                EncryptionConfigError::InvalidConfig("missing key for 'aegis-256'".to_owned()),
-            ),
+            (Some(EncryptionAlgorithm::Aegis256), None) => Err(EncryptionSpecError::InvalidConfig(
+                "missing key for 'aegis-256'".to_owned(),
+            )),
             (Some(EncryptionAlgorithm::Aes256Gcm), Some(key_b64)) => {
                 Ok(Self::Aes256Gcm(Aes256GcmKey::from_base64(key_b64)?))
             }
             (Some(EncryptionAlgorithm::Aes256Gcm), None) => Err(
-                EncryptionConfigError::InvalidConfig("missing key for 'aes-256-gcm'".to_owned()),
+                EncryptionSpecError::InvalidConfig("missing key for 'aes-256-gcm'".to_owned()),
             ),
         }
     }
 }
 
-impl ParseableHeader for EncryptionConfig {
+impl ParseableHeader for EncryptionSpec {
     fn name() -> &'static HeaderName {
         &S2_ENCRYPTION_HEADER
     }
@@ -148,7 +148,7 @@ impl ParseableHeader for EncryptionConfig {
 
 fn parse_encryption_key<const N: usize>(
     key_b64: &str,
-) -> Result<EncryptionKey<N>, EncryptionConfigError> {
+) -> Result<EncryptionKey<N>, EncryptionSpecError> {
     use base64ct::{Base64, Encoding};
     use secrecy::zeroize::Zeroize;
 
@@ -157,7 +157,7 @@ fn parse_encryption_key<const N: usize>(
         Ok(decoded) => decoded,
         Err(e) => {
             key.as_mut().zeroize();
-            return Err(EncryptionConfigError::InvalidConfig(format!(
+            return Err(EncryptionSpecError::InvalidConfig(format!(
                 "key is not valid base64: {e}"
             )));
         }
@@ -166,7 +166,7 @@ fn parse_encryption_key<const N: usize>(
     if decoded.len() != N {
         let len = decoded.len();
         key.as_mut().zeroize();
-        return Err(EncryptionConfigError::InvalidConfig(format!(
+        return Err(EncryptionSpecError::InvalidConfig(format!(
             "key must be exactly {N} bytes, got {len} bytes"
         )));
     }
@@ -186,7 +186,7 @@ fn header_value_for_key(algorithm: EncryptionAlgorithm, key: &[u8; 32]) -> Heade
     HeaderValue::from_bytes(&value).expect("encryption header value should be ASCII")
 }
 
-fn parse_algorithm(alg_str: &str) -> Result<Option<EncryptionAlgorithm>, EncryptionConfigError> {
+fn parse_algorithm(alg_str: &str) -> Result<Option<EncryptionAlgorithm>, EncryptionSpecError> {
     if alg_str.eq_ignore_ascii_case("plain") {
         Ok(None)
     } else {
@@ -194,7 +194,7 @@ fn parse_algorithm(alg_str: &str) -> Result<Option<EncryptionAlgorithm>, Encrypt
             .parse::<EncryptionAlgorithm>()
             .map(Some)
             .map_err(|_| {
-                EncryptionConfigError::InvalidConfig(format!(
+                EncryptionSpecError::InvalidConfig(format!(
                     "unknown algorithm {alg_str:?}; expected 'plain', 'aegis-256', or 'aes-256-gcm'"
                 ))
             })
@@ -215,29 +215,29 @@ mod tests {
     ];
 
     fn assert_encrypted_config(
-        config: EncryptionConfig,
+        config: EncryptionSpec,
         algorithm: EncryptionAlgorithm,
         expected: &[u8; 32],
     ) {
         match (algorithm, config) {
-            (EncryptionAlgorithm::Aegis256, EncryptionConfig::Aegis256(key)) => {
+            (EncryptionAlgorithm::Aegis256, EncryptionSpec::Aegis256(key)) => {
                 assert_eq!(key.secret(), expected)
             }
-            (EncryptionAlgorithm::Aes256Gcm, EncryptionConfig::Aes256Gcm(key)) => {
+            (EncryptionAlgorithm::Aes256Gcm, EncryptionSpec::Aes256Gcm(key)) => {
                 assert_eq!(key.secret(), expected)
             }
-            (_, EncryptionConfig::Plain) => panic!("expected encrypted config"),
-            (expected_algorithm, actual_config) => {
-                panic!("expected {expected_algorithm:?}, got {actual_config:?}")
+            (_, EncryptionSpec::Plain) => panic!("expected encrypted spec"),
+            (expected_algorithm, actual_spec) => {
+                panic!("expected {expected_algorithm:?}, got {actual_spec:?}")
             }
         }
     }
 
     fn assert_invalid_parse(header: &str) {
-        let result = header.parse::<EncryptionConfig>();
+        let result = header.parse::<EncryptionSpec>();
         assert!(
-            matches!(result, Err(EncryptionConfigError::InvalidConfig(_))),
-            "expected invalid config for {header:?}, got {result:?}"
+            matches!(result, Err(EncryptionSpecError::InvalidConfig(_))),
+            "expected invalid spec for {header:?}, got {result:?}"
         );
     }
 
@@ -251,7 +251,7 @@ mod tests {
         #[case] expected: EncryptionAlgorithm,
     ) {
         let config = format!("{algorithm}; {KEY_B64}")
-            .parse::<EncryptionConfig>()
+            .parse::<EncryptionSpec>()
             .unwrap();
         assert_encrypted_config(config, expected, &KEY_BYTES);
     }
@@ -259,7 +259,7 @@ mod tests {
     #[test]
     fn parse_header_aes_with_whitespace() {
         let config = format!(" aes-256-gcm ; {KEY_B64} ")
-            .parse::<EncryptionConfig>()
+            .parse::<EncryptionSpec>()
             .unwrap();
         assert_encrypted_config(config, EncryptionAlgorithm::Aes256Gcm, &KEY_BYTES);
     }
@@ -269,8 +269,8 @@ mod tests {
     #[case("PLAIN")]
     #[case("plain; ")]
     fn parse_header_plain_variants(#[case] header: &str) {
-        let config = header.parse::<EncryptionConfig>().unwrap();
-        assert!(matches!(config, EncryptionConfig::Plain));
+        let config = header.parse::<EncryptionSpec>().unwrap();
+        assert!(matches!(config, EncryptionSpec::Plain));
     }
 
     #[rstest]
@@ -287,19 +287,19 @@ mod tests {
 
     #[test]
     fn header_value_is_sensitive() {
-        let value = EncryptionConfig::aegis256([7; 32]).to_header_value();
+        let value = EncryptionSpec::aegis256([7; 32]).to_header_value();
         assert!(value.is_sensitive());
         assert_ne!(value, HeaderValue::from_static("plain"));
     }
 
     #[test]
     fn plain_header_value_roundtrips() {
-        let value = EncryptionConfig::Plain.to_header_value();
+        let value = EncryptionSpec::Plain.to_header_value();
         assert_eq!(value.to_str().unwrap(), "plain");
         assert!(value.is_sensitive());
 
-        let parsed = value.to_str().unwrap().parse::<EncryptionConfig>().unwrap();
-        assert!(matches!(parsed, EncryptionConfig::Plain));
+        let parsed = value.to_str().unwrap().parse::<EncryptionSpec>().unwrap();
+        assert!(matches!(parsed, EncryptionSpec::Plain));
     }
 
     #[rstest]
@@ -307,14 +307,14 @@ mod tests {
     #[case(EncryptionAlgorithm::Aes256Gcm)]
     fn encrypted_header_value_roundtrips(#[case] algorithm: EncryptionAlgorithm) {
         let value = match algorithm {
-            EncryptionAlgorithm::Aegis256 => EncryptionConfig::aegis256(KEY_BYTES),
-            EncryptionAlgorithm::Aes256Gcm => EncryptionConfig::aes256_gcm(KEY_BYTES),
+            EncryptionAlgorithm::Aegis256 => EncryptionSpec::aegis256(KEY_BYTES),
+            EncryptionAlgorithm::Aes256Gcm => EncryptionSpec::aes256_gcm(KEY_BYTES),
         }
         .to_header_value();
         assert_eq!(value.to_str().unwrap(), format!("{algorithm}; {KEY_B64}"));
         assert!(value.is_sensitive());
 
-        let parsed = value.to_str().unwrap().parse::<EncryptionConfig>().unwrap();
+        let parsed = value.to_str().unwrap().parse::<EncryptionSpec>().unwrap();
         assert_encrypted_config(parsed, algorithm, &KEY_BYTES);
     }
 }

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -26,6 +26,27 @@ pub enum EncryptionAlgorithm {
     Aes256Gcm,
 }
 
+/// Encryption mode, including plaintext.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Display, EnumString)]
+#[strum(ascii_case_insensitive)]
+pub enum EncryptionMode {
+    #[strum(serialize = "plain")]
+    Plain,
+    #[strum(serialize = "aegis-256")]
+    Aegis256,
+    #[strum(serialize = "aes-256-gcm")]
+    Aes256Gcm,
+}
+
+impl From<EncryptionAlgorithm> for EncryptionMode {
+    fn from(value: EncryptionAlgorithm) -> Self {
+        match value {
+            EncryptionAlgorithm::Aegis256 => Self::Aegis256,
+            EncryptionAlgorithm::Aes256Gcm => Self::Aes256Gcm,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Aegis256Key(EncryptionKey<32>);
 
@@ -83,6 +104,14 @@ impl EncryptionSpec {
         Self::Aes256Gcm(Aes256GcmKey::new(key))
     }
 
+    pub fn mode(&self) -> EncryptionMode {
+        match self {
+            Self::Plain => EncryptionMode::Plain,
+            Self::Aegis256(_) => EncryptionMode::Aegis256,
+            Self::Aes256Gcm(_) => EncryptionMode::Aes256Gcm,
+        }
+    }
+
     pub fn to_header_value(&self) -> HeaderValue {
         let mut value = match self {
             Self::Plain => HeaderValue::from_static("plain"),
@@ -119,23 +148,23 @@ impl FromStr for EncryptionSpec {
         }
 
         let key_b64 = key_b64.filter(|key| !key.is_empty());
-        match (parse_algorithm(alg_str)?, key_b64) {
-            (None, None) => Ok(Self::Plain),
-            (None, Some(_)) => Err(EncryptionSpecError::InvalidConfig(
+        match (parse_mode(alg_str)?, key_b64) {
+            (EncryptionMode::Plain, None) => Ok(Self::Plain),
+            (EncryptionMode::Plain, Some(_)) => Err(EncryptionSpecError::InvalidConfig(
                 "key is not allowed when algorithm is 'plain'".to_owned(),
             )),
-            (Some(EncryptionAlgorithm::Aegis256), Some(key_b64)) => {
+            (EncryptionMode::Aegis256, Some(key_b64)) => {
                 Ok(Self::Aegis256(Aegis256Key::from_base64(key_b64)?))
             }
-            (Some(EncryptionAlgorithm::Aegis256), None) => Err(EncryptionSpecError::InvalidConfig(
+            (EncryptionMode::Aegis256, None) => Err(EncryptionSpecError::InvalidConfig(
                 "missing key for 'aegis-256'".to_owned(),
             )),
-            (Some(EncryptionAlgorithm::Aes256Gcm), Some(key_b64)) => {
+            (EncryptionMode::Aes256Gcm, Some(key_b64)) => {
                 Ok(Self::Aes256Gcm(Aes256GcmKey::from_base64(key_b64)?))
             }
-            (Some(EncryptionAlgorithm::Aes256Gcm), None) => Err(
-                EncryptionSpecError::InvalidConfig("missing key for 'aes-256-gcm'".to_owned()),
-            ),
+            (EncryptionMode::Aes256Gcm, None) => Err(EncryptionSpecError::InvalidConfig(
+                "missing key for 'aes-256-gcm'".to_owned(),
+            )),
         }
     }
 }
@@ -186,19 +215,12 @@ fn header_value_for_key(algorithm: EncryptionAlgorithm, key: &[u8; 32]) -> Heade
     HeaderValue::from_bytes(&value).expect("encryption header value should be ASCII")
 }
 
-fn parse_algorithm(alg_str: &str) -> Result<Option<EncryptionAlgorithm>, EncryptionSpecError> {
-    if alg_str.eq_ignore_ascii_case("plain") {
-        Ok(None)
-    } else {
-        alg_str
-            .parse::<EncryptionAlgorithm>()
-            .map(Some)
-            .map_err(|_| {
-                EncryptionSpecError::InvalidConfig(format!(
-                    "unknown algorithm {alg_str:?}; expected 'plain', 'aegis-256', or 'aes-256-gcm'"
-                ))
-            })
-    }
+fn parse_mode(mode_str: &str) -> Result<EncryptionMode, EncryptionSpecError> {
+    mode_str.parse::<EncryptionMode>().map_err(|_| {
+        EncryptionSpecError::InvalidConfig(format!(
+            "unknown encryption mode {mode_str:?}; expected 'plain', 'aegis-256', or 'aes-256-gcm'"
+        ))
+    })
 }
 
 #[cfg(test)]
@@ -271,6 +293,19 @@ mod tests {
     fn parse_header_plain_variants(#[case] header: &str) {
         let config = header.parse::<EncryptionSpec>().unwrap();
         assert!(matches!(config, EncryptionSpec::Plain));
+    }
+
+    #[test]
+    fn spec_mode_matches_variant() {
+        assert_eq!(EncryptionSpec::Plain.mode(), EncryptionMode::Plain);
+        assert_eq!(
+            EncryptionSpec::aegis256(KEY_BYTES).mode(),
+            EncryptionMode::Aegis256
+        );
+        assert_eq!(
+            EncryptionSpec::aes256_gcm(KEY_BYTES).mode(),
+            EncryptionMode::Aes256Gcm
+        );
     }
 
     #[rstest]

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -91,8 +91,8 @@ pub enum EncryptionSpecError {
         "Invalid encryption spec: unknown encryption mode {mode:?}; expected 'plain', 'aegis-256', or 'aes-256-gcm'"
     )]
     UnknownMode { mode: String },
-    #[error("Invalid encryption spec: key is not allowed when mode is '{mode}'")]
-    UnexpectedKey { mode: EncryptionMode },
+    #[error("Invalid encryption spec: key is not allowed when mode is 'plain'")]
+    UnexpectedKeyForPlain,
     #[error("Invalid encryption spec: missing key for '{mode}'")]
     MissingKey { mode: EncryptionMode },
     #[error("Invalid encryption spec: key is not valid base64")]
@@ -160,9 +160,7 @@ impl FromStr for EncryptionSpec {
         let key_b64 = key_b64.filter(|key| !key.is_empty());
         match (parse_mode(alg_str)?, key_b64) {
             (EncryptionMode::Plain, None) => Ok(Self::Plain),
-            (EncryptionMode::Plain, Some(_)) => Err(EncryptionSpecError::UnexpectedKey {
-                mode: EncryptionMode::Plain,
-            }),
+            (EncryptionMode::Plain, Some(_)) => Err(EncryptionSpecError::UnexpectedKeyForPlain),
             (EncryptionMode::Aegis256, Some(key_b64)) => {
                 Ok(Self::Aegis256(Aegis256Key::from_base64(key_b64)?))
             }
@@ -348,9 +346,7 @@ mod tests {
     )]
     #[case(
         "plain; AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=",
-        EncryptionSpecError::UnexpectedKey {
-            mode: EncryptionMode::Plain
-        }
+        EncryptionSpecError::UnexpectedKeyForPlain
     )]
     fn parse_header_invalid_cases(#[case] header: &str, #[case] expected: EncryptionSpecError) {
         assert_invalid_parse(header, expected);

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -83,7 +83,7 @@ impl Aes256GcmKey {
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum EncryptionSpecError {
-    #[error("Invalid encryption spec: expected '<alg>; <key>' or 'plain'")]
+    #[error("Invalid encryption spec: expected '<mode>; <key>' or 'plain'")]
     InvalidSyntax,
     #[error("Invalid encryption spec: missing encryption mode")]
     MissingMode,
@@ -147,18 +147,18 @@ impl FromStr for EncryptionSpec {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.trim();
         let mut parts = s.splitn(3, ';');
-        let alg_str = parts.next().unwrap_or_default().trim();
+        let mode_str = parts.next().unwrap_or_default().trim();
         let key_b64 = parts.next().map(str::trim);
         if parts.next().is_some() {
             return Err(EncryptionSpecError::InvalidSyntax);
         }
 
-        if alg_str.is_empty() {
+        if mode_str.is_empty() {
             return Err(EncryptionSpecError::MissingMode);
         }
 
         let key_b64 = key_b64.filter(|key| !key.is_empty());
-        match (parse_mode(alg_str)?, key_b64) {
+        match (parse_mode(mode_str)?, key_b64) {
             (EncryptionMode::Plain, None) => Ok(Self::Plain),
             (EncryptionMode::Plain, Some(_)) => Err(EncryptionSpecError::UnexpectedKeyForPlain),
             (EncryptionMode::Aegis256, Some(key_b64)) => {
@@ -243,12 +243,12 @@ mod tests {
         26, 27, 28, 29, 30, 31, 32,
     ];
 
-    fn assert_encrypted_config(
-        config: EncryptionSpec,
+    fn assert_encrypted_spec(
+        spec: EncryptionSpec,
         algorithm: EncryptionAlgorithm,
         expected: &[u8; 32],
     ) {
-        match (algorithm, config) {
+        match (algorithm, spec) {
             (EncryptionAlgorithm::Aegis256, EncryptionSpec::Aegis256(key)) => {
                 assert_eq!(key.secret(), expected)
             }
@@ -279,18 +279,18 @@ mod tests {
         #[case] algorithm: &str,
         #[case] expected: EncryptionAlgorithm,
     ) {
-        let config = format!("{algorithm}; {KEY_B64}")
+        let spec = format!("{algorithm}; {KEY_B64}")
             .parse::<EncryptionSpec>()
             .unwrap();
-        assert_encrypted_config(config, expected, &KEY_BYTES);
+        assert_encrypted_spec(spec, expected, &KEY_BYTES);
     }
 
     #[test]
     fn parse_header_aes_with_whitespace() {
-        let config = format!(" aes-256-gcm ; {KEY_B64} ")
+        let spec = format!(" aes-256-gcm ; {KEY_B64} ")
             .parse::<EncryptionSpec>()
             .unwrap();
-        assert_encrypted_config(config, EncryptionAlgorithm::Aes256Gcm, &KEY_BYTES);
+        assert_encrypted_spec(spec, EncryptionAlgorithm::Aes256Gcm, &KEY_BYTES);
     }
 
     #[rstest]
@@ -298,8 +298,8 @@ mod tests {
     #[case("PLAIN")]
     #[case("plain; ")]
     fn parse_header_plain_variants(#[case] header: &str) {
-        let config = header.parse::<EncryptionSpec>().unwrap();
-        assert!(matches!(config, EncryptionSpec::Plain));
+        let spec = header.parse::<EncryptionSpec>().unwrap();
+        assert!(matches!(spec, EncryptionSpec::Plain));
     }
 
     #[test]
@@ -382,6 +382,6 @@ mod tests {
         assert!(value.is_sensitive());
 
         let parsed = value.to_str().unwrap().parse::<EncryptionSpec>().unwrap();
-        assert_encrypted_config(parsed, algorithm, &KEY_BYTES);
+        assert_encrypted_spec(parsed, algorithm, &KEY_BYTES);
     }
 }

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -81,10 +81,24 @@ impl Aes256GcmKey {
     }
 }
 
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum EncryptionSpecError {
-    #[error("Invalid encryption spec: {0}")]
-    InvalidSpec(String),
+    #[error("Invalid encryption spec: expected '<alg>; <key>' or 'plain'")]
+    InvalidSyntax,
+    #[error("Invalid encryption spec: missing encryption mode")]
+    MissingMode,
+    #[error(
+        "Invalid encryption spec: unknown encryption mode {mode:?}; expected 'plain', 'aegis-256', or 'aes-256-gcm'"
+    )]
+    UnknownMode { mode: String },
+    #[error("Invalid encryption spec: key is not allowed when mode is '{mode}'")]
+    UnexpectedKey { mode: EncryptionMode },
+    #[error("Invalid encryption spec: missing key for '{mode}'")]
+    MissingKey { mode: EncryptionMode },
+    #[error("Invalid encryption spec: key is not valid base64")]
+    InvalidKeyBase64,
+    #[error("Invalid encryption spec: key must be exactly {expected} bytes, got {actual} bytes")]
+    InvalidKeyLength { expected: usize, actual: usize },
 }
 
 #[derive(Debug, Clone, Default)]
@@ -136,35 +150,31 @@ impl FromStr for EncryptionSpec {
         let alg_str = parts.next().unwrap_or_default().trim();
         let key_b64 = parts.next().map(str::trim);
         if parts.next().is_some() {
-            return Err(EncryptionSpecError::InvalidSpec(
-                "expected '<alg>; <key>' or 'plain'".to_owned(),
-            ));
+            return Err(EncryptionSpecError::InvalidSyntax);
         }
 
         if alg_str.is_empty() {
-            return Err(EncryptionSpecError::InvalidSpec(
-                "missing algorithm".to_owned(),
-            ));
+            return Err(EncryptionSpecError::MissingMode);
         }
 
         let key_b64 = key_b64.filter(|key| !key.is_empty());
         match (parse_mode(alg_str)?, key_b64) {
             (EncryptionMode::Plain, None) => Ok(Self::Plain),
-            (EncryptionMode::Plain, Some(_)) => Err(EncryptionSpecError::InvalidSpec(
-                "key is not allowed when algorithm is 'plain'".to_owned(),
-            )),
+            (EncryptionMode::Plain, Some(_)) => Err(EncryptionSpecError::UnexpectedKey {
+                mode: EncryptionMode::Plain,
+            }),
             (EncryptionMode::Aegis256, Some(key_b64)) => {
                 Ok(Self::Aegis256(Aegis256Key::from_base64(key_b64)?))
             }
-            (EncryptionMode::Aegis256, None) => Err(EncryptionSpecError::InvalidSpec(
-                "missing key for 'aegis-256'".to_owned(),
-            )),
+            (EncryptionMode::Aegis256, None) => Err(EncryptionSpecError::MissingKey {
+                mode: EncryptionMode::Aegis256,
+            }),
             (EncryptionMode::Aes256Gcm, Some(key_b64)) => {
                 Ok(Self::Aes256Gcm(Aes256GcmKey::from_base64(key_b64)?))
             }
-            (EncryptionMode::Aes256Gcm, None) => Err(EncryptionSpecError::InvalidSpec(
-                "missing key for 'aes-256-gcm'".to_owned(),
-            )),
+            (EncryptionMode::Aes256Gcm, None) => Err(EncryptionSpecError::MissingKey {
+                mode: EncryptionMode::Aes256Gcm,
+            }),
         }
     }
 }
@@ -184,20 +194,19 @@ fn parse_encryption_key<const N: usize>(
     let mut key = Box::new([0u8; N]);
     let decoded = match Base64::decode(key_b64, key.as_mut()) {
         Ok(decoded) => decoded,
-        Err(e) => {
+        Err(_) => {
             key.as_mut().zeroize();
-            return Err(EncryptionSpecError::InvalidSpec(format!(
-                "key is not valid base64: {e}"
-            )));
+            return Err(EncryptionSpecError::InvalidKeyBase64);
         }
     };
 
     if decoded.len() != N {
         let len = decoded.len();
         key.as_mut().zeroize();
-        return Err(EncryptionSpecError::InvalidSpec(format!(
-            "key must be exactly {N} bytes, got {len} bytes"
-        )));
+        return Err(EncryptionSpecError::InvalidKeyLength {
+            expected: N,
+            actual: len,
+        });
     }
 
     Ok(Arc::new(SecretBox::new(key)))
@@ -216,11 +225,11 @@ fn header_value_for_key(algorithm: EncryptionAlgorithm, key: &[u8; 32]) -> Heade
 }
 
 fn parse_mode(mode_str: &str) -> Result<EncryptionMode, EncryptionSpecError> {
-    mode_str.parse::<EncryptionMode>().map_err(|_| {
-        EncryptionSpecError::InvalidSpec(format!(
-            "unknown encryption mode {mode_str:?}; expected 'plain', 'aegis-256', or 'aes-256-gcm'"
-        ))
-    })
+    mode_str
+        .parse::<EncryptionMode>()
+        .map_err(|_| EncryptionSpecError::UnknownMode {
+            mode: mode_str.to_owned(),
+        })
 }
 
 #[cfg(test)]
@@ -255,12 +264,12 @@ mod tests {
         }
     }
 
-    fn assert_invalid_parse(header: &str) {
+    fn assert_invalid_parse(header: &str, expected: EncryptionSpecError) {
         let result = header.parse::<EncryptionSpec>();
-        assert!(
-            matches!(result, Err(EncryptionSpecError::InvalidSpec(_))),
-            "expected invalid spec for {header:?}, got {result:?}"
-        );
+        match result {
+            Err(actual) => assert_eq!(actual, expected),
+            Ok(actual) => panic!("expected invalid spec for {header:?}, got {actual:?}"),
+        }
     }
 
     #[rstest]
@@ -309,15 +318,42 @@ mod tests {
     }
 
     #[rstest]
-    #[case("")]
-    #[case("aegis-256")]
-    #[case("aegis-256; AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=; extra")]
-    #[case("aegis-256; 3q2+7w==")]
-    #[case("aegis-256; not-valid-base64!!!")]
-    #[case("bogus; AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=")]
-    #[case("plain; AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=")]
-    fn parse_header_invalid_cases(#[case] header: &str) {
-        assert_invalid_parse(header);
+    #[case("", EncryptionSpecError::MissingMode)]
+    #[case(
+        "aegis-256",
+        EncryptionSpecError::MissingKey {
+            mode: EncryptionMode::Aegis256
+        }
+    )]
+    #[case(
+        "aegis-256; AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=; extra",
+        EncryptionSpecError::InvalidSyntax
+    )]
+    #[case(
+        "aegis-256; 3q2+7w==",
+        EncryptionSpecError::InvalidKeyLength {
+            expected: 32,
+            actual: 4
+        }
+    )]
+    #[case(
+        "aegis-256; not-valid-base64!!!",
+        EncryptionSpecError::InvalidKeyBase64
+    )]
+    #[case(
+        "bogus; AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=",
+        EncryptionSpecError::UnknownMode {
+            mode: "bogus".to_owned()
+        }
+    )]
+    #[case(
+        "plain; AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=",
+        EncryptionSpecError::UnexpectedKey {
+            mode: EncryptionMode::Plain
+        }
+    )]
+    fn parse_header_invalid_cases(#[case] header: &str, #[case] expected: EncryptionSpecError) {
+        assert_invalid_parse(header, expected);
     }
 
     #[test]

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -84,7 +84,7 @@ impl Aes256GcmKey {
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum EncryptionSpecError {
     #[error("Invalid encryption spec: {0}")]
-    InvalidConfig(String),
+    InvalidSpec(String),
 }
 
 #[derive(Debug, Clone, Default)]
@@ -136,13 +136,13 @@ impl FromStr for EncryptionSpec {
         let alg_str = parts.next().unwrap_or_default().trim();
         let key_b64 = parts.next().map(str::trim);
         if parts.next().is_some() {
-            return Err(EncryptionSpecError::InvalidConfig(
+            return Err(EncryptionSpecError::InvalidSpec(
                 "expected '<alg>; <key>' or 'plain'".to_owned(),
             ));
         }
 
         if alg_str.is_empty() {
-            return Err(EncryptionSpecError::InvalidConfig(
+            return Err(EncryptionSpecError::InvalidSpec(
                 "missing algorithm".to_owned(),
             ));
         }
@@ -150,19 +150,19 @@ impl FromStr for EncryptionSpec {
         let key_b64 = key_b64.filter(|key| !key.is_empty());
         match (parse_mode(alg_str)?, key_b64) {
             (EncryptionMode::Plain, None) => Ok(Self::Plain),
-            (EncryptionMode::Plain, Some(_)) => Err(EncryptionSpecError::InvalidConfig(
+            (EncryptionMode::Plain, Some(_)) => Err(EncryptionSpecError::InvalidSpec(
                 "key is not allowed when algorithm is 'plain'".to_owned(),
             )),
             (EncryptionMode::Aegis256, Some(key_b64)) => {
                 Ok(Self::Aegis256(Aegis256Key::from_base64(key_b64)?))
             }
-            (EncryptionMode::Aegis256, None) => Err(EncryptionSpecError::InvalidConfig(
+            (EncryptionMode::Aegis256, None) => Err(EncryptionSpecError::InvalidSpec(
                 "missing key for 'aegis-256'".to_owned(),
             )),
             (EncryptionMode::Aes256Gcm, Some(key_b64)) => {
                 Ok(Self::Aes256Gcm(Aes256GcmKey::from_base64(key_b64)?))
             }
-            (EncryptionMode::Aes256Gcm, None) => Err(EncryptionSpecError::InvalidConfig(
+            (EncryptionMode::Aes256Gcm, None) => Err(EncryptionSpecError::InvalidSpec(
                 "missing key for 'aes-256-gcm'".to_owned(),
             )),
         }
@@ -186,7 +186,7 @@ fn parse_encryption_key<const N: usize>(
         Ok(decoded) => decoded,
         Err(e) => {
             key.as_mut().zeroize();
-            return Err(EncryptionSpecError::InvalidConfig(format!(
+            return Err(EncryptionSpecError::InvalidSpec(format!(
                 "key is not valid base64: {e}"
             )));
         }
@@ -195,7 +195,7 @@ fn parse_encryption_key<const N: usize>(
     if decoded.len() != N {
         let len = decoded.len();
         key.as_mut().zeroize();
-        return Err(EncryptionSpecError::InvalidConfig(format!(
+        return Err(EncryptionSpecError::InvalidSpec(format!(
             "key must be exactly {N} bytes, got {len} bytes"
         )));
     }
@@ -217,7 +217,7 @@ fn header_value_for_key(algorithm: EncryptionAlgorithm, key: &[u8; 32]) -> Heade
 
 fn parse_mode(mode_str: &str) -> Result<EncryptionMode, EncryptionSpecError> {
     mode_str.parse::<EncryptionMode>().map_err(|_| {
-        EncryptionSpecError::InvalidConfig(format!(
+        EncryptionSpecError::InvalidSpec(format!(
             "unknown encryption mode {mode_str:?}; expected 'plain', 'aegis-256', or 'aes-256-gcm'"
         ))
     })
@@ -258,7 +258,7 @@ mod tests {
     fn assert_invalid_parse(header: &str) {
         let result = header.parse::<EncryptionSpec>();
         assert!(
-            matches!(result, Err(EncryptionSpecError::InvalidConfig(_))),
+            matches!(result, Err(EncryptionSpecError::InvalidSpec(_))),
             "expected invalid spec for {header:?}, got {result:?}"
         );
     }

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -52,6 +52,7 @@ pub(crate) enum EncryptedRecordFormat {
 }
 
 impl EncryptedRecordFormat {
+    /// Current write format for newly encrypted records with this algorithm.
     const fn current_for_algorithm(algorithm: EncryptionAlgorithm) -> Self {
         match algorithm {
             EncryptionAlgorithm::Aegis256 => Self::Aegis256V1,
@@ -306,6 +307,9 @@ fn decrypt_payload(
 ) -> Result<Bytes, RecordDecryptionError> {
     let format = record.format;
     let expected = encryption.mode();
+    let (mut encoded, payload_start, payload_end) = decryption_layout(record, format)?;
+    let plaintext_len = payload_end - payload_start;
+
     match format {
         EncryptedRecordFormat::Aegis256V1 => {
             let key = match encryption {
@@ -317,11 +321,6 @@ fn decrypt_payload(
                     });
                 }
             };
-            let payload_start = FORMAT_ID_LEN + format.nonce_len();
-            let tag_len = format.tag_len();
-            let mut encoded = record.into_mut_encoded();
-            let payload_end = payload_end(encoded.len(), payload_start, tag_len)?;
-            let plaintext_len = payload_end - payload_start;
             let nonce: [u8; 32] = encoded
                 .get(FORMAT_ID_LEN..payload_start)
                 .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?
@@ -353,11 +352,6 @@ fn decrypt_payload(
                     });
                 }
             };
-            let payload_start = FORMAT_ID_LEN + format.nonce_len();
-            let tag_len = format.tag_len();
-            let mut encoded = record.into_mut_encoded();
-            let payload_end = payload_end(encoded.len(), payload_start, tag_len)?;
-            let plaintext_len = payload_end - payload_start;
             let cipher = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key.secret()));
             let nonce = aes_gcm::Nonce::clone_from_slice(
                 encoded
@@ -380,6 +374,15 @@ fn decrypt_payload(
             Ok(encoded.freeze())
         }
     }
+}
+
+fn decryption_layout(
+    record: EncryptedRecord,
+    format: EncryptedRecordFormat,
+) -> Result<(BytesMut, usize, usize), RecordDecryptionError> {
+    let payload_start = FORMAT_ID_LEN + format.nonce_len();
+    let payload_end = payload_end(record.encoded.len(), payload_start, format.tag_len())?;
+    Ok((record.into_mut_encoded(), payload_start, payload_end))
 }
 
 fn payload_end(

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -35,7 +35,7 @@ use rand::random;
 use super::{Encodable, Metered, MeteredSize, Record, RecordDecodeError, StoredRecord};
 use crate::{
     deep_size::DeepSize,
-    encryption::{EncryptionAlgorithm, EncryptionConfig},
+    encryption::{EncryptionAlgorithm, EncryptionSpec},
     record::MeteredExt as _,
 };
 
@@ -175,19 +175,19 @@ impl Encodable for EncryptedRecord {
 
 pub fn encrypt_record(
     record: Metered<Record>,
-    encryption: &EncryptionConfig,
+    encryption: &EncryptionSpec,
     aad: &[u8],
 ) -> Metered<StoredRecord> {
     let metered_size = record.metered_size();
     let record = match (record.into_inner(), encryption) {
         (record @ Record::Command(_), _) => StoredRecord::Plaintext(record),
-        (record @ Record::Envelope(_), EncryptionConfig::Plain) => StoredRecord::Plaintext(record),
-        (Record::Envelope(envelope), EncryptionConfig::Aegis256(key)) => {
+        (record @ Record::Envelope(_), EncryptionSpec::Plain) => StoredRecord::Plaintext(record),
+        (Record::Envelope(envelope), EncryptionSpec::Aegis256(key)) => {
             let encrypted =
                 encrypt_payload(&envelope, EncryptionAlgorithm::Aegis256, key.secret(), aad);
             StoredRecord::encrypted(encrypted, metered_size)
         }
-        (Record::Envelope(envelope), EncryptionConfig::Aes256Gcm(key)) => {
+        (Record::Envelope(envelope), EncryptionSpec::Aes256Gcm(key)) => {
             let encrypted =
                 encrypt_payload(&envelope, EncryptionAlgorithm::Aes256Gcm, key.secret(), aad);
             StoredRecord::encrypted(encrypted, metered_size)
@@ -253,7 +253,7 @@ impl TryFrom<Bytes> for EncryptedRecord {
 
 pub fn decrypt_stored_record(
     record: StoredRecord,
-    encryption: &EncryptionConfig,
+    encryption: &EncryptionSpec,
     aad: &[u8],
 ) -> Result<Metered<Record>, RecordDecryptionError> {
     match record {
@@ -278,16 +278,16 @@ pub fn decrypt_stored_record(
 
 fn decrypt_payload(
     record: EncryptedRecord,
-    encryption: &EncryptionConfig,
+    encryption: &EncryptionSpec,
     aad: &[u8],
 ) -> Result<Bytes, RecordDecryptionError> {
     let algorithm = record.algorithm();
     match (encryption, algorithm) {
-        (EncryptionConfig::Plain, actual) => Err(RecordDecryptionError::AlgorithmMismatch {
+        (EncryptionSpec::Plain, actual) => Err(RecordDecryptionError::AlgorithmMismatch {
             expected: None,
             actual,
         }),
-        (EncryptionConfig::Aegis256(key), EncryptionAlgorithm::Aegis256) => {
+        (EncryptionSpec::Aegis256(key), EncryptionAlgorithm::Aegis256) => {
             let payload_start = SUITE_ID_LEN + algorithm.nonce_len();
             let tag_len = algorithm.tag_len();
             let mut encoded = record.into_mut_encoded();
@@ -314,7 +314,7 @@ fn decrypt_payload(
             encoded.truncate(plaintext_len);
             Ok(encoded.freeze())
         }
-        (EncryptionConfig::Aes256Gcm(key), EncryptionAlgorithm::Aes256Gcm) => {
+        (EncryptionSpec::Aes256Gcm(key), EncryptionAlgorithm::Aes256Gcm) => {
             let payload_start = SUITE_ID_LEN + algorithm.nonce_len();
             let tag_len = algorithm.tag_len();
             let mut encoded = record.into_mut_encoded();
@@ -341,11 +341,11 @@ fn decrypt_payload(
             encoded.truncate(plaintext_len);
             Ok(encoded.freeze())
         }
-        (EncryptionConfig::Aegis256(_), actual) => Err(RecordDecryptionError::AlgorithmMismatch {
+        (EncryptionSpec::Aegis256(_), actual) => Err(RecordDecryptionError::AlgorithmMismatch {
             expected: Some(EncryptionAlgorithm::Aegis256),
             actual,
         }),
-        (EncryptionConfig::Aes256Gcm(_), actual) => Err(RecordDecryptionError::AlgorithmMismatch {
+        (EncryptionSpec::Aes256Gcm(_), actual) => Err(RecordDecryptionError::AlgorithmMismatch {
             expected: Some(EncryptionAlgorithm::Aes256Gcm),
             actual,
         }),
@@ -377,17 +377,17 @@ mod tests {
     const TEST_KEY: [u8; 32] = [0x42; 32];
     const OTHER_TEST_KEY: [u8; 32] = [0x99; 32];
 
-    fn test_encryption(alg: EncryptionAlgorithm) -> EncryptionConfig {
+    fn test_encryption(alg: EncryptionAlgorithm) -> EncryptionSpec {
         match alg {
-            EncryptionAlgorithm::Aegis256 => EncryptionConfig::aegis256(TEST_KEY),
-            EncryptionAlgorithm::Aes256Gcm => EncryptionConfig::aes256_gcm(TEST_KEY),
+            EncryptionAlgorithm::Aegis256 => EncryptionSpec::aegis256(TEST_KEY),
+            EncryptionAlgorithm::Aes256Gcm => EncryptionSpec::aes256_gcm(TEST_KEY),
         }
     }
 
-    fn other_test_encryption(alg: EncryptionAlgorithm) -> EncryptionConfig {
+    fn other_test_encryption(alg: EncryptionAlgorithm) -> EncryptionSpec {
         match alg {
-            EncryptionAlgorithm::Aegis256 => EncryptionConfig::aegis256(OTHER_TEST_KEY),
-            EncryptionAlgorithm::Aes256Gcm => EncryptionConfig::aes256_gcm(OTHER_TEST_KEY),
+            EncryptionAlgorithm::Aegis256 => EncryptionSpec::aegis256(OTHER_TEST_KEY),
+            EncryptionAlgorithm::Aes256Gcm => EncryptionSpec::aes256_gcm(OTHER_TEST_KEY),
         }
     }
 
@@ -435,7 +435,7 @@ mod tests {
     }
 
     fn make_encrypted_stored_record(
-        encryption: &EncryptionConfig,
+        encryption: &EncryptionSpec,
         headers: Vec<Header>,
         body: Bytes,
         aad: &[u8],
@@ -443,13 +443,13 @@ mod tests {
         let metered_size = make_plaintext_envelope(headers.clone(), body.clone()).metered_size();
         let plaintext = make_envelope(headers, body);
         let encrypted = match encryption {
-            EncryptionConfig::Plain => {
+            EncryptionSpec::Plain => {
                 unreachable!("plain encryption should not produce ciphertext")
             }
-            EncryptionConfig::Aegis256(key) => {
+            EncryptionSpec::Aegis256(key) => {
                 encrypt_payload(&plaintext, EncryptionAlgorithm::Aegis256, key.secret(), aad)
             }
-            EncryptionConfig::Aes256Gcm(key) => encrypt_payload(
+            EncryptionSpec::Aes256Gcm(key) => encrypt_payload(
                 &plaintext,
                 EncryptionAlgorithm::Aes256Gcm,
                 key.secret(),
@@ -706,7 +706,7 @@ mod tests {
             &aad,
         );
 
-        let result = decrypt_stored_record(record, &EncryptionConfig::Plain, &aad);
+        let result = decrypt_stored_record(record, &EncryptionSpec::Plain, &aad);
 
         assert!(matches!(
             result,

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -1,19 +1,20 @@
 //! Encrypted record storage, wire format, and raw cryptography.
 //!
 //! ```text
-//! [suite_id: 1 byte] [nonce] [ciphertext] [tag]
+//! [format_id: 1 byte] [nonce] [ciphertext] [tag]
 //! ```
 //!
-//! | suite_id | Suite          | Nonce  | Tag  |
-//! |----------|----------------|--------|------|
-//! | 0x01     | AEGIS-256 v1   | 32 B   | 16 B |
-//! | 0x02     | AES-256-GCM v1 | 12 B   | 16 B |
+//! | format_id | Format         | Nonce  | Tag  |
+//! |-----------|----------------|--------|------|
+//! | 0x01      | AEGIS-256 v1   | 32 B   | 16 B |
+//! | 0x02      | AES-256-GCM v1 | 12 B   | 16 B |
 //!
-//! The leading suite byte identifies the full ciphertext framing, not just the
-//! algorithm. This leaves room for future layout changes without a separate
-//! version byte.
+//! The leading format byte identifies the full encrypted record framing,
+//! including the framing version and encryption algorithm. This leaves room for
+//! future layout changes without a separate version byte.
 //!
-//! AAD is caller-supplied associated data.
+//! AAD is caller-supplied associated data and is not stored in the encoded
+//! record.
 //!
 //! Plaintext records are stored as `StoredRecord::Plaintext(Record)` and use
 //! the same command/envelope framing as the logical record layer.
@@ -39,10 +40,71 @@ use crate::{
     record::MeteredExt as _,
 };
 
-const SUITE_ID_LEN: usize = 1;
+const FORMAT_ID_LEN: usize = 1;
 
-const SUITE_ID_AEGIS256_V1: u8 = 0x01;
-const SUITE_ID_AES256GCM_V1: u8 = 0x02;
+const FORMAT_ID_AEGIS256_V1: u8 = 0x01;
+const FORMAT_ID_AES256GCM_V1: u8 = 0x02;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EncryptedRecordFormat {
+    Aegis256V1,
+    Aes256GcmV1,
+}
+
+impl EncryptedRecordFormat {
+    const fn current_for_algorithm(algorithm: EncryptionAlgorithm) -> Self {
+        match algorithm {
+            EncryptionAlgorithm::Aegis256 => Self::Aegis256V1,
+            EncryptionAlgorithm::Aes256Gcm => Self::Aes256GcmV1,
+        }
+    }
+
+    const fn try_from_format_id(format_id: u8) -> Result<Self, RecordDecodeError> {
+        match format_id {
+            FORMAT_ID_AEGIS256_V1 => Ok(Self::Aegis256V1),
+            FORMAT_ID_AES256GCM_V1 => Ok(Self::Aes256GcmV1),
+            _ => Err(RecordDecodeError::InvalidValue(
+                "EncryptedRecord",
+                "invalid encrypted record format id",
+            )),
+        }
+    }
+
+    const fn format_id(self) -> u8 {
+        match self {
+            Self::Aegis256V1 => FORMAT_ID_AEGIS256_V1,
+            Self::Aes256GcmV1 => FORMAT_ID_AES256GCM_V1,
+        }
+    }
+
+    const fn algorithm(self) -> EncryptionAlgorithm {
+        match self {
+            Self::Aegis256V1 => EncryptionAlgorithm::Aegis256,
+            Self::Aes256GcmV1 => EncryptionAlgorithm::Aes256Gcm,
+        }
+    }
+
+    const fn nonce_len(self) -> usize {
+        match self {
+            Self::Aegis256V1 => 32,
+            Self::Aes256GcmV1 => 12,
+        }
+    }
+
+    const fn tag_len(self) -> usize {
+        match self {
+            Self::Aegis256V1 => 16,
+            Self::Aes256GcmV1 => 16,
+        }
+    }
+
+    fn put_random_nonce(self, buf: &mut impl BufMut) {
+        match self {
+            Self::Aegis256V1 => buf.put_slice(&random::<[u8; 32]>()),
+            Self::Aes256GcmV1 => buf.put_slice(&random::<[u8; 12]>()),
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum RecordDecryptionError {
@@ -64,35 +126,35 @@ pub enum RecordDecryptionError {
 #[derive(PartialEq, Eq, Clone)]
 pub struct EncryptedRecord {
     encoded: Bytes,
-    algorithm: EncryptionAlgorithm,
+    format: EncryptedRecordFormat,
 }
 
 impl EncryptedRecord {
-    fn new(encoded: Bytes, algorithm: EncryptionAlgorithm) -> Self {
+    fn new(encoded: Bytes, format: EncryptedRecordFormat) -> Self {
         debug_assert!(!encoded.is_empty());
-        debug_assert_eq!(encoded[0], algorithm.suite_id());
-        debug_assert!(encoded.len() >= SUITE_ID_LEN + algorithm.nonce_len() + algorithm.tag_len());
-        Self { encoded, algorithm }
+        debug_assert_eq!(encoded[0], format.format_id());
+        debug_assert!(encoded.len() >= FORMAT_ID_LEN + format.nonce_len() + format.tag_len());
+        Self { encoded, format }
     }
 
-    pub(crate) fn algorithm(&self) -> EncryptionAlgorithm {
-        self.algorithm
+    pub(crate) fn format(&self) -> EncryptedRecordFormat {
+        self.format
     }
 
     pub(crate) fn nonce(&self) -> &[u8] {
-        let start = SUITE_ID_LEN;
-        let end = start + self.algorithm.nonce_len();
+        let start = FORMAT_ID_LEN;
+        let end = start + self.format.nonce_len();
         &self.encoded[start..end]
     }
 
     pub(crate) fn ciphertext(&self) -> &[u8] {
-        let start = SUITE_ID_LEN + self.algorithm.nonce_len();
-        let end = self.encoded.len() - self.algorithm.tag_len();
+        let start = FORMAT_ID_LEN + self.format.nonce_len();
+        let end = self.encoded.len() - self.format.tag_len();
         &self.encoded[start..end]
     }
 
     pub(crate) fn tag(&self) -> &[u8] {
-        let start = self.encoded.len() - self.algorithm.tag_len();
+        let start = self.encoded.len() - self.format.tag_len();
         let end = self.encoded.len();
         &self.encoded[start..end]
     }
@@ -104,52 +166,12 @@ impl EncryptedRecord {
     }
 }
 
-impl EncryptionAlgorithm {
-    const fn try_from_suite_id(suite_id: u8) -> Result<Self, RecordDecodeError> {
-        match suite_id {
-            SUITE_ID_AEGIS256_V1 => Ok(Self::Aegis256),
-            SUITE_ID_AES256GCM_V1 => Ok(Self::Aes256Gcm),
-            _ => Err(RecordDecodeError::InvalidValue(
-                "EncryptedRecord",
-                "invalid ciphertext suite id",
-            )),
-        }
-    }
-
-    const fn suite_id(self) -> u8 {
-        match self {
-            Self::Aegis256 => SUITE_ID_AEGIS256_V1,
-            Self::Aes256Gcm => SUITE_ID_AES256GCM_V1,
-        }
-    }
-
-    const fn nonce_len(self) -> usize {
-        match self {
-            Self::Aegis256 => 32,
-            Self::Aes256Gcm => 12,
-        }
-    }
-
-    const fn tag_len(self) -> usize {
-        match self {
-            Self::Aegis256 => 16,
-            Self::Aes256Gcm => 16,
-        }
-    }
-
-    fn put_random_nonce(self, buf: &mut impl BufMut) {
-        match self {
-            Self::Aegis256 => buf.put_slice(&random::<[u8; 32]>()),
-            Self::Aes256Gcm => buf.put_slice(&random::<[u8; 12]>()),
-        }
-    }
-}
-
 impl std::fmt::Debug for EncryptedRecord {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EncryptedRecord")
-            .field("suite_id", &self.encoded[0])
-            .field("algorithm", &self.algorithm)
+            .field("format_id", &self.encoded[0])
+            .field("format", &self.format)
+            .field("algorithm", &self.format.algorithm())
             .field("nonce.len", &self.nonce().len())
             .field("ciphertext.len", &self.ciphertext().len())
             .field("tag.len", &self.tag().len())
@@ -202,25 +224,26 @@ fn encrypt_payload(
     key: &[u8; 32],
     aad: &[u8],
 ) -> EncryptedRecord {
-    let payload_start = SUITE_ID_LEN + alg.nonce_len();
+    let format = EncryptedRecordFormat::current_for_algorithm(alg);
+    let payload_start = FORMAT_ID_LEN + format.nonce_len();
     let mut encoded =
-        BytesMut::with_capacity(payload_start + plaintext.encoded_size() + alg.tag_len());
-    encoded.put_u8(alg.suite_id());
-    alg.put_random_nonce(&mut encoded);
+        BytesMut::with_capacity(payload_start + plaintext.encoded_size() + format.tag_len());
+    encoded.put_u8(format.format_id());
+    format.put_random_nonce(&mut encoded);
     plaintext.encode_into(&mut encoded);
 
     let (prefix, payload) = encoded.split_at_mut(payload_start);
-    let nonce = &prefix[SUITE_ID_LEN..];
+    let nonce = &prefix[FORMAT_ID_LEN..];
 
-    match alg {
-        EncryptionAlgorithm::Aegis256 => {
+    match format {
+        EncryptedRecordFormat::Aegis256V1 => {
             let nonce: &[u8; 32] = nonce
                 .try_into()
                 .expect("AEGIS-256 nonce should match the encoded record framing");
             let tag = Aegis256::<16>::new(key, nonce).encrypt_in_place(payload, aad);
             encoded.put_slice(tag.as_ref());
         }
-        EncryptionAlgorithm::Aes256Gcm => {
+        EncryptedRecordFormat::Aes256GcmV1 => {
             let nonce = aes_gcm::Nonce::from_slice(nonce);
             let tag = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key))
                 .encrypt_in_place_detached(nonce, aad, payload)
@@ -229,25 +252,25 @@ fn encrypt_payload(
         }
     }
 
-    EncryptedRecord::new(encoded.freeze(), alg)
+    EncryptedRecord::new(encoded.freeze(), format)
 }
 
 impl TryFrom<Bytes> for EncryptedRecord {
     type Error = RecordDecodeError;
 
     fn try_from(encoded: Bytes) -> Result<Self, Self::Error> {
-        if encoded.len() < SUITE_ID_LEN {
-            return Err(RecordDecodeError::Truncated("EncryptedRecordSuiteId"));
+        if encoded.len() < FORMAT_ID_LEN {
+            return Err(RecordDecodeError::Truncated("EncryptedRecordFormatId"));
         }
 
-        let algorithm = EncryptionAlgorithm::try_from_suite_id(encoded[0])?;
-        let nonce_len = algorithm.nonce_len();
-        let tag_len = algorithm.tag_len();
-        if encoded.len() < SUITE_ID_LEN + nonce_len + tag_len {
+        let format = EncryptedRecordFormat::try_from_format_id(encoded[0])?;
+        let nonce_len = format.nonce_len();
+        let tag_len = format.tag_len();
+        if encoded.len() < FORMAT_ID_LEN + nonce_len + tag_len {
             return Err(RecordDecodeError::Truncated("EncryptedRecordFrame"));
         }
 
-        Ok(Self::new(encoded, algorithm))
+        Ok(Self::new(encoded, format))
     }
 }
 
@@ -281,18 +304,19 @@ fn decrypt_payload(
     encryption: &EncryptionSpec,
     aad: &[u8],
 ) -> Result<Bytes, RecordDecryptionError> {
-    let algorithm = record.algorithm();
+    let format = record.format();
+    let algorithm = format.algorithm();
     let expected = encryption.mode();
     let actual = EncryptionMode::from(algorithm);
-    match (encryption, algorithm) {
-        (EncryptionSpec::Aegis256(key), EncryptionAlgorithm::Aegis256) => {
-            let payload_start = SUITE_ID_LEN + algorithm.nonce_len();
-            let tag_len = algorithm.tag_len();
+    match (encryption, format) {
+        (EncryptionSpec::Aegis256(key), EncryptedRecordFormat::Aegis256V1) => {
+            let payload_start = FORMAT_ID_LEN + format.nonce_len();
+            let tag_len = format.tag_len();
             let mut encoded = record.into_mut_encoded();
             let payload_end = payload_end(encoded.len(), payload_start, tag_len)?;
             let plaintext_len = payload_end - payload_start;
             let nonce: [u8; 32] = encoded
-                .get(SUITE_ID_LEN..payload_start)
+                .get(FORMAT_ID_LEN..payload_start)
                 .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?
                 .try_into()
                 .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
@@ -312,16 +336,16 @@ fn decrypt_payload(
             encoded.truncate(plaintext_len);
             Ok(encoded.freeze())
         }
-        (EncryptionSpec::Aes256Gcm(key), EncryptionAlgorithm::Aes256Gcm) => {
-            let payload_start = SUITE_ID_LEN + algorithm.nonce_len();
-            let tag_len = algorithm.tag_len();
+        (EncryptionSpec::Aes256Gcm(key), EncryptedRecordFormat::Aes256GcmV1) => {
+            let payload_start = FORMAT_ID_LEN + format.nonce_len();
+            let tag_len = format.tag_len();
             let mut encoded = record.into_mut_encoded();
             let payload_end = payload_end(encoded.len(), payload_start, tag_len)?;
             let plaintext_len = payload_end - payload_start;
             let cipher = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key.secret()));
             let nonce = aes_gcm::Nonce::clone_from_slice(
                 encoded
-                    .get(SUITE_ID_LEN..payload_start)
+                    .get(FORMAT_ID_LEN..payload_start)
                     .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?,
             );
             let tag = aes_gcm::Tag::clone_from_slice(
@@ -391,7 +415,7 @@ mod tests {
     }
 
     fn make_encrypted_record(
-        algorithm: EncryptionAlgorithm,
+        format: EncryptedRecordFormat,
         nonce: impl AsRef<[u8]>,
         ciphertext: impl AsRef<[u8]>,
         tag: impl AsRef<[u8]>,
@@ -400,17 +424,17 @@ mod tests {
         let ciphertext = ciphertext.as_ref();
         let tag = tag.as_ref();
 
-        assert_eq!(nonce.len(), algorithm.nonce_len());
-        assert_eq!(tag.len(), algorithm.tag_len());
+        assert_eq!(nonce.len(), format.nonce_len());
+        assert_eq!(tag.len(), format.tag_len());
 
         let mut encoded =
-            BytesMut::with_capacity(SUITE_ID_LEN + nonce.len() + ciphertext.len() + tag.len());
-        encoded.put_u8(algorithm.suite_id());
+            BytesMut::with_capacity(FORMAT_ID_LEN + nonce.len() + ciphertext.len() + tag.len());
+        encoded.put_u8(format.format_id());
         encoded.put_slice(nonce);
         encoded.put_slice(ciphertext);
         encoded.put_slice(tag);
 
-        EncryptedRecord::new(encoded.freeze(), algorithm)
+        EncryptedRecord::new(encoded.freeze(), format)
     }
 
     fn aad() -> [u8; 32] {
@@ -501,22 +525,26 @@ mod tests {
         let result = EncryptedRecord::try_from(Bytes::new());
         assert!(matches!(
             result,
-            Err(RecordDecodeError::Truncated("EncryptedRecordSuiteId"))
+            Err(RecordDecodeError::Truncated("EncryptedRecordFormatId"))
         ));
     }
 
     #[test]
-    fn suite_id_byte_present() {
+    fn format_id_byte_present() {
         let aad = aad();
         let plaintext = make_envelope(vec![], Bytes::from_static(b"data"));
         let ciphertext = encrypt_test_payload(&plaintext, EncryptionAlgorithm::Aegis256, &aad);
         let encoded = ciphertext.to_bytes();
-        assert_eq!(ciphertext.algorithm(), EncryptionAlgorithm::Aegis256);
+        assert_eq!(ciphertext.format(), EncryptedRecordFormat::Aegis256V1);
+        assert_eq!(
+            ciphertext.format().algorithm(),
+            EncryptionAlgorithm::Aegis256
+        );
         assert_eq!(encoded[0], 0x01);
     }
 
     #[test]
-    fn suite_id_flip_detected() {
+    fn format_id_flip_detected() {
         let aad = aad();
         let plaintext = make_envelope(vec![], Bytes::from_static(b"data"));
         let mut ciphertext = encrypt_test_payload(&plaintext, EncryptionAlgorithm::Aegis256, &aad)
@@ -561,7 +589,7 @@ mod tests {
         let aad = aad();
         let record = EncryptedRecord {
             encoded: Bytes::from_static(b"\x01short"),
-            algorithm: EncryptionAlgorithm::Aegis256,
+            format: EncryptedRecordFormat::Aegis256V1,
         };
 
         let result = decrypt_payload(
@@ -579,7 +607,7 @@ mod tests {
     #[test]
     fn encrypted_record_roundtrips_aes256gcm() {
         let record = make_encrypted_record(
-            EncryptionAlgorithm::Aes256Gcm,
+            EncryptedRecordFormat::Aes256GcmV1,
             Bytes::from_static(b"0123456789ab"),
             Bytes::from_static(b"ciphertext"),
             Bytes::from_static(b"0123456789abcdef"),
@@ -589,18 +617,22 @@ mod tests {
         let decoded = EncryptedRecord::try_from(bytes).unwrap();
 
         assert_eq!(decoded, record);
-        assert_eq!(decoded.encoded[0], SUITE_ID_AES256GCM_V1);
+        assert_eq!(decoded.format(), EncryptedRecordFormat::Aes256GcmV1);
+        assert_eq!(decoded.encoded[0], FORMAT_ID_AES256GCM_V1);
         assert_eq!(decoded.nonce(), b"0123456789ab");
         assert_eq!(decoded.ciphertext(), b"ciphertext");
         assert_eq!(decoded.tag(), b"0123456789abcdef");
     }
 
     #[test]
-    fn rejects_invalid_suite_id() {
+    fn rejects_invalid_format_id() {
         let err = EncryptedRecord::try_from(Bytes::from_static(b"\xFFpayload")).unwrap_err();
         assert_eq!(
             err,
-            RecordDecodeError::InvalidValue("EncryptedRecord", "invalid ciphertext suite id")
+            RecordDecodeError::InvalidValue(
+                "EncryptedRecord",
+                "invalid encrypted record format id"
+            )
         );
     }
 
@@ -628,7 +660,8 @@ mod tests {
         else {
             panic!("expected encrypted envelope record");
         };
-        assert_eq!(envelope.algorithm(), EncryptionAlgorithm::Aegis256);
+        assert_eq!(envelope.format(), EncryptedRecordFormat::Aegis256V1);
+        assert_eq!(envelope.format().algorithm(), EncryptionAlgorithm::Aegis256);
 
         let decrypted = decrypt_stored_record(stored, &encryption, &aad).unwrap();
         let Record::Envelope(record) = decrypted.into_inner() else {

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -305,11 +305,18 @@ fn decrypt_payload(
     aad: &[u8],
 ) -> Result<Bytes, RecordDecryptionError> {
     let format = record.format;
-    let algorithm = format.algorithm();
     let expected = encryption.mode();
-    let actual = EncryptionMode::from(algorithm);
-    match (encryption, format) {
-        (EncryptionSpec::Aegis256(key), EncryptedRecordFormat::Aegis256V1) => {
+    match format {
+        EncryptedRecordFormat::Aegis256V1 => {
+            let key = match encryption {
+                EncryptionSpec::Aegis256(key) => key,
+                _ => {
+                    return Err(RecordDecryptionError::ModeMismatch {
+                        expected,
+                        actual: EncryptionMode::Aegis256,
+                    });
+                }
+            };
             let payload_start = FORMAT_ID_LEN + format.nonce_len();
             let tag_len = format.tag_len();
             let mut encoded = record.into_mut_encoded();
@@ -336,7 +343,16 @@ fn decrypt_payload(
             encoded.truncate(plaintext_len);
             Ok(encoded.freeze())
         }
-        (EncryptionSpec::Aes256Gcm(key), EncryptedRecordFormat::Aes256GcmV1) => {
+        EncryptedRecordFormat::Aes256GcmV1 => {
+            let key = match encryption {
+                EncryptionSpec::Aes256Gcm(key) => key,
+                _ => {
+                    return Err(RecordDecryptionError::ModeMismatch {
+                        expected,
+                        actual: EncryptionMode::Aes256Gcm,
+                    });
+                }
+            };
             let payload_start = FORMAT_ID_LEN + format.nonce_len();
             let tag_len = format.tag_len();
             let mut encoded = record.into_mut_encoded();
@@ -363,7 +379,6 @@ fn decrypt_payload(
             encoded.truncate(plaintext_len);
             Ok(encoded.freeze())
         }
-        _ => Err(RecordDecryptionError::ModeMismatch { expected, actual }),
     }
 }
 

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -321,23 +321,23 @@ fn decrypt_payload(
                     });
                 }
             };
-            let nonce: [u8; 32] = encoded
-                .get(FORMAT_ID_LEN..payload_start)
-                .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?
-                .try_into()
-                .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
-            let tag: [u8; 16] = encoded
-                .get(payload_end..)
-                .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?
-                .try_into()
-                .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
-            let ciphertext = encoded
-                .get_mut(payload_start..payload_end)
-                .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?;
+            {
+                let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
+                let nonce: &[u8; 32] = prefix
+                    .get(FORMAT_ID_LEN..)
+                    .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?
+                    .try_into()
+                    .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
+                let (ciphertext, tag) = payload_and_tag.split_at_mut(plaintext_len);
+                let tag: &[u8; 16] = tag
+                    .as_ref()
+                    .try_into()
+                    .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
 
-            Aegis256::<16>::new(key.secret(), &nonce)
-                .decrypt_in_place(ciphertext, &tag, aad)
-                .map_err(|_| RecordDecryptionError::AuthenticationFailed)?;
+                Aegis256::<16>::new(key.secret(), nonce)
+                    .decrypt_in_place(ciphertext, tag, aad)
+                    .map_err(|_| RecordDecryptionError::AuthenticationFailed)?;
+            }
             let _ = encoded.split_to(payload_start);
             encoded.truncate(plaintext_len);
             Ok(encoded.freeze())
@@ -353,22 +353,24 @@ fn decrypt_payload(
                 }
             };
             let cipher = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key.secret()));
-            let nonce = aes_gcm::Nonce::clone_from_slice(
-                encoded
-                    .get(FORMAT_ID_LEN..payload_start)
-                    .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?,
-            );
-            let tag = aes_gcm::Tag::clone_from_slice(
-                encoded
-                    .get(payload_end..)
-                    .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?,
-            );
-            let ciphertext = encoded
-                .get_mut(payload_start..payload_end)
-                .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?;
-            cipher
-                .decrypt_in_place_detached(&nonce, aad, ciphertext, &tag)
-                .map_err(|_| RecordDecryptionError::AuthenticationFailed)?;
+            {
+                let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
+                let nonce: &[u8; 12] = prefix
+                    .get(FORMAT_ID_LEN..)
+                    .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?
+                    .try_into()
+                    .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
+                let nonce = aes_gcm::Nonce::from_slice(nonce);
+                let (ciphertext, tag) = payload_and_tag.split_at_mut(plaintext_len);
+                let tag: &[u8; 16] = tag
+                    .as_ref()
+                    .try_into()
+                    .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
+                let tag = aes_gcm::Tag::from_slice(tag);
+                cipher
+                    .decrypt_in_place_detached(nonce, aad, ciphertext, tag)
+                    .map_err(|_| RecordDecryptionError::AuthenticationFailed)?;
+            }
             let _ = encoded.split_to(payload_start);
             encoded.truncate(plaintext_len);
             Ok(encoded.freeze())

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -25,8 +25,8 @@
 //! plaintext [`EnvelopeRecord`](super::EnvelopeRecord) encoding.
 //!
 //! The stored `metered_size` remains the logical plaintext metered size rather
-//! than the ciphertext size, so protection does not change append/read
-//! metering, limits, or accounting.
+//! than the encoded encrypted record size, so protection does not change
+//! append/read metering, limits, or accounting.
 
 use aegis::aegis256::Aegis256;
 use aes_gcm::{Aes256Gcm, KeyInit, aead::AeadInPlace};
@@ -108,7 +108,7 @@ impl EncryptedRecordFormat {
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum RecordDecryptionError {
-    #[error("ciphertext encryption mode mismatch")]
+    #[error("record encryption mode mismatch")]
     ModeMismatch {
         expected: EncryptionMode,
         actual: EncryptionMode,
@@ -406,7 +406,7 @@ mod tests {
         }
     }
 
-    fn encrypt_test_payload(
+    fn encrypt_test_record(
         plaintext: &(impl Encodable + ?Sized),
         alg: EncryptionAlgorithm,
         aad: &[u8],
@@ -459,7 +459,7 @@ mod tests {
         let plaintext = make_envelope(headers, body);
         let encrypted = match encryption {
             EncryptionSpec::Plain => {
-                unreachable!("plain encryption should not produce ciphertext")
+                unreachable!("plain mode should not produce an encrypted record")
             }
             EncryptionSpec::Aegis256(key) => {
                 encrypt_payload(&plaintext, EncryptionAlgorithm::Aegis256, key.secret(), aad)
@@ -481,7 +481,7 @@ mod tests {
     #[case::aes_shared(EncryptionAlgorithm::Aes256Gcm, true)]
     fn encrypted_payload_roundtrips(
         #[case] algorithm: EncryptionAlgorithm,
-        #[case] shared_ciphertext_buffer: bool,
+        #[case] shared_encoded_record_buffer: bool,
     ) {
         let headers = vec![Header {
             name: Bytes::from_static(b"x-test"),
@@ -492,14 +492,14 @@ mod tests {
         let aad = aad();
         let plaintext = make_envelope(headers.clone(), body.clone());
         let encryption = test_encryption(algorithm);
-        let ciphertext = encrypt_test_payload(&plaintext, algorithm, &aad);
-        let ciphertext = if shared_ciphertext_buffer {
-            let shared = ciphertext.encoded.clone();
+        let encrypted_record = encrypt_test_record(&plaintext, algorithm, &aad);
+        let encrypted_record = if shared_encoded_record_buffer {
+            let shared = encrypted_record.encoded.clone();
             EncryptedRecord::try_from(shared).unwrap()
         } else {
-            ciphertext
+            encrypted_record
         };
-        let decrypted = decrypt_payload(ciphertext, &encryption, &aad).unwrap();
+        let decrypted = decrypt_payload(encrypted_record, &encryption, &aad).unwrap();
         let (out_headers, out_body) = EnvelopeRecord::try_from(decrypted).unwrap().into_parts();
 
         assert_eq!(out_headers, headers);
@@ -512,8 +512,8 @@ mod tests {
     fn wrong_key_fails(#[case] algorithm: EncryptionAlgorithm) {
         let aad = aad();
         let plaintext = make_envelope(vec![], Bytes::from_static(b"data"));
-        let ciphertext = encrypt_test_payload(&plaintext, algorithm, &aad);
-        let result = decrypt_payload(ciphertext, &other_test_encryption(algorithm), &aad);
+        let encrypted_record = encrypt_test_record(&plaintext, algorithm, &aad);
+        let result = decrypt_payload(encrypted_record, &other_test_encryption(algorithm), &aad);
         assert!(matches!(
             result,
             Err(RecordDecryptionError::AuthenticationFailed)
@@ -533,10 +533,10 @@ mod tests {
     fn format_id_byte_present() {
         let aad = aad();
         let plaintext = make_envelope(vec![], Bytes::from_static(b"data"));
-        let ciphertext = encrypt_test_payload(&plaintext, EncryptionAlgorithm::Aegis256, &aad);
-        let encoded = ciphertext.to_bytes();
-        assert_eq!(ciphertext.format, EncryptedRecordFormat::Aegis256V1);
-        assert_eq!(ciphertext.algorithm(), EncryptionAlgorithm::Aegis256);
+        let encrypted_record = encrypt_test_record(&plaintext, EncryptionAlgorithm::Aegis256, &aad);
+        let encoded = encrypted_record.to_bytes();
+        assert_eq!(encrypted_record.format, EncryptedRecordFormat::Aegis256V1);
+        assert_eq!(encrypted_record.algorithm(), EncryptionAlgorithm::Aegis256);
         assert_eq!(encoded[0], 0x01);
     }
 
@@ -544,14 +544,15 @@ mod tests {
     fn format_id_flip_detected() {
         let aad = aad();
         let plaintext = make_envelope(vec![], Bytes::from_static(b"data"));
-        let mut ciphertext = encrypt_test_payload(&plaintext, EncryptionAlgorithm::Aegis256, &aad)
-            .to_bytes()
-            .to_vec();
-        assert_eq!(ciphertext[0], 0x01);
-        ciphertext[0] = 0x02;
-        let ciphertext = EncryptedRecord::try_from(Bytes::from(ciphertext)).unwrap();
+        let mut encoded_record =
+            encrypt_test_record(&plaintext, EncryptionAlgorithm::Aegis256, &aad)
+                .to_bytes()
+                .to_vec();
+        assert_eq!(encoded_record[0], 0x01);
+        encoded_record[0] = 0x02;
+        let encrypted_record = EncryptedRecord::try_from(Bytes::from(encoded_record)).unwrap();
         let result = decrypt_payload(
-            ciphertext,
+            encrypted_record,
             &test_encryption(EncryptionAlgorithm::Aegis256),
             &aad,
         );
@@ -569,9 +570,9 @@ mod tests {
         let aad = aad();
         let other_aad = [0x5A; 32];
         let plaintext = make_envelope(vec![], Bytes::from_static(b"data"));
-        let ciphertext = encrypt_test_payload(&plaintext, EncryptionAlgorithm::Aegis256, &aad);
+        let encrypted_record = encrypt_test_record(&plaintext, EncryptionAlgorithm::Aegis256, &aad);
         let result = decrypt_payload(
-            ciphertext,
+            encrypted_record,
             &test_encryption(EncryptionAlgorithm::Aegis256),
             &other_aad,
         );

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -338,9 +338,7 @@ fn decrypt_payload(
                     .decrypt_in_place(ciphertext, tag, aad)
                     .map_err(|_| RecordDecryptionError::AuthenticationFailed)?;
             }
-            let _ = encoded.split_to(payload_start);
-            encoded.truncate(plaintext_len);
-            Ok(encoded.freeze())
+            Ok(decryption_finish(encoded, payload_start, plaintext_len))
         }
         EncryptedRecordFormat::Aes256GcmV1 => {
             let key = match encryption {
@@ -371,9 +369,7 @@ fn decrypt_payload(
                     .decrypt_in_place_detached(nonce, aad, ciphertext, tag)
                     .map_err(|_| RecordDecryptionError::AuthenticationFailed)?;
             }
-            let _ = encoded.split_to(payload_start);
-            encoded.truncate(plaintext_len);
-            Ok(encoded.freeze())
+            Ok(decryption_finish(encoded, payload_start, plaintext_len))
         }
     }
 }
@@ -392,6 +388,12 @@ fn decryption_layout(
         return Err(RecordDecryptionError::MalformedEncryptedRecord);
     }
     Ok((record.into_mut_encoded(), payload_start, payload_end))
+}
+
+fn decryption_finish(mut encoded: BytesMut, payload_start: usize, plaintext_len: usize) -> Bytes {
+    let _ = encoded.split_to(payload_start);
+    encoded.truncate(plaintext_len);
+    encoded.freeze()
 }
 
 #[cfg(test)]

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -35,7 +35,7 @@ use rand::random;
 use super::{Encodable, Metered, MeteredSize, Record, RecordDecodeError, StoredRecord};
 use crate::{
     deep_size::DeepSize,
-    encryption::{EncryptionAlgorithm, EncryptionSpec},
+    encryption::{EncryptionAlgorithm, EncryptionMode, EncryptionSpec},
     record::MeteredExt as _,
 };
 
@@ -46,10 +46,10 @@ const SUITE_ID_AES256GCM_V1: u8 = 0x02;
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum RecordDecryptionError {
-    #[error("ciphertext algorithm mismatch")]
-    AlgorithmMismatch {
-        expected: Option<EncryptionAlgorithm>,
-        actual: EncryptionAlgorithm,
+    #[error("ciphertext encryption mode mismatch")]
+    ModeMismatch {
+        expected: EncryptionMode,
+        actual: EncryptionMode,
     },
     #[error("record decryption failed")]
     AuthenticationFailed,
@@ -282,11 +282,9 @@ fn decrypt_payload(
     aad: &[u8],
 ) -> Result<Bytes, RecordDecryptionError> {
     let algorithm = record.algorithm();
+    let expected = encryption.mode();
+    let actual = EncryptionMode::from(algorithm);
     match (encryption, algorithm) {
-        (EncryptionSpec::Plain, actual) => Err(RecordDecryptionError::AlgorithmMismatch {
-            expected: None,
-            actual,
-        }),
         (EncryptionSpec::Aegis256(key), EncryptionAlgorithm::Aegis256) => {
             let payload_start = SUITE_ID_LEN + algorithm.nonce_len();
             let tag_len = algorithm.tag_len();
@@ -341,14 +339,7 @@ fn decrypt_payload(
             encoded.truncate(plaintext_len);
             Ok(encoded.freeze())
         }
-        (EncryptionSpec::Aegis256(_), actual) => Err(RecordDecryptionError::AlgorithmMismatch {
-            expected: Some(EncryptionAlgorithm::Aegis256),
-            actual,
-        }),
-        (EncryptionSpec::Aes256Gcm(_), actual) => Err(RecordDecryptionError::AlgorithmMismatch {
-            expected: Some(EncryptionAlgorithm::Aes256Gcm),
-            actual,
-        }),
+        _ => Err(RecordDecryptionError::ModeMismatch { expected, actual }),
     }
 }
 
@@ -541,9 +532,9 @@ mod tests {
         );
         assert!(matches!(
             result,
-            Err(RecordDecryptionError::AlgorithmMismatch {
-                expected: Some(EncryptionAlgorithm::Aegis256),
-                actual: EncryptionAlgorithm::Aes256Gcm,
+            Err(RecordDecryptionError::ModeMismatch {
+                expected: EncryptionMode::Aegis256,
+                actual: EncryptionMode::Aes256Gcm,
             })
         ));
     }
@@ -710,9 +701,9 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(RecordDecryptionError::AlgorithmMismatch {
-                expected: None,
-                actual: EncryptionAlgorithm::Aegis256,
+            Err(RecordDecryptionError::ModeMismatch {
+                expected: EncryptionMode::Plain,
+                actual: EncryptionMode::Aegis256,
             })
         ));
     }

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -381,22 +381,15 @@ fn decryption_layout(
     format: EncryptedRecordFormat,
 ) -> Result<(BytesMut, usize, usize), RecordDecryptionError> {
     let payload_start = FORMAT_ID_LEN + format.nonce_len();
-    let payload_end = payload_end(record.encoded.len(), payload_start, format.tag_len())?;
-    Ok((record.into_mut_encoded(), payload_start, payload_end))
-}
-
-fn payload_end(
-    encoded_len: usize,
-    payload_start: usize,
-    tag_len: usize,
-) -> Result<usize, RecordDecryptionError> {
-    let payload_end = encoded_len
-        .checked_sub(tag_len)
+    let payload_end = record
+        .encoded
+        .len()
+        .checked_sub(format.tag_len())
         .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?;
     if payload_start > payload_end {
         return Err(RecordDecryptionError::MalformedEncryptedRecord);
     }
-    Ok(payload_end)
+    Ok((record.into_mut_encoded(), payload_start, payload_end))
 }
 
 #[cfg(test)]

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -137,8 +137,8 @@ impl EncryptedRecord {
         Self { encoded, format }
     }
 
-    pub(crate) fn format(&self) -> EncryptedRecordFormat {
-        self.format
+    pub fn algorithm(&self) -> EncryptionAlgorithm {
+        self.format.algorithm()
     }
 
     pub(crate) fn nonce(&self) -> &[u8] {
@@ -304,7 +304,7 @@ fn decrypt_payload(
     encryption: &EncryptionSpec,
     aad: &[u8],
 ) -> Result<Bytes, RecordDecryptionError> {
-    let format = record.format();
+    let format = record.format;
     let algorithm = format.algorithm();
     let expected = encryption.mode();
     let actual = EncryptionMode::from(algorithm);
@@ -535,11 +535,8 @@ mod tests {
         let plaintext = make_envelope(vec![], Bytes::from_static(b"data"));
         let ciphertext = encrypt_test_payload(&plaintext, EncryptionAlgorithm::Aegis256, &aad);
         let encoded = ciphertext.to_bytes();
-        assert_eq!(ciphertext.format(), EncryptedRecordFormat::Aegis256V1);
-        assert_eq!(
-            ciphertext.format().algorithm(),
-            EncryptionAlgorithm::Aegis256
-        );
+        assert_eq!(ciphertext.format, EncryptedRecordFormat::Aegis256V1);
+        assert_eq!(ciphertext.algorithm(), EncryptionAlgorithm::Aegis256);
         assert_eq!(encoded[0], 0x01);
     }
 
@@ -617,7 +614,7 @@ mod tests {
         let decoded = EncryptedRecord::try_from(bytes).unwrap();
 
         assert_eq!(decoded, record);
-        assert_eq!(decoded.format(), EncryptedRecordFormat::Aes256GcmV1);
+        assert_eq!(decoded.format, EncryptedRecordFormat::Aes256GcmV1);
         assert_eq!(decoded.encoded[0], FORMAT_ID_AES256GCM_V1);
         assert_eq!(decoded.nonce(), b"0123456789ab");
         assert_eq!(decoded.ciphertext(), b"ciphertext");
@@ -660,8 +657,8 @@ mod tests {
         else {
             panic!("expected encrypted envelope record");
         };
-        assert_eq!(envelope.format(), EncryptedRecordFormat::Aegis256V1);
-        assert_eq!(envelope.format().algorithm(), EncryptionAlgorithm::Aegis256);
+        assert_eq!(envelope.format, EncryptedRecordFormat::Aegis256V1);
+        assert_eq!(envelope.algorithm(), EncryptionAlgorithm::Aegis256);
 
         let decrypted = decrypt_stored_record(stored, &encryption, &aad).unwrap();
         let Record::Envelope(record) = decrypted.into_inner() else {

--- a/common/src/types/stream.rs
+++ b/common/src/types/stream.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{
     caps,
-    encryption::EncryptionConfig,
+    encryption::EncryptionSpec,
     read_extent::{ReadLimit, ReadUntil},
     record::{
         FencingToken, Metered, MeteredExt, MeteredSize, Record, RecordDecryptionError, SeqNum,
@@ -326,7 +326,7 @@ pub struct AppendInput<T = Record> {
 }
 
 impl AppendInput<Record> {
-    pub fn encrypt(self, encryption: &EncryptionConfig, aad: &[u8]) -> AppendInput<StoredRecord> {
+    pub fn encrypt(self, encryption: &EncryptionSpec, aad: &[u8]) -> AppendInput<StoredRecord> {
         let AppendInput {
             records,
             match_seq_num,
@@ -446,7 +446,7 @@ impl<T> std::fmt::Debug for ReadBatch<T> {
 impl ReadBatch<StoredRecord> {
     pub fn decrypt(
         self,
-        encryption: &EncryptionConfig,
+        encryption: &EncryptionSpec,
         aad: &[u8],
     ) -> Result<ReadBatch, RecordDecryptionError> {
         let records: Result<Metered<Vec<Sequenced<Record>>>, RecordDecryptionError> = self
@@ -478,7 +478,7 @@ pub enum ReadSessionOutput<T = Record> {
 impl ReadSessionOutput<StoredRecord> {
     pub fn decrypt(
         self,
-        encryption: &EncryptionConfig,
+        encryption: &EncryptionSpec,
         aad: &[u8],
     ) -> Result<ReadSessionOutput, RecordDecryptionError> {
         match self {
@@ -578,7 +578,7 @@ mod test {
     #[case::encrypt(true)]
     #[case::into(false)]
     fn append_input_to_stored_preserves_metadata(#[case] encrypt: bool) {
-        let encryption = EncryptionConfig::aegis256([0x42; 32]);
+        let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let mapped = if encrypt {
             sample_append_input().encrypt(&encryption, TEST_AAD)
         } else {
@@ -642,7 +642,7 @@ mod test {
         };
 
         let mapped = batch
-            .decrypt(&crate::encryption::EncryptionConfig::Plain, &[])
+            .decrypt(&crate::encryption::EncryptionSpec::Plain, &[])
             .unwrap();
         let records = mapped.records.into_inner();
 

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -97,7 +97,7 @@ impl ServiceError {
             },
             ServiceError::Validation(e) => standard(ErrorCode::Invalid, e.to_string()),
             ServiceError::RecordDecryption(e) => match e {
-                RecordDecryptionError::AlgorithmMismatch { .. }
+                RecordDecryptionError::ModeMismatch { .. }
                 | RecordDecryptionError::AuthenticationFailed => {
                     standard(ErrorCode::Invalid, e.to_string())
                 }

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -14,7 +14,7 @@ use s2_api::{
 };
 use s2_common::{
     caps::RECORD_BATCH_MAX,
-    encryption::EncryptionConfig,
+    encryption::EncryptionSpec,
     http::extract::Header,
     read_extent::{CountOrBytes, ReadLimit},
     record::{Metered, MeteredSize as _},
@@ -40,7 +40,7 @@ pub fn router() -> axum::Router<Backend> {
 
 fn decrypt_session<S>(
     session: S,
-    encryption: EncryptionConfig,
+    encryption: EncryptionSpec,
     stream_id: StreamId,
 ) -> impl Stream<Item = Result<ReadSessionOutput, ServiceError>>
 where
@@ -479,7 +479,7 @@ mod tests {
         s2s::{FrameDecoder, SessionMessage, TerminalMessage},
     };
     use s2_common::{
-        encryption::{EncryptionAlgorithm, EncryptionConfig, S2_ENCRYPTION_HEADER},
+        encryption::{EncryptionAlgorithm, EncryptionSpec, S2_ENCRYPTION_HEADER},
         read_extent::{ReadLimit, ReadUntil},
         record::{EnvelopeRecord, Metered, Record, RecordDecryptionError},
         types::{
@@ -560,7 +560,7 @@ mod tests {
         basin: &BasinName,
         stream: &StreamName,
         body: &'static [u8],
-        encryption: &EncryptionConfig,
+        encryption: &EncryptionSpec,
     ) {
         let stream_id = StreamId::new(basin, stream);
         let input = append_input(body).encrypt(encryption, stream_id.as_bytes());
@@ -656,7 +656,7 @@ mod tests {
 
     #[tokio::test]
     async fn unary_append_with_encryption_header_persists_encrypted_record() {
-        let encryption = EncryptionConfig::aegis256([0x42; 32]);
+        let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let (app, backend, basin, stream) = setup_app("append-unary-encrypted").await;
 
         let input = proto::AppendInput {
@@ -688,7 +688,7 @@ mod tests {
         let stored_batch = first_stored_batch(&backend, &basin, &stream).await;
 
         assert!(matches!(
-            stored_batch.clone().decrypt(&EncryptionConfig::Plain, &[]),
+            stored_batch.clone().decrypt(&EncryptionSpec::Plain, &[]),
             Err(RecordDecryptionError::AlgorithmMismatch {
                 expected: None,
                 actual: EncryptionAlgorithm::Aegis256,
@@ -709,8 +709,8 @@ mod tests {
 
     #[tokio::test]
     async fn unary_read_with_wrong_key_returns_invalid_error() {
-        let encryption = EncryptionConfig::aegis256([0x42; 32]);
-        let wrong_key = EncryptionConfig::aegis256([0x24; 32]);
+        let encryption = EncryptionSpec::aegis256([0x42; 32]);
+        let wrong_key = EncryptionSpec::aegis256([0x24; 32]);
         let (app, backend, basin, stream) = setup_app("read-unary-bad-key").await;
         append_encrypted_payload(&backend, &basin, &stream, b"secret", &encryption).await;
 
@@ -730,7 +730,7 @@ mod tests {
 
     #[tokio::test]
     async fn sse_read_with_plain_header_emits_error_event_and_terminates() {
-        let encryption = EncryptionConfig::aegis256([0x42; 32]);
+        let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let (app, backend, basin, stream) = setup_app("read-sse-plain").await;
         append_encrypted_payload(&backend, &basin, &stream, b"secret", &encryption).await;
 
@@ -744,7 +744,7 @@ mod tests {
             .header(header::ACCEPT, "text/event-stream")
             .header(
                 S2_ENCRYPTION_HEADER.as_str(),
-                EncryptionConfig::Plain.to_header_value(),
+                EncryptionSpec::Plain.to_header_value(),
             )
             .body(Body::empty())
             .unwrap(),
@@ -766,7 +766,7 @@ mod tests {
 
     #[tokio::test]
     async fn s2s_read_with_plain_header_returns_terminal_invalid_frame() {
-        let encryption = EncryptionConfig::aegis256([0x42; 32]);
+        let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let (app, backend, basin, stream) = setup_app("read-s2s-plain").await;
         append_encrypted_payload(&backend, &basin, &stream, b"secret", &encryption).await;
 
@@ -776,7 +776,7 @@ mod tests {
                 .header(header::CONTENT_TYPE, "s2s/proto")
                 .header(
                     S2_ENCRYPTION_HEADER.as_str(),
-                    EncryptionConfig::Plain.to_header_value(),
+                    EncryptionSpec::Plain.to_header_value(),
                 )
                 .body(Body::empty())
                 .unwrap(),
@@ -797,7 +797,7 @@ mod tests {
 
     #[tokio::test]
     async fn s2s_read_with_correct_encryption_returns_batch_frame() {
-        let encryption = EncryptionConfig::aegis256([0x42; 32]);
+        let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let (app, backend, basin, stream) = setup_app("read-s2s-ok").await;
         append_encrypted_payload(&backend, &basin, &stream, b"secret", &encryption).await;
 

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -479,7 +479,7 @@ mod tests {
         s2s::{FrameDecoder, SessionMessage, TerminalMessage},
     };
     use s2_common::{
-        encryption::{EncryptionAlgorithm, EncryptionSpec, S2_ENCRYPTION_HEADER},
+        encryption::{EncryptionMode, EncryptionSpec, S2_ENCRYPTION_HEADER},
         read_extent::{ReadLimit, ReadUntil},
         record::{EnvelopeRecord, Metered, Record, RecordDecryptionError},
         types::{
@@ -689,9 +689,9 @@ mod tests {
 
         assert!(matches!(
             stored_batch.clone().decrypt(&EncryptionSpec::Plain, &[]),
-            Err(RecordDecryptionError::AlgorithmMismatch {
-                expected: None,
-                actual: EncryptionAlgorithm::Aegis256,
+            Err(RecordDecryptionError::ModeMismatch {
+                expected: EncryptionMode::Plain,
+                actual: EncryptionMode::Aegis256,
             })
         ));
 
@@ -759,7 +759,7 @@ mod tests {
         let body = String::from_utf8(body.to_vec()).expect("utf8 sse body");
         assert!(body.contains("event: error"));
         assert!(body.contains("\"code\":\"invalid\""));
-        assert!(body.contains("ciphertext algorithm mismatch"));
+        assert!(body.contains("ciphertext encryption mode mismatch"));
         assert!(!body.contains("event: ping"));
         assert!(!body.contains("[DONE]"));
     }
@@ -792,7 +792,7 @@ mod tests {
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY.as_u16());
         let info: serde_json::Value =
             serde_json::from_str(&body).expect("terminal json error info");
-        assert_invalid_error(&info, "ciphertext algorithm mismatch");
+        assert_invalid_error(&info, "ciphertext encryption mode mismatch");
     }
 
     #[tokio::test]

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -759,7 +759,7 @@ mod tests {
         let body = String::from_utf8(body.to_vec()).expect("utf8 sse body");
         assert!(body.contains("event: error"));
         assert!(body.contains("\"code\":\"invalid\""));
-        assert!(body.contains("ciphertext encryption mode mismatch"));
+        assert!(body.contains("record encryption mode mismatch"));
         assert!(!body.contains("event: ping"));
         assert!(!body.contains("[DONE]"));
     }
@@ -792,7 +792,7 @@ mod tests {
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY.as_u16());
         let info: serde_json::Value =
             serde_json::from_str(&body).expect("terminal json error info");
-        assert_invalid_error(&info, "ciphertext encryption mode mismatch");
+        assert_invalid_error(&info, "record encryption mode mismatch");
     }
 
     #[tokio::test]

--- a/lite/tests/backend/common.rs
+++ b/lite/tests/backend/common.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use bytesize::ByteSize;
 use futures::StreamExt;
 use s2_common::{
-    encryption::EncryptionConfig,
+    encryption::EncryptionSpec,
     record::{CommandRecord, FencingToken, Metered, Record, SequencedRecord, Timestamp},
     types::{
         basin::BasinName,
@@ -47,8 +47,8 @@ pub fn test_stream_name(suffix: &str) -> StreamName {
     format!("test-stream-{}", suffix).parse().unwrap()
 }
 
-pub fn aegis256_encryption() -> EncryptionConfig {
-    EncryptionConfig::aegis256([0x42; 32])
+pub fn aegis256_encryption() -> EncryptionSpec {
+    EncryptionSpec::aegis256([0x42; 32])
 }
 
 pub fn create_test_record(body: Bytes) -> AppendRecord {
@@ -138,7 +138,7 @@ pub async fn append_payloads(
     stream: &StreamName,
     payloads: &[&[u8]],
 ) -> s2_common::types::stream::AppendAck {
-    let encryption = EncryptionConfig::Plain;
+    let encryption = EncryptionSpec::Plain;
     append_payloads_with_encryption(backend, basin, stream, payloads, &encryption).await
 }
 
@@ -147,7 +147,7 @@ pub async fn append_payloads_with_encryption(
     basin: &BasinName,
     stream: &StreamName,
     payloads: &[&[u8]],
-    encryption: &EncryptionConfig,
+    encryption: &EncryptionSpec,
 ) -> s2_common::types::stream::AppendAck {
     let bodies = payloads
         .iter()
@@ -170,7 +170,7 @@ pub fn encrypt_input_for_stream(
     input: AppendInput,
     basin: &BasinName,
     stream: &StreamName,
-    encryption: &EncryptionConfig,
+    encryption: &EncryptionSpec,
 ) -> StoredAppendInput {
     let stream_id = s2_lite::backend::StreamId::new(basin, stream);
     input.encrypt(encryption, stream_id.as_bytes())
@@ -190,7 +190,7 @@ pub async fn append_repeat(
 
 pub fn decrypt_plain_batch(batch: StoredReadBatch) -> ReadBatch {
     batch
-        .decrypt(&EncryptionConfig::Plain, &[])
+        .decrypt(&EncryptionSpec::Plain, &[])
         .expect("Failed to decode batch")
 }
 
@@ -198,7 +198,7 @@ pub fn decrypt_batch_for_stream(
     batch: StoredReadBatch,
     basin: &BasinName,
     stream: &StreamName,
-    encryption: &EncryptionConfig,
+    encryption: &EncryptionSpec,
 ) -> ReadBatch {
     let stream_id = s2_lite::backend::StreamId::new(basin, stream);
     batch
@@ -228,7 +228,7 @@ pub async fn collect_records_with_encryption<S>(
     session: &mut Pin<Box<S>>,
     basin: &BasinName,
     stream: &StreamName,
-    encryption: &EncryptionConfig,
+    encryption: &EncryptionSpec,
 ) -> Vec<SequencedRecord>
 where
     S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,

--- a/lite/tests/backend/data_plane/append.rs
+++ b/lite/tests/backend/data_plane/append.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use futures::StreamExt;
 use s2_common::{
-    encryption::EncryptionConfig,
+    encryption::EncryptionSpec,
     read_extent::{ReadLimit, ReadUntil},
     record::FencingToken,
     types::{
@@ -18,7 +18,7 @@ use s2_lite::backend::error::{AppendConditionFailedError, AppendError};
 
 use super::common::*;
 
-async fn assert_append_session_roundtrip(test_suffix: &str, encryption: &EncryptionConfig) {
+async fn assert_append_session_roundtrip(test_suffix: &str, encryption: &EncryptionSpec) {
     let (backend, basin_name, stream_name) =
         setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await;
 
@@ -379,7 +379,7 @@ async fn test_append_with_seq_num_mismatch() {
 
 #[tokio::test]
 async fn test_append_session_basic() {
-    let encryption = EncryptionConfig::Plain;
+    let encryption = EncryptionSpec::Plain;
     assert_append_session_roundtrip("append-session-basic", &encryption).await;
 }
 

--- a/lite/tests/backend/data_plane/read.rs
+++ b/lite/tests/backend/data_plane/read.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use futures::StreamExt;
 use s2_common::{
-    encryption::{EncryptionAlgorithm, EncryptionSpec},
+    encryption::{EncryptionMode, EncryptionSpec},
     read_extent::{ReadLimit, ReadUntil},
     record::{MeteredSize, RecordDecryptionError, StreamPosition},
     types::{
@@ -169,10 +169,10 @@ async fn test_read_encrypted_batch_rejects_plaintext_decryption() {
     let batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
     assert!(matches!(
         batch.decrypt(&EncryptionSpec::Plain, &[]),
-        Err(RecordDecryptionError::AlgorithmMismatch {
-            expected: None,
+        Err(RecordDecryptionError::ModeMismatch {
+            expected: EncryptionMode::Plain,
             actual,
-        }) if actual == EncryptionAlgorithm::Aegis256
+        }) if actual == EncryptionMode::Aegis256
     ));
 }
 

--- a/lite/tests/backend/data_plane/read.rs
+++ b/lite/tests/backend/data_plane/read.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use futures::StreamExt;
 use s2_common::{
-    encryption::{EncryptionAlgorithm, EncryptionConfig},
+    encryption::{EncryptionAlgorithm, EncryptionSpec},
     read_extent::{ReadLimit, ReadUntil},
     record::{MeteredSize, RecordDecryptionError, StreamPosition},
     types::{
@@ -168,7 +168,7 @@ async fn test_read_encrypted_batch_rejects_plaintext_decryption() {
 
     let batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
     assert!(matches!(
-        batch.decrypt(&EncryptionConfig::Plain, &[]),
+        batch.decrypt(&EncryptionSpec::Plain, &[]),
         Err(RecordDecryptionError::AlgorithmMismatch {
             expected: None,
             actual,

--- a/lite/tests/backend/data_plane/read_follow.rs
+++ b/lite/tests/backend/data_plane/read_follow.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use rstest::rstest;
 use s2_common::{
-    encryption::EncryptionConfig,
+    encryption::EncryptionSpec,
     read_extent::{ReadLimit, ReadUntil},
     types::{
         config::OptionalStreamConfig,
@@ -15,7 +15,7 @@ use s2_lite::backend::FOLLOWER_MAX_LAG;
 
 use super::common::*;
 
-async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &EncryptionConfig) {
+async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &EncryptionSpec) {
     let (backend, basin_name, stream_name) =
         setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await;
 
@@ -216,12 +216,12 @@ async fn test_follow_mode_heartbeats() {
 }
 
 #[rstest]
-#[case::plaintext("follow-new-data", EncryptionConfig::Plain)]
+#[case::plaintext("follow-new-data", EncryptionSpec::Plain)]
 #[case::encrypted("follow-enc", aegis256_encryption())]
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_follow_mode_receives_new_data(
     #[case] test_suffix: &str,
-    #[case] encryption: EncryptionConfig,
+    #[case] encryption: EncryptionSpec,
 ) {
     run_follow_mode_receives_new_data_case(test_suffix, &encryption).await;
 }

--- a/sdk/src/api.rs
+++ b/sdk/src/api.rs
@@ -40,7 +40,7 @@ use crate::{
     retry::{RetryBackoff, RetryBackoffBuilder},
     types::{
         AccessTokenId, AppendRetryPolicy, BasinAuthority, BasinName, Compression,
-        EncryptionConfig, RetryConfig, S2Config, S2Endpoints, StreamName,
+        EncryptionSpec, RetryConfig, S2Config, S2Endpoints, StreamName,
     },
 };
 
@@ -346,7 +346,7 @@ impl BasinClient {
         &self,
         name: &StreamName,
         input: AppendInput,
-        encryption: Option<&EncryptionConfig>,
+        encryption: Option<&EncryptionSpec>,
         append_retry_policy: AppendRetryPolicy,
     ) -> Result<AppendAck, ApiError> {
         let url = self
@@ -384,7 +384,7 @@ impl BasinClient {
         name: &StreamName,
         start: ReadStart,
         end: ReadEnd,
-        encryption: Option<&EncryptionConfig>,
+        encryption: Option<&EncryptionSpec>,
     ) -> Result<ReadBatch, ApiError> {
         let url = self
             .base_url
@@ -412,7 +412,7 @@ impl BasinClient {
         &self,
         name: &StreamName,
         inputs: I,
-        encryption: Option<&EncryptionConfig>,
+        encryption: Option<&EncryptionSpec>,
         frame_signal: Option<FrameSignal>,
     ) -> Result<Streaming<AppendAck>, ApiError>
     where
@@ -481,7 +481,7 @@ impl BasinClient {
         name: &StreamName,
         start: ReadStart,
         end: ReadEnd,
-        encryption: Option<&EncryptionConfig>,
+        encryption: Option<&EncryptionSpec>,
     ) -> Result<Streaming<ReadBatch>, ApiError> {
         let url = self
             .base_url
@@ -909,7 +909,7 @@ impl BaseClient {
     }
 }
 
-fn set_encryption_header(request: &mut client::Request, encryption: Option<&EncryptionConfig>) {
+fn set_encryption_header(request: &mut client::Request, encryption: Option<&EncryptionSpec>) {
     if let Some(encryption) = encryption {
         request
             .headers_mut()

--- a/sdk/src/ops.rs
+++ b/sdk/src/ops.rs
@@ -12,7 +12,7 @@ use crate::{
     session::{self, AppendSession, AppendSessionConfig},
     types::{
         AccessTokenId, AccessTokenInfo, AppendAck, AppendInput, BasinConfig, BasinInfo, BasinName,
-        CreateBasinInput, CreateStreamInput, DeleteBasinInput, DeleteStreamInput, EncryptionConfig,
+        CreateBasinInput, CreateStreamInput, DeleteBasinInput, DeleteStreamInput, EncryptionSpec,
         GetAccountMetricsInput, GetBasinMetricsInput, GetStreamMetricsInput, IssueAccessTokenInput,
         ListAccessTokensInput, ListAllAccessTokensInput, ListAllBasinsInput, ListAllStreamsInput,
         ListBasinsInput, ListStreamsInput, Metric, Page, ReadBatch, ReadInput,
@@ -386,12 +386,12 @@ impl S2Basin {
 pub struct S2Stream {
     client: BasinClient,
     name: StreamName,
-    encryption: Option<EncryptionConfig>,
+    encryption: Option<EncryptionSpec>,
 }
 
 impl S2Stream {
-    /// Set the encryption configuration for this stream handle.
-    pub fn with_encryption(self, encryption: EncryptionConfig) -> Self {
+    /// Set the encryption spec for this stream handle.
+    pub fn with_encryption(self, encryption: EncryptionSpec) -> Self {
         Self {
             encryption: Some(encryption),
             ..self

--- a/sdk/src/producer.rs
+++ b/sdk/src/producer.rs
@@ -21,7 +21,7 @@ use crate::{
     batching::{AppendInputs, AppendRecordBatches, BatchingConfig},
     session::{AppendPermit, AppendPermits, AppendSessionInternal, BatchSubmitTicket},
     types::{
-        AppendAck, AppendRecord, EncryptionConfig, FencingToken, MeteredBytes, ONE_MIB, S2Error,
+        AppendAck, AppendRecord, EncryptionSpec, FencingToken, MeteredBytes, ONE_MIB, S2Error,
         StreamName, ValidationError,
     },
 };
@@ -144,7 +144,7 @@ impl Producer {
     pub(crate) fn new(
         client: BasinClient,
         stream: StreamName,
-        encryption: Option<EncryptionConfig>,
+        encryption: Option<EncryptionSpec>,
         config: ProducerConfig,
     ) -> Self {
         let (cmd_tx, cmd_rx) = mpsc::channel::<Command>(RECORD_BATCH_MAX.count);

--- a/sdk/src/session/append.rs
+++ b/sdk/src/session/append.rs
@@ -23,8 +23,8 @@ use crate::{
     frame_signal::FrameSignal,
     retry::RetryBackoffBuilder,
     types::{
-        AppendAck, AppendInput, AppendRetryPolicy, EncryptionConfig, MeteredBytes, ONE_MIB,
-        S2Error, StreamName, StreamPosition, ValidationError,
+        AppendAck, AppendInput, AppendRetryPolicy, EncryptionSpec, MeteredBytes, ONE_MIB, S2Error,
+        StreamName, StreamPosition, ValidationError,
     },
 };
 
@@ -171,7 +171,7 @@ impl AppendSession {
     pub(crate) fn new(
         client: BasinClient,
         stream: StreamName,
-        encryption: Option<EncryptionConfig>,
+        encryption: Option<EncryptionSpec>,
         config: AppendSessionConfig,
     ) -> Self {
         let buffer_size = config
@@ -296,7 +296,7 @@ impl AppendSessionInternal {
     pub(crate) fn new(
         client: BasinClient,
         stream: StreamName,
-        encryption: Option<EncryptionConfig>,
+        encryption: Option<EncryptionSpec>,
     ) -> Self {
         let buffer_size = DEFAULT_CHANNEL_BUFFER_SIZE;
         let (cmd_tx, cmd_rx) = mpsc::channel(buffer_size);
@@ -410,7 +410,7 @@ impl AppendPermits {
 async fn run_session_with_retry(
     client: BasinClient,
     stream: StreamName,
-    encryption: Option<EncryptionConfig>,
+    encryption: Option<EncryptionSpec>,
     cmd_rx: mpsc::Receiver<Command>,
     retry_builder: RetryBackoffBuilder,
     buffer_size: usize,
@@ -510,7 +510,7 @@ async fn run_session_with_retry(
 async fn run_session(
     client: &BasinClient,
     stream: &StreamName,
-    encryption: Option<&EncryptionConfig>,
+    encryption: Option<&EncryptionSpec>,
     state: &mut SessionState,
     buffer_size: usize,
     frame_signal: &Option<FrameSignal>,
@@ -719,7 +719,7 @@ async fn resend(
 async fn connect(
     client: &BasinClient,
     stream: &StreamName,
-    encryption: Option<&EncryptionConfig>,
+    encryption: Option<&EncryptionSpec>,
     buffer_size: usize,
     frame_signal: Option<FrameSignal>,
 ) -> Result<(mpsc::Sender<AppendInput>, Streaming<AppendAck>), AppendSessionError> {

--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 use crate::{
     api::{ApiError, BasinClient, retry_builder},
     retry::RetryBackoff,
-    types::{EncryptionConfig, MeteredBytes, ReadBatch, S2Error, StreamName},
+    types::{EncryptionSpec, MeteredBytes, ReadBatch, S2Error, StreamName},
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -43,7 +43,7 @@ pub type Streaming<R> = Pin<Box<dyn Send + futures::Stream<Item = Result<R, Read
 pub async fn read_session(
     client: BasinClient,
     name: StreamName,
-    encryption: Option<EncryptionConfig>,
+    encryption: Option<EncryptionSpec>,
     mut start: ReadStart,
     mut end: ReadEnd,
     ignore_command_records: bool,
@@ -153,7 +153,7 @@ pub async fn read_session(
 async fn session_inner(
     client: BasinClient,
     name: StreamName,
-    encryption: Option<EncryptionConfig>,
+    encryption: Option<EncryptionSpec>,
     start: ReadStart,
     end: ReadEnd,
     ignore_command_records: bool,

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -21,6 +21,8 @@ use s2_api::{v1 as api, v1::stream::s2s::CompressionAlgorithm};
 pub use s2_common::caps::RECORD_BATCH_MAX;
 /// Encryption algorithm.
 pub use s2_common::encryption::EncryptionAlgorithm;
+/// Encryption mode, including plaintext.
+pub use s2_common::encryption::EncryptionMode;
 /// Encryption spec for stream operations.
 pub use s2_common::encryption::EncryptionSpec;
 /// Validation error.

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -21,8 +21,8 @@ use s2_api::{v1 as api, v1::stream::s2s::CompressionAlgorithm};
 pub use s2_common::caps::RECORD_BATCH_MAX;
 /// Encryption algorithm.
 pub use s2_common::encryption::EncryptionAlgorithm;
-/// Encryption configuration for stream operations.
-pub use s2_common::encryption::EncryptionConfig;
+/// Encryption spec for stream operations.
+pub use s2_common::encryption::EncryptionSpec;
 /// Validation error.
 pub use s2_common::types::ValidationError;
 /// Access token ID.


### PR DESCRIPTION
Rename the per-request and header-carried encryption type from `EncryptionConfig` to `EncryptionSpec` across the common, API, SDK, CLI, and lite surfaces.

Also tighten the type model around encryption semantics:
- `EncryptionMode` now represents plain-aware semantics where `Option<EncryptionAlgorithm>` was acting as a disguised mode.
- decryption mismatches now use `ModeMismatch` with `EncryptionMode` values.
- `EncryptedRecordFormat` now represents the on-disk/on-wire encrypted record framing version plus algorithm, instead of overloading `EncryptionAlgorithm` with format-id responsibilities.
- `EncryptionAlgorithm` remains the pure ciphertext algorithm type.

Also clean up encryption error and record terminology:
- `EncryptionSpecError` now has structured parse and validation variants instead of a single stringly `InvalidSpec` bucket.
- user-facing mode mismatch errors now say `record encryption mode mismatch` instead of leaking `ciphertext` terminology for the full encrypted record.
- docs and test helpers now distinguish encoded encrypted records from ciphertext slices more precisely.

Testing:
- `cargo test -p s2-common encryption --lib`
- `cargo test -p s2-lite --lib sse_read_with_plain_header_emits_error_event_and_terminates`
- `cargo test -p s2-lite --lib s2s_read_with_plain_header_returns_terminal_invalid_frame`
