### PR TITLE
refactor: remove implicit optional config resolution

### DIFF
--- a/api/src/v1/config.rs
+++ b/api/src/v1/config.rs
@@ -300,10 +300,7 @@ pub struct EncryptionConfig {
 impl EncryptionConfig {
     pub fn to_opt(config: types::config::OptionalEncryptionConfig) -> Option<Self> {
         let config = EncryptionConfig {
-            allowed_modes: config
-                .allowed_modes
-                .map(|modes| modes.into_iter().map(Into::into).collect())
-                .unwrap_or_default(),
+            allowed_modes: config.allowed_modes.into_iter().map(Into::into).collect(),
         };
         if config == Self::default() {
             None
@@ -324,17 +321,11 @@ impl From<types::config::EncryptionConfig> for EncryptionConfig {
 impl From<EncryptionConfig> for types::config::OptionalEncryptionConfig {
     fn from(value: EncryptionConfig) -> Self {
         Self {
-            allowed_modes: if value.allowed_modes.is_empty() {
-                None
-            } else {
-                Some(
-                    value
-                        .allowed_modes
-                        .into_iter()
-                        .map(encryption::EncryptionMode::from)
-                        .collect(),
-                )
-            },
+            allowed_modes: value
+                .allowed_modes
+                .into_iter()
+                .map(encryption::EncryptionMode::from)
+                .collect(),
         }
     }
 }
@@ -833,7 +824,7 @@ mod tests {
             proptest::option::of(gen_timestamping_mode()),
             proptest::option::of(any::<bool>()),
             proptest::option::of(any::<u64>()),
-            proptest::option::of(gen_internal_encryption_modes()),
+            gen_internal_encryption_modes(),
         )
             .prop_map(|(sc, rp, ts_mode, ts_uncapped, doe, encryption)| {
                 types::config::OptionalStreamConfig {
@@ -930,11 +921,13 @@ mod tests {
             );
             prop_assert_eq!(
                 merged.encryption.allowed_modes,
-                stream
-                    .encryption
-                    .allowed_modes
-                    .or(basin.encryption.allowed_modes)
-                    .unwrap_or(types::config::DEFAULT_ALLOWED_ENCRYPTION_MODES)
+                if !stream.encryption.allowed_modes.is_empty() {
+                    stream.encryption.allowed_modes
+                } else if !basin.encryption.allowed_modes.is_empty() {
+                    basin.encryption.allowed_modes
+                } else {
+                    types::config::DEFAULT_ALLOWED_ENCRYPTION_MODES
+                }
             );
         }
 
@@ -967,7 +960,7 @@ mod tests {
             prop_assert!(result.timestamping.mode.is_none());
             prop_assert!(result.timestamping.uncapped.is_none());
             prop_assert!(result.delete_on_empty.min_age.is_none());
-            prop_assert!(result.encryption.allowed_modes.is_none());
+            prop_assert!(result.encryption.allowed_modes.is_empty());
         }
 
         #[test]
@@ -1164,8 +1157,8 @@ mod tests {
             "delete_on_empty.min_age should be None"
         );
         assert!(
-            internal.encryption.allowed_modes.is_none(),
-            "encryption.allowed_modes should be None"
+            internal.encryption.allowed_modes.is_empty(),
+            "encryption.allowed_modes should be empty"
         );
     }
 }

--- a/common/src/types/config.rs
+++ b/common/src/types/config.rs
@@ -250,22 +250,25 @@ impl From<OptionalDeleteOnEmptyConfig> for DeleteOnEmptyReconfiguration {
 
 #[derive(Debug, Clone, Default)]
 pub struct OptionalEncryptionConfig {
-    pub allowed_modes: Option<EnumSet<EncryptionMode>>,
+    pub allowed_modes: EnumSet<EncryptionMode>,
 }
 
 impl OptionalEncryptionConfig {
     pub fn reconfigure(mut self, reconfiguration: EncryptionReconfiguration) -> Self {
         if let Maybe::Specified(allowed_modes) = reconfiguration.allowed_modes {
-            self.allowed_modes = (!allowed_modes.is_empty()).then_some(allowed_modes);
+            self.allowed_modes = allowed_modes;
         }
         self
     }
 
     pub fn merge(self, basin_defaults: Self) -> EncryptionConfig {
-        let allowed_modes = self
-            .allowed_modes
-            .or(basin_defaults.allowed_modes)
-            .unwrap_or(DEFAULT_ALLOWED_ENCRYPTION_MODES);
+        let allowed_modes = if !self.allowed_modes.is_empty() {
+            self.allowed_modes
+        } else if !basin_defaults.allowed_modes.is_empty() {
+            basin_defaults.allowed_modes
+        } else {
+            DEFAULT_ALLOWED_ENCRYPTION_MODES
+        };
         EncryptionConfig { allowed_modes }
     }
 }
@@ -273,9 +276,7 @@ impl OptionalEncryptionConfig {
 impl From<OptionalEncryptionConfig> for EncryptionConfig {
     fn from(value: OptionalEncryptionConfig) -> Self {
         Self {
-            allowed_modes: value
-                .allowed_modes
-                .unwrap_or(DEFAULT_ALLOWED_ENCRYPTION_MODES),
+            allowed_modes: value.allowed_modes,
         }
     }
 }
@@ -283,7 +284,7 @@ impl From<OptionalEncryptionConfig> for EncryptionConfig {
 impl From<EncryptionConfig> for OptionalEncryptionConfig {
     fn from(value: EncryptionConfig) -> Self {
         Self {
-            allowed_modes: Some(value.allowed_modes),
+            allowed_modes: value.allowed_modes,
         }
     }
 }
@@ -291,7 +292,7 @@ impl From<EncryptionConfig> for OptionalEncryptionConfig {
 impl From<OptionalEncryptionConfig> for EncryptionReconfiguration {
     fn from(value: OptionalEncryptionConfig) -> Self {
         Self {
-            allowed_modes: Maybe::Specified(value.allowed_modes.unwrap_or_default()),
+            allowed_modes: Maybe::Specified(value.allowed_modes),
         }
     }
 }

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -234,11 +234,11 @@ impl Streamer {
                 match_seq_num,
             })?;
         }
-        let allowed_encryption_modes = self
-            .config
-            .encryption
-            .allowed_modes
-            .unwrap_or(DEFAULT_ALLOWED_ENCRYPTION_MODES);
+        let allowed_encryption_modes = if self.config.encryption.allowed_modes.is_empty() {
+            DEFAULT_ALLOWED_ENCRYPTION_MODES
+        } else {
+            self.config.encryption.allowed_modes
+        };
         sequenced_records(
             records,
             first_seq_num,

--- a/lite/src/backend/streams.rs
+++ b/lite/src/backend/streams.rs
@@ -404,18 +404,26 @@ impl Backend {
 }
 
 fn validate_encryption_modes_subset(
-    stream_modes: &Option<enumset::EnumSet<EncryptionMode>>,
-    basin_modes: Option<enumset::EnumSet<EncryptionMode>>,
+    stream_modes: &enumset::EnumSet<EncryptionMode>,
+    basin_modes: enumset::EnumSet<EncryptionMode>,
 ) -> Result<(), ValidationError> {
-    if let Some(stream_modes) = stream_modes {
-        let basin_modes = basin_modes.unwrap_or(DEFAULT_ALLOWED_ENCRYPTION_MODES);
-        if !stream_modes.is_subset(basin_modes) {
-            return Err(ValidationError(
-                "stream encryption_modes must be a subset of basin default encryption_modes"
-                    .to_owned(),
-            ));
-        }
+    if stream_modes.is_empty() {
+        return Ok(());
     }
+
+    let basin_modes = if basin_modes.is_empty() {
+        DEFAULT_ALLOWED_ENCRYPTION_MODES
+    } else {
+        basin_modes
+    };
+
+    if !stream_modes.is_subset(basin_modes) {
+        return Err(ValidationError(
+            "stream encryption modes must be a subset of the default encryption modes for the basin"
+                .to_owned(),
+        ));
+    }
+
     Ok(())
 }
 

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -503,14 +503,12 @@ mod tests {
         use s2_common::types::config::OptionalEncryptionConfig;
         OptionalStreamConfig {
             encryption: OptionalEncryptionConfig {
-                allowed_modes: Some(
-                    [
-                        EncryptionMode::Plain,
-                        EncryptionMode::Aegis256,
-                        EncryptionMode::Aes256Gcm,
-                    ]
-                    .into(),
-                ),
+                allowed_modes: [
+                    EncryptionMode::Plain,
+                    EncryptionMode::Aegis256,
+                    EncryptionMode::Aes256Gcm,
+                ]
+                .into(),
             },
             ..Default::default()
         }

--- a/lite/tests/backend/common/setup.rs
+++ b/lite/tests/backend/common/setup.rs
@@ -50,14 +50,12 @@ pub fn all_encryption_modes_stream_config() -> OptionalStreamConfig {
     use s2_common::types::config::OptionalEncryptionConfig;
     OptionalStreamConfig {
         encryption: OptionalEncryptionConfig {
-            allowed_modes: Some(
-                [
-                    EncryptionMode::Plain,
-                    EncryptionMode::Aegis256,
-                    EncryptionMode::Aes256Gcm,
-                ]
-                .into(),
-            ),
+            allowed_modes: [
+                EncryptionMode::Plain,
+                EncryptionMode::Aegis256,
+                EncryptionMode::Aes256Gcm,
+            ]
+            .into(),
         },
         ..Default::default()
     }
@@ -74,7 +72,7 @@ pub fn aegis_only_encryption_stream_config() -> OptionalStreamConfig {
     use s2_common::types::config::OptionalEncryptionConfig;
     OptionalStreamConfig {
         encryption: OptionalEncryptionConfig {
-            allowed_modes: Some([EncryptionMode::Aegis256].into()),
+            allowed_modes: [EncryptionMode::Aegis256].into(),
         },
         ..Default::default()
     }

--- a/lite/tests/backend/control_plane/stream.rs
+++ b/lite/tests/backend/control_plane/stream.rs
@@ -93,10 +93,8 @@ async fn test_create_stream_defaults_encryption_to_plaintext_only() {
         .await
         .expect("Failed to fetch stream config");
 
-    assert_eq!(
-        config.encryption.allowed_modes,
-        Some([EncryptionMode::Plain].into())
-    );
+    let expected_modes: enumset::EnumSet<EncryptionMode> = [EncryptionMode::Plain].into();
+    assert_eq!(config.encryption.allowed_modes, expected_modes);
 }
 
 #[tokio::test]
@@ -158,7 +156,7 @@ async fn test_reconfigure_stream_empty_encryption_uses_basin_defaults() {
     let basin_config = BasinConfig {
         default_stream_config: OptionalStreamConfig {
             encryption: OptionalEncryptionConfig {
-                allowed_modes: Some([EncryptionMode::Plain, EncryptionMode::Aegis256].into()),
+                allowed_modes: [EncryptionMode::Plain, EncryptionMode::Aegis256].into(),
             },
             ..Default::default()
         },
@@ -181,7 +179,7 @@ async fn test_reconfigure_stream_empty_encryption_uses_basin_defaults() {
             stream_name.clone(),
             OptionalStreamConfig {
                 encryption: OptionalEncryptionConfig {
-                    allowed_modes: Some([EncryptionMode::Plain].into()),
+                    allowed_modes: [EncryptionMode::Plain].into(),
                 },
                 ..Default::default()
             },
@@ -204,7 +202,8 @@ async fn test_reconfigure_stream_empty_encryption_uses_basin_defaults() {
         .await
         .expect("Failed to reconfigure stream");
 
-    let expected_modes = Some([EncryptionMode::Plain, EncryptionMode::Aegis256].into());
+    let expected_modes: enumset::EnumSet<EncryptionMode> =
+        [EncryptionMode::Plain, EncryptionMode::Aegis256].into();
     assert_eq!(updated.encryption.allowed_modes, expected_modes);
 
     let fetched = backend


### PR DESCRIPTION
## Summary
- make `OptionalEncryptionConfig.allowed_modes` a plain `EnumSet`
- remove implicit optional-to-concrete config conversions that silently resolved defaults
- keep default resolution explicit through `merge(...)` call sites and aligned tests

## Testing
- `just test`