### PR TITLE
feat: add `DecryptionFailed` error code

### DIFF
--- a/api/src/v1/error.rs
+++ b/api/src/v1/error.rs
@@ -29,6 +29,7 @@ pub enum ErrorCode {
     BasinDeletionPending,
     BasinNotFound,
     ClientHangup,
+    DecryptionFailed,
     HotServer,
     Invalid,
     Other,
@@ -49,7 +50,8 @@ impl ErrorCode {
     pub fn status(self) -> http::StatusCode {
         match self {
             Self::Authn => http::StatusCode::UNAUTHORIZED,
-            Self::BadFrame
+            Self::DecryptionFailed
+            | Self::BadFrame
             | Self::BadHeader
             | Self::BadJson
             | Self::BadPath

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -97,9 +97,11 @@ impl ServiceError {
             },
             ServiceError::Validation(e) => standard(ErrorCode::Invalid, e.to_string()),
             ServiceError::RecordDecryption(e) => match e {
-                RecordDecryptionError::ModeMismatch { .. }
-                | RecordDecryptionError::AuthenticationFailed => {
+                RecordDecryptionError::ModeMismatch { .. } => {
                     standard(ErrorCode::Invalid, e.to_string())
+                }
+                RecordDecryptionError::AuthenticationFailed => {
+                    standard(ErrorCode::DecryptionFailed, e.to_string())
                 }
                 RecordDecryptionError::MalformedEncryptedRecord
                 | RecordDecryptionError::MeteredSizeMismatch { .. }

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -735,7 +735,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unary_read_with_wrong_key_returns_invalid_error() {
+    async fn unary_read_with_wrong_key_returns_decryption_failed_error() {
         let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let wrong_key = EncryptionSpec::aegis256([0x24; 32]);
         let (app, backend, basin, stream) = setup_app_with_config(
@@ -755,9 +755,13 @@ mod tests {
         )
         .await;
 
-        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let info = response_json(response, "read error body").await;
-        assert_invalid_error(&info, "record decryption failed");
+        assert_eq!(info["code"], "decryption_failed");
+        assert!(info["message"]
+            .as_str()
+            .expect("error message string")
+            .contains("record decryption failed"));
     }
 
     #[tokio::test]

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -758,10 +758,12 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let info = response_json(response, "read error body").await;
         assert_eq!(info["code"], "decryption_failed");
-        assert!(info["message"]
-            .as_str()
-            .expect("error message string")
-            .contains("record decryption failed"));
+        assert!(
+            info["message"]
+                .as_str()
+                .expect("error message string")
+                .contains("record decryption failed")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Introduces a new `DecryptionFailed` error code (HTTP 400) to distinguish AEAD authentication failures (wrong encryption key) from other validation errors on the read path.
- `RecordDecryptionError::ModeMismatch` remains mapped to `Invalid` (422); `AuthenticationFailed` now maps to `DecryptionFailed` (400).
- Updates handler tests to assert the new error code.

## Test plan
- [x] `unary_read_with_wrong_key_returns_decryption_failed_error` — verifies 400 status and `decryption_failed` code
- [x] Existing mode mismatch tests (`sse_read_with_plain_header_emits_error_event_and_terminates`, `s2s_read_with_plain_header_returns_terminal_invalid_frame`) still pass with `Invalid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)