### PR TITLE
fix(cli): render Duration fields with humantime in config output

### DIFF
--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -203,7 +203,7 @@ pub struct TimestampingConfig {
 #[derive(Clone, Debug, Serialize)]
 pub enum RetentionPolicy {
     #[allow(dead_code)]
-    Age(Duration),
+    Age(#[serde(serialize_with = "serialize_duration_as_secs")] Duration),
     Infinite,
 }
 
@@ -231,6 +231,7 @@ impl FromStr for RetentionPolicy {
 #[derive(Args, Clone, Debug, Serialize)]
 pub struct DeleteOnEmptyConfig {
     #[arg(long, value_parser = humantime::parse_duration, required = false)]
+    #[serde(serialize_with = "serialize_duration_as_secs")]
     /// Minimum age before an empty stream can be deleted.
     /// Example: 1d, 1w, 1y
     pub delete_on_empty_min_age: Duration,
@@ -490,6 +491,13 @@ where
     S: serde::Serializer,
 {
     serializer.serialize_str(&value.to_string())
+}
+
+fn serialize_duration_as_secs<S>(value: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_u64(value.as_secs())
 }
 
 impl FromStr for BasinMatcher {

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -203,7 +203,7 @@ pub struct TimestampingConfig {
 #[derive(Clone, Debug, Serialize)]
 pub enum RetentionPolicy {
     #[allow(dead_code)]
-    Age(#[serde(serialize_with = "serialize_duration_as_secs")] Duration),
+    Age(#[serde(serialize_with = "serialize_duration_humantime")] Duration),
     Infinite,
 }
 
@@ -231,7 +231,7 @@ impl FromStr for RetentionPolicy {
 #[derive(Args, Clone, Debug, Serialize)]
 pub struct DeleteOnEmptyConfig {
     #[arg(long, value_parser = humantime::parse_duration, required = false)]
-    #[serde(serialize_with = "serialize_duration_as_secs")]
+    #[serde(serialize_with = "serialize_duration_humantime")]
     /// Minimum age before an empty stream can be deleted.
     /// Example: 1d, 1w, 1y
     pub delete_on_empty_min_age: Duration,
@@ -493,11 +493,11 @@ where
     serializer.serialize_str(&value.to_string())
 }
 
-fn serialize_duration_as_secs<S>(value: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_duration_humantime<S>(value: &Duration, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
-    serializer.serialize_u64(value.as_secs())
+    serializer.serialize_str(&humantime::format_duration(*value).to_string())
 }
 
 impl FromStr for BasinMatcher {


### PR DESCRIPTION
## Summary
- `get-basin-config` and `get-stream-config` currently render `Duration` fields (retention policy age, delete-on-empty min age) as `{secs, nanos}`, which is disconcerting
- Add a `serialize_duration_humantime` serde helper and apply it to `RetentionPolicy::Age` and `DeleteOnEmptyConfig::delete_on_empty_min_age` so they render as a humantime string (e.g. `"1day"`, `"1h 30m"`)
- Units are explicit and the output round-trips with the humantime format already accepted on input

## Test plan
- [x] `cargo build -p s2-cli`
- [x] `s2 get-basin-config <basin>` — confirm retention + delete-on-empty render as humantime strings
- [x] `s2 get-stream-config s2://<basin>/<stream>` — same check

🤖 Generated with [Claude Code](https://claude.com/claude-code)