### PR TITLE
fix: dashed string repr for AEGIS-256 and AES-256-GCM modes

### DIFF
--- a/api/src/v1/config.rs
+++ b/api/src/v1/config.rs
@@ -257,13 +257,15 @@ impl From<types::config::DeleteOnEmptyReconfiguration> for DeleteOnEmptyReconfig
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[serde(rename_all = "kebab-case")]
 pub enum EncryptionMode {
     /// Plaintext (no encryption).
+    #[serde(rename = "plain")]
     Plain,
     /// AEGIS-256 authenticated encryption.
+    #[serde(rename = "aegis-256")]
     Aegis256,
     /// AES-256-GCM authenticated encryption.
+    #[serde(rename = "aes-256-gcm")]
     Aes256Gcm,
 }
 

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -43,13 +43,17 @@ pub enum EncryptionAlgorithm {
 #[strum(ascii_case_insensitive)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[enumset(no_super_impls)]
-#[serde(rename_all = "kebab-case")]
 pub enum EncryptionMode {
     #[strum(serialize = "plain")]
+    #[serde(rename = "plain")]
     Plain,
     #[strum(serialize = "aegis-256")]
+    #[serde(rename = "aegis-256")]
+    #[cfg_attr(feature = "clap", value(name = "aegis-256"))]
     Aegis256,
     #[strum(serialize = "aes-256-gcm")]
+    #[serde(rename = "aes-256-gcm")]
+    #[cfg_attr(feature = "clap", value(name = "aes-256-gcm"))]
     Aes256Gcm,
 }
 
@@ -328,6 +332,25 @@ mod tests {
             EncryptionSpec::aes256_gcm(KEY_BYTES).mode(),
             EncryptionMode::Aes256Gcm
         );
+    }
+
+    #[rstest]
+    #[case(EncryptionMode::Plain, "\"plain\"")]
+    #[case(EncryptionMode::Aegis256, "\"aegis-256\"")]
+    #[case(EncryptionMode::Aes256Gcm, "\"aes-256-gcm\"")]
+    fn mode_serde_roundtrip(#[case] mode: EncryptionMode, #[case] expected: &str) {
+        let serialized = serde_json::to_string(&mode).unwrap();
+        assert_eq!(serialized, expected);
+        let deserialized: EncryptionMode = serde_json::from_str(expected).unwrap();
+        assert_eq!(deserialized, mode);
+    }
+
+    #[rstest]
+    #[case(EncryptionMode::Plain, "plain")]
+    #[case(EncryptionMode::Aegis256, "aegis-256")]
+    #[case(EncryptionMode::Aes256Gcm, "aes-256-gcm")]
+    fn mode_display_matches_spec(#[case] mode: EncryptionMode, #[case] expected: &str) {
+        assert_eq!(mode.to_string(), expected);
     }
 
     #[rstest]

--- a/lite/src/init.rs
+++ b/lite/src/init.rs
@@ -110,10 +110,12 @@ impl From<StorageClassSpec> for StorageClass {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case")]
 pub enum EncryptionModeSpec {
+    #[serde(rename = "plain")]
     Plain,
+    #[serde(rename = "aegis-256")]
     Aegis256,
+    #[serde(rename = "aes-256-gcm")]
     Aes256Gcm,
 }
 


### PR DESCRIPTION
## Summary
- `serde(rename_all = \"kebab-case\")` and clap's default `ValueEnum` renaming don't insert a dash between letters and digits, so `Aegis256` / `Aes256Gcm` were emitted as `aegis256` / `aes256-gcm` on the wire and in CLI help.
- `EncryptionModeSpec` in `lite/src/init.rs` compounded this: its hand-written JSON schema advertised the dashed values while its deserializer expected the undashed ones.
- Fixed by adding explicit per-variant `#[serde(rename = ...)]` and `#[value(name = ...)]` attributes so Display, serde, clap, and the declared schema all agree on `aegis-256` and `aes-256-gcm`.
- Added serde roundtrip and Display regression tests in `common/src/encryption.rs`.

## Test plan
- [x] `just fmt`
- [x] `just test` (475/475 pass, including new `mode_serde_roundtrip` and `mode_display_matches_spec` cases)
- [x] Verified `s2 create-stream --help` now lists `plain, aegis-256, aes-256-gcm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)