### PR TITLE
refactor!: replace encryption modes with stream cipher metadata and key-only headers

### DIFF
--- a/api/src/data.rs
+++ b/api/src/data.rs
@@ -101,10 +101,10 @@ pub struct S2FormatHeader {
 #[cfg_attr(feature = "utoipa", derive(utoipa::IntoParams))]
 #[cfg_attr(feature = "utoipa", into_params(parameter_in = Header))]
 pub struct S2EncryptionHeader {
-    /// Optional per-request encryption spec for append/read operations.
-    /// Use `plain` for plaintext, or `<alg>; <base64-key>` where `<alg>` is `aegis-256` or `aes-256-gcm`.
-    #[cfg_attr(feature = "utoipa", param(required = false, rename = "s2-encryption", value_type = String))]
-    pub s2_encryption: String,
+    /// Optional per-request encryption key for append/read operations.
+    /// When stream encryption is enabled, provide a 32-byte symmetric key encoded as Base64.
+    #[cfg_attr(feature = "utoipa", param(required = false, rename = "s2-encryption-key", value_type = String))]
+    pub s2_encryption_key: String,
 }
 
 #[cfg(feature = "axum")]

--- a/api/src/data.rs
+++ b/api/src/data.rs
@@ -101,7 +101,7 @@ pub struct S2FormatHeader {
 #[cfg_attr(feature = "utoipa", derive(utoipa::IntoParams))]
 #[cfg_attr(feature = "utoipa", into_params(parameter_in = Header))]
 pub struct S2EncryptionKeyHeader {
-    /// Optional per-request encryption key material for append/read operations.
+    /// Optional customer-supplied encryption key material for append/read operations.
     /// When stream encryption is enabled, provide Base64-encoded key material.
     #[cfg_attr(feature = "utoipa", param(required = false, rename = "s2-encryption-key", value_type = String))]
     pub s2_encryption_key: String,

--- a/api/src/data.rs
+++ b/api/src/data.rs
@@ -100,9 +100,9 @@ pub struct S2FormatHeader {
 #[derive(Debug)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::IntoParams))]
 #[cfg_attr(feature = "utoipa", into_params(parameter_in = Header))]
-pub struct S2EncryptionHeader {
-    /// Optional per-request encryption key for append/read operations.
-    /// When stream encryption is enabled, provide a 32-byte symmetric key encoded as Base64.
+pub struct S2EncryptionKeyHeader {
+    /// Optional per-request encryption key material for append/read operations.
+    /// When stream encryption is enabled, provide Base64-encoded key material.
     #[cfg_attr(feature = "utoipa", param(required = false, rename = "s2-encryption-key", value_type = String))]
     pub s2_encryption_key: String,
 }

--- a/api/src/v1/config.rs
+++ b/api/src/v1/config.rs
@@ -433,7 +433,7 @@ impl From<types::config::StreamReconfiguration> for StreamReconfiguration {
 pub struct BasinConfig {
     /// Default stream configuration.
     pub default_stream_config: Option<StreamConfig>,
-    /// Encryption algorithm to apply to newly created streams in the basin.
+    /// Cipher to apply to newly created streams in the basin.
     pub stream_cipher: Option<EncryptionAlgorithm>,
     /// Create stream on append if it doesn't exist, using the default stream configuration.
     #[serde(default)]
@@ -494,7 +494,7 @@ pub struct BasinReconfiguration {
     #[serde(default, skip_serializing_if = "Maybe::is_unspecified")]
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<StreamReconfiguration>))]
     pub default_stream_config: Maybe<Option<StreamReconfiguration>>,
-    /// Encryption algorithm to apply to newly created streams in the basin.
+    /// Cipher to apply to newly created streams in the basin.
     #[serde(default, skip_serializing_if = "Maybe::is_unspecified")]
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<EncryptionAlgorithm>))]
     pub stream_cipher: Maybe<Option<EncryptionAlgorithm>>,

--- a/api/src/v1/config.rs
+++ b/api/src/v1/config.rs
@@ -257,10 +257,7 @@ impl From<types::config::DeleteOnEmptyReconfiguration> for DeleteOnEmptyReconfig
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-pub enum EncryptionMode {
-    /// Plaintext (no encryption).
-    #[serde(rename = "plain")]
-    Plain,
+pub enum EncryptionAlgorithm {
     /// AEGIS-256 authenticated encryption.
     #[serde(rename = "aegis-256")]
     Aegis256,
@@ -269,99 +266,20 @@ pub enum EncryptionMode {
     Aes256Gcm,
 }
 
-impl From<EncryptionMode> for encryption::EncryptionMode {
-    fn from(value: EncryptionMode) -> Self {
+impl From<EncryptionAlgorithm> for encryption::EncryptionAlgorithm {
+    fn from(value: EncryptionAlgorithm) -> Self {
         match value {
-            EncryptionMode::Plain => Self::Plain,
-            EncryptionMode::Aegis256 => Self::Aegis256,
-            EncryptionMode::Aes256Gcm => Self::Aes256Gcm,
+            EncryptionAlgorithm::Aegis256 => Self::Aegis256,
+            EncryptionAlgorithm::Aes256Gcm => Self::Aes256Gcm,
         }
     }
 }
 
-impl From<encryption::EncryptionMode> for EncryptionMode {
-    fn from(value: encryption::EncryptionMode) -> Self {
+impl From<encryption::EncryptionAlgorithm> for EncryptionAlgorithm {
+    fn from(value: encryption::EncryptionAlgorithm) -> Self {
         match value {
-            encryption::EncryptionMode::Plain => Self::Plain,
-            encryption::EncryptionMode::Aegis256 => Self::Aegis256,
-            encryption::EncryptionMode::Aes256Gcm => Self::Aes256Gcm,
-        }
-    }
-}
-
-#[rustfmt::skip]
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-pub struct EncryptionConfig {
-    /// Allowed encryption modes for the stream.
-    /// If empty, use defaults. If no default is configured, only plaintext is allowed.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub allowed_modes: Vec<EncryptionMode>,
-}
-
-impl EncryptionConfig {
-    pub fn to_opt(config: types::config::OptionalEncryptionConfig) -> Option<Self> {
-        let config = EncryptionConfig {
-            allowed_modes: config.allowed_modes.into_iter().map(Into::into).collect(),
-        };
-        if config == Self::default() {
-            None
-        } else {
-            Some(config)
-        }
-    }
-}
-
-impl From<types::config::EncryptionConfig> for EncryptionConfig {
-    fn from(value: types::config::EncryptionConfig) -> Self {
-        Self {
-            allowed_modes: value.allowed_modes.into_iter().map(Into::into).collect(),
-        }
-    }
-}
-
-impl From<EncryptionConfig> for types::config::OptionalEncryptionConfig {
-    fn from(value: EncryptionConfig) -> Self {
-        Self {
-            allowed_modes: value
-                .allowed_modes
-                .into_iter()
-                .map(encryption::EncryptionMode::from)
-                .collect(),
-        }
-    }
-}
-
-#[rustfmt::skip]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-pub struct EncryptionReconfiguration {
-    /// Allowed encryption modes for the stream.
-    /// Specify an empty list to reset to defaults.
-    #[serde(default, skip_serializing_if = "Maybe::is_unspecified")]
-    #[cfg_attr(feature = "utoipa", schema(value_type = Option<Vec<EncryptionMode>>))]
-    pub allowed_modes: Maybe<Vec<EncryptionMode>>,
-}
-
-impl From<EncryptionReconfiguration> for types::config::EncryptionReconfiguration {
-    fn from(value: EncryptionReconfiguration) -> Self {
-        Self {
-            allowed_modes: value.allowed_modes.map(|modes| {
-                modes
-                    .into_iter()
-                    .map(encryption::EncryptionMode::from)
-                    .collect()
-            }),
-        }
-    }
-}
-
-impl From<types::config::EncryptionReconfiguration> for EncryptionReconfiguration {
-    fn from(value: types::config::EncryptionReconfiguration) -> Self {
-        Self {
-            allowed_modes: value
-                .allowed_modes
-                .map(|modes| modes.into_iter().map(Into::into).collect()),
+            encryption::EncryptionAlgorithm::Aegis256 => Self::Aegis256,
+            encryption::EncryptionAlgorithm::Aes256Gcm => Self::Aes256Gcm,
         }
     }
 }
@@ -380,9 +298,6 @@ pub struct StreamConfig {
     /// Delete-on-empty configuration.
     #[serde(default)]
     pub delete_on_empty: Option<DeleteOnEmptyConfig>,
-    /// Encryption configuration.
-    #[serde(default)]
-    pub encryption: Option<EncryptionConfig>,
 }
 
 impl StreamConfig {
@@ -392,7 +307,6 @@ impl StreamConfig {
             retention_policy,
             timestamping,
             delete_on_empty,
-            encryption,
         } = config;
 
         let config = StreamConfig {
@@ -400,7 +314,6 @@ impl StreamConfig {
             retention_policy: retention_policy.map(Into::into),
             timestamping: TimestampingConfig::to_opt(timestamping),
             delete_on_empty: DeleteOnEmptyConfig::to_opt(delete_on_empty),
-            encryption: EncryptionConfig::to_opt(encryption),
         };
         if config == Self::default() {
             None
@@ -417,7 +330,6 @@ impl From<types::config::StreamConfig> for StreamConfig {
             retention_policy,
             timestamping,
             delete_on_empty,
-            encryption,
         } = value;
 
         Self {
@@ -425,7 +337,6 @@ impl From<types::config::StreamConfig> for StreamConfig {
             retention_policy: Some(retention_policy.into()),
             timestamping: Some(timestamping.into()),
             delete_on_empty: Some(delete_on_empty.into()),
-            encryption: Some(encryption.into()),
         }
     }
 }
@@ -439,7 +350,6 @@ impl TryFrom<StreamConfig> for types::config::OptionalStreamConfig {
             retention_policy,
             timestamping,
             delete_on_empty,
-            encryption,
         } = value;
 
         let retention_policy = match retention_policy {
@@ -452,7 +362,6 @@ impl TryFrom<StreamConfig> for types::config::OptionalStreamConfig {
             retention_policy,
             timestamping: timestamping.map(Into::into).unwrap_or_default(),
             delete_on_empty: delete_on_empty.map(Into::into).unwrap_or_default(),
-            encryption: encryption.map(Into::into).unwrap_or_default(),
         })
     }
 }
@@ -478,10 +387,6 @@ pub struct StreamReconfiguration {
     #[serde(default, skip_serializing_if = "Maybe::is_unspecified")]
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<DeleteOnEmptyReconfiguration>))]
     pub delete_on_empty: Maybe<Option<DeleteOnEmptyReconfiguration>>,
-    /// Encryption configuration.
-    #[serde(default, skip_serializing_if = "Maybe::is_unspecified")]
-    #[cfg_attr(feature = "utoipa", schema(value_type = Option<EncryptionReconfiguration>))]
-    pub encryption: Maybe<Option<EncryptionReconfiguration>>,
 }
 
 impl TryFrom<StreamReconfiguration> for types::config::StreamReconfiguration {
@@ -493,7 +398,6 @@ impl TryFrom<StreamReconfiguration> for types::config::StreamReconfiguration {
             retention_policy,
             timestamping,
             delete_on_empty,
-            encryption,
         } = value;
 
         Ok(Self {
@@ -501,7 +405,6 @@ impl TryFrom<StreamReconfiguration> for types::config::StreamReconfiguration {
             retention_policy: retention_policy.try_map_opt(TryInto::try_into)?,
             timestamping: timestamping.map_opt(Into::into),
             delete_on_empty: delete_on_empty.map_opt(Into::into),
-            encryption: encryption.map_opt(Into::into),
         })
     }
 }
@@ -513,7 +416,6 @@ impl From<types::config::StreamReconfiguration> for StreamReconfiguration {
             retention_policy,
             timestamping,
             delete_on_empty,
-            encryption,
         } = value;
 
         Self {
@@ -521,7 +423,6 @@ impl From<types::config::StreamReconfiguration> for StreamReconfiguration {
             retention_policy: retention_policy.map_opt(Into::into),
             timestamping: timestamping.map_opt(Into::into),
             delete_on_empty: delete_on_empty.map_opt(Into::into),
-            encryption: encryption.map_opt(Into::into),
         }
     }
 }
@@ -532,6 +433,8 @@ impl From<types::config::StreamReconfiguration> for StreamReconfiguration {
 pub struct BasinConfig {
     /// Default stream configuration.
     pub default_stream_config: Option<StreamConfig>,
+    /// Encryption algorithm materialized into streams created in the basin.
+    pub stream_encryption_algorithm: Option<EncryptionAlgorithm>,
     /// Create stream on append if it doesn't exist, using the default stream configuration.
     #[serde(default)]
     #[cfg_attr(feature = "utoipa", schema(default = false))]
@@ -548,6 +451,7 @@ impl TryFrom<BasinConfig> for types::config::BasinConfig {
     fn try_from(value: BasinConfig) -> Result<Self, Self::Error> {
         let BasinConfig {
             default_stream_config,
+            stream_encryption_algorithm,
             create_stream_on_append,
             create_stream_on_read,
         } = value;
@@ -557,6 +461,7 @@ impl TryFrom<BasinConfig> for types::config::BasinConfig {
                 Some(config) => config.try_into()?,
                 None => Default::default(),
             },
+            stream_encryption_algorithm: stream_encryption_algorithm.map(Into::into),
             create_stream_on_append,
             create_stream_on_read,
         })
@@ -567,12 +472,14 @@ impl From<types::config::BasinConfig> for BasinConfig {
     fn from(value: types::config::BasinConfig) -> Self {
         let types::config::BasinConfig {
             default_stream_config,
+            stream_encryption_algorithm,
             create_stream_on_append,
             create_stream_on_read,
         } = value;
 
         Self {
             default_stream_config: StreamConfig::to_opt(default_stream_config),
+            stream_encryption_algorithm: stream_encryption_algorithm.map(Into::into),
             create_stream_on_append,
             create_stream_on_read,
         }
@@ -587,6 +494,10 @@ pub struct BasinReconfiguration {
     #[serde(default, skip_serializing_if = "Maybe::is_unspecified")]
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<StreamReconfiguration>))]
     pub default_stream_config: Maybe<Option<StreamReconfiguration>>,
+    /// Encryption algorithm materialized into newly created streams in the basin.
+    #[serde(default, skip_serializing_if = "Maybe::is_unspecified")]
+    #[cfg_attr(feature = "utoipa", schema(value_type = Option<EncryptionAlgorithm>))]
+    pub stream_encryption_algorithm: Maybe<Option<EncryptionAlgorithm>>,
     /// Create a stream on append.
     #[serde(default, skip_serializing_if = "Maybe::is_unspecified")]
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<bool>))]
@@ -603,12 +514,14 @@ impl TryFrom<BasinReconfiguration> for types::config::BasinReconfiguration {
     fn try_from(value: BasinReconfiguration) -> Result<Self, Self::Error> {
         let BasinReconfiguration {
             default_stream_config,
+            stream_encryption_algorithm,
             create_stream_on_append,
             create_stream_on_read,
         } = value;
 
         Ok(Self {
             default_stream_config: default_stream_config.try_map_opt(TryInto::try_into)?,
+            stream_encryption_algorithm: stream_encryption_algorithm.map_opt(Into::into),
             create_stream_on_append: create_stream_on_append.map(Into::into),
             create_stream_on_read: create_stream_on_read.map(Into::into),
         })
@@ -619,12 +532,14 @@ impl From<types::config::BasinReconfiguration> for BasinReconfiguration {
     fn from(value: types::config::BasinReconfiguration) -> Self {
         let types::config::BasinReconfiguration {
             default_stream_config,
+            stream_encryption_algorithm,
             create_stream_on_append,
             create_stream_on_read,
         } = value;
 
         Self {
             default_stream_config: default_stream_config.map_opt(Into::into),
+            stream_encryption_algorithm: stream_encryption_algorithm.map_opt(Into::into),
             create_stream_on_append: create_stream_on_append.map(Into::into),
             create_stream_on_read: create_stream_on_read.map(Into::into),
         }
@@ -668,51 +583,11 @@ mod tests {
         any::<u64>().prop_map(|min_age_secs| DeleteOnEmptyConfig { min_age_secs })
     }
 
-    fn gen_encryption_mode() -> impl Strategy<Value = EncryptionMode> {
+    fn gen_encryption_algorithm() -> impl Strategy<Value = EncryptionAlgorithm> {
         prop_oneof![
-            Just(EncryptionMode::Plain),
-            Just(EncryptionMode::Aegis256),
-            Just(EncryptionMode::Aes256Gcm),
+            Just(EncryptionAlgorithm::Aegis256),
+            Just(EncryptionAlgorithm::Aes256Gcm),
         ]
-    }
-
-    fn gen_encryption_config() -> impl Strategy<Value = EncryptionConfig> {
-        (any::<bool>(), any::<bool>(), any::<bool>()).prop_map(|(plain, aegis, aes)| {
-            let allowed_modes = [
-                (plain, EncryptionMode::Plain),
-                (aegis, EncryptionMode::Aegis256),
-                (aes, EncryptionMode::Aes256Gcm),
-            ]
-            .into_iter()
-            .filter_map(|(include, mode)| include.then_some(mode))
-            .collect();
-            EncryptionConfig { allowed_modes }
-        })
-    }
-
-    fn gen_encryption_reconfiguration() -> impl Strategy<Value = EncryptionReconfiguration> {
-        prop_oneof![
-            Just(Maybe::Unspecified),
-            proptest::collection::vec(gen_encryption_mode(), 0..=3).prop_map(Maybe::Specified),
-        ]
-        .prop_map(|allowed_modes| EncryptionReconfiguration { allowed_modes })
-    }
-
-    fn gen_internal_encryption_modes()
-    -> impl Strategy<Value = enumset::EnumSet<encryption::EncryptionMode>> {
-        (any::<bool>(), any::<bool>(), any::<bool>()).prop_map(|(plain, aegis, aes)| {
-            let mut allowed_modes = enumset::EnumSet::new();
-            if plain {
-                allowed_modes.insert(encryption::EncryptionMode::Plain);
-            }
-            if aegis {
-                allowed_modes.insert(encryption::EncryptionMode::Aegis256);
-            }
-            if aes {
-                allowed_modes.insert(encryption::EncryptionMode::Aes256Gcm);
-            }
-            allowed_modes
-        })
     }
 
     fn gen_stream_config() -> impl Strategy<Value = StreamConfig> {
@@ -721,17 +596,13 @@ mod tests {
             proptest::option::of(gen_retention_policy()),
             proptest::option::of(gen_timestamping_config()),
             proptest::option::of(gen_delete_on_empty_config()),
-            proptest::option::of(gen_encryption_config()),
         )
             .prop_map(
-                |(storage_class, retention_policy, timestamping, delete_on_empty, encryption)| {
-                    StreamConfig {
-                        storage_class,
-                        retention_policy,
-                        timestamping,
-                        delete_on_empty,
-                        encryption,
-                    }
+                |(storage_class, retention_policy, timestamping, delete_on_empty)| StreamConfig {
+                    storage_class,
+                    retention_policy,
+                    timestamping,
+                    delete_on_empty,
                 },
             )
     }
@@ -739,13 +610,20 @@ mod tests {
     fn gen_basin_config() -> impl Strategy<Value = BasinConfig> {
         (
             proptest::option::of(gen_stream_config()),
+            proptest::option::of(gen_encryption_algorithm()),
             any::<bool>(),
             any::<bool>(),
         )
             .prop_map(
-                |(default_stream_config, create_stream_on_append, create_stream_on_read)| {
+                |(
+                    default_stream_config,
+                    stream_encryption_algorithm,
+                    create_stream_on_append,
+                    create_stream_on_read,
+                )| {
                     BasinConfig {
                         default_stream_config,
+                        stream_encryption_algorithm,
                         create_stream_on_append,
                         create_stream_on_read,
                     }
@@ -769,16 +647,14 @@ mod tests {
             gen_maybe(gen_retention_policy()),
             gen_maybe(gen_timestamping_reconfiguration()),
             gen_maybe(gen_delete_on_empty_reconfiguration()),
-            gen_maybe(gen_encryption_reconfiguration()),
         )
             .prop_map(
-                |(storage_class, retention_policy, timestamping, delete_on_empty, encryption)| {
+                |(storage_class, retention_policy, timestamping, delete_on_empty)| {
                     StreamReconfiguration {
                         storage_class,
                         retention_policy,
                         timestamping,
                         delete_on_empty,
-                        encryption,
                     }
                 },
             )
@@ -798,6 +674,7 @@ mod tests {
     fn gen_basin_reconfiguration() -> impl Strategy<Value = BasinReconfiguration> {
         (
             gen_maybe(gen_stream_reconfiguration()),
+            gen_maybe(gen_encryption_algorithm()),
             prop_oneof![
                 Just(Maybe::Unspecified),
                 any::<bool>().prop_map(Maybe::Specified),
@@ -808,12 +685,16 @@ mod tests {
             ],
         )
             .prop_map(
-                |(default_stream_config, create_stream_on_append, create_stream_on_read)| {
-                    BasinReconfiguration {
-                        default_stream_config,
-                        create_stream_on_append,
-                        create_stream_on_read,
-                    }
+                |(
+                    default_stream_config,
+                    stream_encryption_algorithm,
+                    create_stream_on_append,
+                    create_stream_on_read,
+                )| BasinReconfiguration {
+                    default_stream_config,
+                    stream_encryption_algorithm,
+                    create_stream_on_append,
+                    create_stream_on_read,
                 },
             )
     }
@@ -826,9 +707,8 @@ mod tests {
             proptest::option::of(gen_timestamping_mode()),
             proptest::option::of(any::<bool>()),
             proptest::option::of(any::<u64>()),
-            gen_internal_encryption_modes(),
         )
-            .prop_map(|(sc, rp, ts_mode, ts_uncapped, doe, encryption)| {
+            .prop_map(|(sc, rp, ts_mode, ts_uncapped, doe)| {
                 types::config::OptionalStreamConfig {
                     storage_class: sc.map(Into::into),
                     retention_policy: rp.map(|rp| match rp {
@@ -843,9 +723,6 @@ mod tests {
                     },
                     delete_on_empty: types::config::OptionalDeleteOnEmptyConfig {
                         min_age: doe.map(Duration::from_secs),
-                    },
-                    encryption: types::config::OptionalEncryptionConfig {
-                        allowed_modes: encryption,
                     },
                 }
             })
@@ -921,16 +798,6 @@ mod tests {
                 merged.delete_on_empty.min_age,
                 stream.delete_on_empty.min_age.or(basin.delete_on_empty.min_age).unwrap_or_default()
             );
-            prop_assert_eq!(
-                merged.encryption.allowed_modes,
-                if !stream.encryption.allowed_modes.is_empty() {
-                    stream.encryption.allowed_modes
-                } else if !basin.encryption.allowed_modes.is_empty() {
-                    basin.encryption.allowed_modes
-                } else {
-                    types::config::DEFAULT_ALLOWED_ENCRYPTION_MODES
-                }
-            );
         }
 
         #[test]
@@ -943,7 +810,6 @@ mod tests {
             prop_assert_eq!(result.timestamping.mode, base.timestamping.mode);
             prop_assert_eq!(result.timestamping.uncapped, base.timestamping.uncapped);
             prop_assert_eq!(result.delete_on_empty.min_age, base.delete_on_empty.min_age);
-            prop_assert_eq!(result.encryption.allowed_modes, base.encryption.allowed_modes);
         }
 
         #[test]
@@ -953,7 +819,6 @@ mod tests {
                 retention_policy: Maybe::Specified(None),
                 timestamping: Maybe::Specified(None),
                 delete_on_empty: Maybe::Specified(None),
-                encryption: Maybe::Specified(None),
             };
             let result = base.reconfigure(reconfig);
 
@@ -962,7 +827,6 @@ mod tests {
             prop_assert!(result.timestamping.mode.is_none());
             prop_assert!(result.timestamping.uncapped.is_none());
             prop_assert!(result.delete_on_empty.min_age.is_none());
-            prop_assert!(result.encryption.allowed_modes.is_empty());
         }
 
         #[test]
@@ -1037,6 +901,7 @@ mod tests {
         #[test]
         fn reconfigure_basin_unspecified_preserves(
             base_sc in proptest::option::of(gen_storage_class()),
+            base_algorithm in proptest::option::of(gen_encryption_algorithm()),
             base_on_append in any::<bool>(),
             base_on_read in any::<bool>(),
         ) {
@@ -1045,6 +910,7 @@ mod tests {
                     storage_class: base_sc.map(Into::into),
                     ..Default::default()
                 },
+                stream_encryption_algorithm: base_algorithm.map(Into::into),
                 create_stream_on_append: base_on_append,
                 create_stream_on_read: base_on_read,
             };
@@ -1053,6 +919,7 @@ mod tests {
             let result = base.clone().reconfigure(reconfig);
 
             prop_assert_eq!(result.default_stream_config.storage_class, base.default_stream_config.storage_class);
+            prop_assert_eq!(result.stream_encryption_algorithm, base.stream_encryption_algorithm);
             prop_assert_eq!(result.create_stream_on_append, base.create_stream_on_append);
             prop_assert_eq!(result.create_stream_on_read, base.create_stream_on_read);
         }
@@ -1062,6 +929,7 @@ mod tests {
             base_on_append in any::<bool>(),
             new_on_append in any::<bool>(),
             new_sc in gen_storage_class(),
+            new_algorithm in gen_encryption_algorithm(),
         ) {
             let base = types::config::BasinConfig {
                 create_stream_on_append: base_on_append,
@@ -1073,12 +941,14 @@ mod tests {
                     storage_class: Maybe::Specified(Some(new_sc.into())),
                     ..Default::default()
                 })),
+                stream_encryption_algorithm: Maybe::Specified(Some(new_algorithm.into())),
                 create_stream_on_append: Maybe::Specified(new_on_append),
                 ..Default::default()
             };
             let result = base.reconfigure(reconfig);
 
             prop_assert_eq!(result.default_stream_config.storage_class, Some(new_sc.into()));
+            prop_assert_eq!(result.stream_encryption_algorithm, Some(new_algorithm.into()));
             prop_assert_eq!(result.create_stream_on_append, new_on_append);
         }
 
@@ -1157,10 +1027,6 @@ mod tests {
         assert!(
             internal.delete_on_empty.min_age.is_none(),
             "delete_on_empty.min_age should be None"
-        );
-        assert!(
-            internal.encryption.allowed_modes.is_empty(),
-            "encryption.allowed_modes should be empty"
         );
     }
 }

--- a/api/src/v1/config.rs
+++ b/api/src/v1/config.rs
@@ -433,7 +433,7 @@ impl From<types::config::StreamReconfiguration> for StreamReconfiguration {
 pub struct BasinConfig {
     /// Default stream configuration.
     pub default_stream_config: Option<StreamConfig>,
-    /// Encryption algorithm materialized into streams created in the basin.
+    /// Encryption algorithm to apply to newly created streams in the basin.
     pub stream_encryption_algorithm: Option<EncryptionAlgorithm>,
     /// Create stream on append if it doesn't exist, using the default stream configuration.
     #[serde(default)]
@@ -494,7 +494,7 @@ pub struct BasinReconfiguration {
     #[serde(default, skip_serializing_if = "Maybe::is_unspecified")]
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<StreamReconfiguration>))]
     pub default_stream_config: Maybe<Option<StreamReconfiguration>>,
-    /// Encryption algorithm materialized into newly created streams in the basin.
+    /// Encryption algorithm to apply to newly created streams in the basin.
     #[serde(default, skip_serializing_if = "Maybe::is_unspecified")]
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<EncryptionAlgorithm>))]
     pub stream_encryption_algorithm: Maybe<Option<EncryptionAlgorithm>>,

--- a/api/src/v1/config.rs
+++ b/api/src/v1/config.rs
@@ -434,7 +434,7 @@ pub struct BasinConfig {
     /// Default stream configuration.
     pub default_stream_config: Option<StreamConfig>,
     /// Encryption algorithm to apply to newly created streams in the basin.
-    pub stream_encryption_algorithm: Option<EncryptionAlgorithm>,
+    pub stream_cipher: Option<EncryptionAlgorithm>,
     /// Create stream on append if it doesn't exist, using the default stream configuration.
     #[serde(default)]
     #[cfg_attr(feature = "utoipa", schema(default = false))]
@@ -451,7 +451,7 @@ impl TryFrom<BasinConfig> for types::config::BasinConfig {
     fn try_from(value: BasinConfig) -> Result<Self, Self::Error> {
         let BasinConfig {
             default_stream_config,
-            stream_encryption_algorithm,
+            stream_cipher,
             create_stream_on_append,
             create_stream_on_read,
         } = value;
@@ -461,7 +461,7 @@ impl TryFrom<BasinConfig> for types::config::BasinConfig {
                 Some(config) => config.try_into()?,
                 None => Default::default(),
             },
-            stream_encryption_algorithm: stream_encryption_algorithm.map(Into::into),
+            stream_cipher: stream_cipher.map(Into::into),
             create_stream_on_append,
             create_stream_on_read,
         })
@@ -472,14 +472,14 @@ impl From<types::config::BasinConfig> for BasinConfig {
     fn from(value: types::config::BasinConfig) -> Self {
         let types::config::BasinConfig {
             default_stream_config,
-            stream_encryption_algorithm,
+            stream_cipher,
             create_stream_on_append,
             create_stream_on_read,
         } = value;
 
         Self {
             default_stream_config: StreamConfig::to_opt(default_stream_config),
-            stream_encryption_algorithm: stream_encryption_algorithm.map(Into::into),
+            stream_cipher: stream_cipher.map(Into::into),
             create_stream_on_append,
             create_stream_on_read,
         }
@@ -497,7 +497,7 @@ pub struct BasinReconfiguration {
     /// Encryption algorithm to apply to newly created streams in the basin.
     #[serde(default, skip_serializing_if = "Maybe::is_unspecified")]
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<EncryptionAlgorithm>))]
-    pub stream_encryption_algorithm: Maybe<Option<EncryptionAlgorithm>>,
+    pub stream_cipher: Maybe<Option<EncryptionAlgorithm>>,
     /// Create a stream on append.
     #[serde(default, skip_serializing_if = "Maybe::is_unspecified")]
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<bool>))]
@@ -514,14 +514,14 @@ impl TryFrom<BasinReconfiguration> for types::config::BasinReconfiguration {
     fn try_from(value: BasinReconfiguration) -> Result<Self, Self::Error> {
         let BasinReconfiguration {
             default_stream_config,
-            stream_encryption_algorithm,
+            stream_cipher,
             create_stream_on_append,
             create_stream_on_read,
         } = value;
 
         Ok(Self {
             default_stream_config: default_stream_config.try_map_opt(TryInto::try_into)?,
-            stream_encryption_algorithm: stream_encryption_algorithm.map_opt(Into::into),
+            stream_cipher: stream_cipher.map_opt(Into::into),
             create_stream_on_append: create_stream_on_append.map(Into::into),
             create_stream_on_read: create_stream_on_read.map(Into::into),
         })
@@ -532,14 +532,14 @@ impl From<types::config::BasinReconfiguration> for BasinReconfiguration {
     fn from(value: types::config::BasinReconfiguration) -> Self {
         let types::config::BasinReconfiguration {
             default_stream_config,
-            stream_encryption_algorithm,
+            stream_cipher,
             create_stream_on_append,
             create_stream_on_read,
         } = value;
 
         Self {
             default_stream_config: default_stream_config.map_opt(Into::into),
-            stream_encryption_algorithm: stream_encryption_algorithm.map_opt(Into::into),
+            stream_cipher: stream_cipher.map_opt(Into::into),
             create_stream_on_append: create_stream_on_append.map(Into::into),
             create_stream_on_read: create_stream_on_read.map(Into::into),
         }
@@ -617,13 +617,13 @@ mod tests {
             .prop_map(
                 |(
                     default_stream_config,
-                    stream_encryption_algorithm,
+                    stream_cipher,
                     create_stream_on_append,
                     create_stream_on_read,
                 )| {
                     BasinConfig {
                         default_stream_config,
-                        stream_encryption_algorithm,
+                        stream_cipher,
                         create_stream_on_append,
                         create_stream_on_read,
                     }
@@ -687,12 +687,12 @@ mod tests {
             .prop_map(
                 |(
                     default_stream_config,
-                    stream_encryption_algorithm,
+                    stream_cipher,
                     create_stream_on_append,
                     create_stream_on_read,
                 )| BasinReconfiguration {
                     default_stream_config,
-                    stream_encryption_algorithm,
+                    stream_cipher,
                     create_stream_on_append,
                     create_stream_on_read,
                 },
@@ -910,7 +910,7 @@ mod tests {
                     storage_class: base_sc.map(Into::into),
                     ..Default::default()
                 },
-                stream_encryption_algorithm: base_algorithm.map(Into::into),
+                stream_cipher: base_algorithm.map(Into::into),
                 create_stream_on_append: base_on_append,
                 create_stream_on_read: base_on_read,
             };
@@ -919,7 +919,7 @@ mod tests {
             let result = base.clone().reconfigure(reconfig);
 
             prop_assert_eq!(result.default_stream_config.storage_class, base.default_stream_config.storage_class);
-            prop_assert_eq!(result.stream_encryption_algorithm, base.stream_encryption_algorithm);
+            prop_assert_eq!(result.stream_cipher, base.stream_cipher);
             prop_assert_eq!(result.create_stream_on_append, base.create_stream_on_append);
             prop_assert_eq!(result.create_stream_on_read, base.create_stream_on_read);
         }
@@ -941,14 +941,14 @@ mod tests {
                     storage_class: Maybe::Specified(Some(new_sc.into())),
                     ..Default::default()
                 })),
-                stream_encryption_algorithm: Maybe::Specified(Some(new_algorithm.into())),
+                stream_cipher: Maybe::Specified(Some(new_algorithm.into())),
                 create_stream_on_append: Maybe::Specified(new_on_append),
                 ..Default::default()
             };
             let result = base.reconfigure(reconfig);
 
             prop_assert_eq!(result.default_stream_config.storage_class, Some(new_sc.into()));
-            prop_assert_eq!(result.stream_encryption_algorithm, Some(new_algorithm.into()));
+            prop_assert_eq!(result.stream_cipher, Some(new_algorithm.into()));
             prop_assert_eq!(result.create_stream_on_append, new_on_append);
         }
 

--- a/api/src/v1/config.rs
+++ b/api/src/v1/config.rs
@@ -433,7 +433,7 @@ impl From<types::config::StreamReconfiguration> for StreamReconfiguration {
 pub struct BasinConfig {
     /// Default stream configuration.
     pub default_stream_config: Option<StreamConfig>,
-    /// Cipher to apply to newly created streams in the basin.
+    /// Encryption algorithm to apply to newly created streams in the basin.
     pub stream_cipher: Option<EncryptionAlgorithm>,
     /// Create stream on append if it doesn't exist, using the default stream configuration.
     #[serde(default)]
@@ -494,7 +494,7 @@ pub struct BasinReconfiguration {
     #[serde(default, skip_serializing_if = "Maybe::is_unspecified")]
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<StreamReconfiguration>))]
     pub default_stream_config: Maybe<Option<StreamReconfiguration>>,
-    /// Cipher to apply to newly created streams in the basin.
+    /// Encryption algorithm to apply to newly created streams in the basin.
     #[serde(default, skip_serializing_if = "Maybe::is_unspecified")]
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<EncryptionAlgorithm>))]
     pub stream_cipher: Maybe<Option<EncryptionAlgorithm>>,

--- a/api/src/v1/stream/extract.rs
+++ b/api/src/v1/stream/extract.rs
@@ -5,7 +5,7 @@ use axum::{
 use futures::StreamExt as _;
 use http::{StatusCode, request::Parts};
 use s2_common::{
-    encryption::EncryptionSpec,
+    encryption::EncryptionKey,
     http::{ParseableHeader, extract::HeaderRejection},
     types,
 };
@@ -54,7 +54,7 @@ where
 
     async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
         let content_type = crate::mime::content_type(req.headers());
-        let encryption = parse_header_opt::<EncryptionSpec>(req.headers())?.unwrap_or_default();
+        let encryption_key = parse_header_opt::<EncryptionKey>(req.headers())?;
 
         if content_type.as_ref().is_some_and(crate::mime::is_s2s_proto) {
             let response_compression =
@@ -88,7 +88,7 @@ where
             });
 
             return Ok(Self::S2s {
-                encryption,
+                encryption_key,
                 inputs: Box::pin(inputs),
                 response_compression,
             });
@@ -117,7 +117,7 @@ where
         };
 
         Ok(Self::Unary {
-            encryption,
+            encryption_key,
             input,
             response_mime,
         })
@@ -132,13 +132,13 @@ where
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         let content_type = crate::mime::content_type(&parts.headers);
-        let encryption = parse_header_opt::<EncryptionSpec>(&parts.headers)?.unwrap_or_default();
+        let encryption_key = parse_header_opt::<EncryptionKey>(&parts.headers)?;
 
         if content_type.as_ref().is_some_and(crate::mime::is_s2s_proto) {
             let response_compression =
                 s2s::CompressionAlgorithm::from_accept_encoding(&parts.headers);
             return Ok(Self::S2s {
-                encryption,
+                encryption_key,
                 response_compression,
             });
         }
@@ -150,7 +150,7 @@ where
         if accept.as_ref().is_some_and(crate::mime::is_event_stream) {
             let last_event_id = parse_header_opt::<LastEventId>(&parts.headers)?;
             return Ok(Self::EventStream {
-                encryption,
+                encryption_key,
                 format,
                 last_event_id,
             });
@@ -162,7 +162,7 @@ where
             .unwrap_or(JsonOrProto::Json);
 
         Ok(Self::Unary {
-            encryption,
+            encryption_key,
             format,
             response_mime,
         })

--- a/api/src/v1/stream/mod.rs
+++ b/api/src/v1/stream/mod.rs
@@ -36,7 +36,7 @@ pub struct StreamInfo {
     /// Deletion time in RFC 3339 format, if the stream is being deleted.
     #[serde(with = "time::serde::rfc3339::option")]
     pub deleted_at: Option<OffsetDateTime>,
-    /// Cipher for this stream, if encryption is enabled.
+    /// Encryption algorithm for this stream, if encryption is enabled.
     pub cipher: Option<EncryptionAlgorithm>,
 }
 

--- a/api/src/v1/stream/mod.rs
+++ b/api/src/v1/stream/mod.rs
@@ -37,7 +37,7 @@ pub struct StreamInfo {
     #[serde(with = "time::serde::rfc3339::option")]
     pub deleted_at: Option<OffsetDateTime>,
     /// Encryption algorithm for this stream, if encryption is enabled.
-    pub encryption_algorithm: Option<EncryptionAlgorithm>,
+    pub cipher: Option<EncryptionAlgorithm>,
 }
 
 impl From<types::stream::StreamInfo> for StreamInfo {
@@ -46,7 +46,7 @@ impl From<types::stream::StreamInfo> for StreamInfo {
             name: value.name,
             created_at: value.created_at,
             deleted_at: value.deleted_at,
-            encryption_algorithm: value.encryption_algorithm.map(Into::into),
+            cipher: value.cipher.map(Into::into),
         }
     }
 }

--- a/api/src/v1/stream/mod.rs
+++ b/api/src/v1/stream/mod.rs
@@ -36,7 +36,7 @@ pub struct StreamInfo {
     /// Deletion time in RFC 3339 format, if the stream is being deleted.
     #[serde(with = "time::serde::rfc3339::option")]
     pub deleted_at: Option<OffsetDateTime>,
-    /// Stream encryption algorithm materialized at creation time, if encryption is enabled.
+    /// Encryption algorithm for this stream, if encryption is enabled.
     pub encryption_algorithm: Option<EncryptionAlgorithm>,
 }
 

--- a/api/src/v1/stream/mod.rs
+++ b/api/src/v1/stream/mod.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use futures::stream::BoxStream;
 use itertools::Itertools as _;
 use s2_common::{
-    encryption::EncryptionSpec,
+    encryption::EncryptionKey,
     record,
     types::{
         self,
@@ -21,7 +21,7 @@ use s2_common::{
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
-use super::config::StreamConfig;
+use super::config::{EncryptionAlgorithm, StreamConfig};
 use crate::{data::Format, mime::JsonOrProto};
 
 #[rustfmt::skip]
@@ -36,6 +36,8 @@ pub struct StreamInfo {
     /// Deletion time in RFC 3339 format, if the stream is being deleted.
     #[serde(with = "time::serde::rfc3339::option")]
     pub deleted_at: Option<OffsetDateTime>,
+    /// Stream encryption algorithm materialized at creation time, if encryption is enabled.
+    pub encryption_algorithm: Option<EncryptionAlgorithm>,
 }
 
 impl From<types::stream::StreamInfo> for StreamInfo {
@@ -44,6 +46,7 @@ impl From<types::stream::StreamInfo> for StreamInfo {
             name: value.name,
             created_at: value.created_at,
             deleted_at: value.deleted_at,
+            encryption_algorithm: value.encryption_algorithm.map(Into::into),
         }
     }
 }
@@ -212,19 +215,19 @@ impl From<ReadEnd> for types::stream::ReadEnd {
 pub enum ReadRequest {
     /// Unary
     Unary {
-        encryption: EncryptionSpec,
+        encryption_key: Option<EncryptionKey>,
         format: Format,
         response_mime: JsonOrProto,
     },
     /// Server-Sent Events streaming response
     EventStream {
-        encryption: EncryptionSpec,
+        encryption_key: Option<EncryptionKey>,
         format: Format,
         last_event_id: Option<sse::LastEventId>,
     },
     /// S2S streaming response
     S2s {
-        encryption: EncryptionSpec,
+        encryption_key: Option<EncryptionKey>,
         response_compression: s2s::CompressionAlgorithm,
     },
 }
@@ -232,13 +235,13 @@ pub enum ReadRequest {
 pub enum AppendRequest {
     /// Unary
     Unary {
-        encryption: EncryptionSpec,
+        encryption_key: Option<EncryptionKey>,
         input: types::stream::AppendInput,
         response_mime: JsonOrProto,
     },
     /// S2S bi-directional streaming
     S2s {
-        encryption: EncryptionSpec,
+        encryption_key: Option<EncryptionKey>,
         inputs: BoxStream<'static, Result<types::stream::AppendInput, AppendInputStreamError>>,
         response_compression: s2s::CompressionAlgorithm,
     },
@@ -248,22 +251,22 @@ impl std::fmt::Debug for AppendRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             AppendRequest::Unary {
-                encryption,
+                encryption_key,
                 input,
                 response_mime: response,
             } => f
                 .debug_struct("AppendRequest::Unary")
-                .field("encryption", encryption)
+                .field("encryption_key", encryption_key)
                 .field("input", input)
                 .field("response", response)
                 .finish(),
             AppendRequest::S2s {
-                encryption,
+                encryption_key,
                 response_compression,
                 ..
             } => f
                 .debug_struct("AppendRequest::S2s")
-                .field("encryption", encryption)
+                .field("encryption_key", encryption_key)
                 .field("response_compression", response_compression)
                 .finish(),
         }

--- a/api/src/v1/stream/mod.rs
+++ b/api/src/v1/stream/mod.rs
@@ -36,7 +36,7 @@ pub struct StreamInfo {
     /// Deletion time in RFC 3339 format, if the stream is being deleted.
     #[serde(with = "time::serde::rfc3339::option")]
     pub deleted_at: Option<OffsetDateTime>,
-    /// Encryption algorithm for this stream, if encryption is enabled.
+    /// Cipher for this stream, if encryption is enabled.
     pub cipher: Option<EncryptionAlgorithm>,
 }
 

--- a/cli/schema.json
+++ b/cli/schema.json
@@ -53,7 +53,7 @@
           ]
         },
         "stream_encryption_algorithm": {
-          "description": "Encryption algorithm materialized into streams created in the basin.",
+          "description": "Encryption algorithm to apply to newly created streams in the basin.",
           "anyOf": [
             {
               "$ref": "#/$defs/EncryptionAlgorithmSpec"
@@ -212,7 +212,7 @@
       ]
     },
     "EncryptionAlgorithmSpec": {
-      "description": "Encryption algorithm materialized into streams created in the basin.",
+      "description": "Encryption algorithm to apply to newly created streams in the basin.",
       "type": "string",
       "enum": [
         "aegis-256",

--- a/cli/schema.json
+++ b/cli/schema.json
@@ -52,6 +52,18 @@
             }
           ]
         },
+        "stream_encryption_algorithm": {
+          "description": "Encryption algorithm materialized into streams created in the basin.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EncryptionAlgorithmSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "create_stream_on_append": {
           "description": "Create stream on append if it doesn't exist, using the default stream configuration.",
           "type": [
@@ -118,18 +130,6 @@
               "type": "null"
             }
           ]
-        },
-        "encryption": {
-          "description": "Encryption configuration.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EncryptionConfigSpec"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
         }
       },
       "additionalProperties": false
@@ -211,25 +211,10 @@
         "2h 30m"
       ]
     },
-    "EncryptionConfigSpec": {
-      "type": "object",
-      "properties": {
-        "allowed_modes": {
-          "description": "Allowed encryption modes.\nIf empty, use defaults. If no default is configured, only plaintext is allowed.",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/EncryptionModeSpec"
-          },
-          "default": []
-        }
-      },
-      "additionalProperties": false
-    },
-    "EncryptionModeSpec": {
-      "description": "Allowed encryption mode.",
+    "EncryptionAlgorithmSpec": {
+      "description": "Encryption algorithm materialized into streams created in the basin.",
       "type": "string",
       "enum": [
-        "plain",
         "aegis-256",
         "aes-256-gcm"
       ]

--- a/cli/schema.json
+++ b/cli/schema.json
@@ -53,7 +53,7 @@
           ]
         },
         "stream_cipher": {
-          "description": "Cipher to apply to newly created streams in the basin.",
+          "description": "Encryption algorithm to apply to newly created streams in the basin.",
           "anyOf": [
             {
               "$ref": "#/$defs/EncryptionAlgorithmSpec"
@@ -212,7 +212,7 @@
       ]
     },
     "EncryptionAlgorithmSpec": {
-      "description": "Cipher to apply to newly created streams in the basin.",
+      "description": "Encryption algorithm to apply to newly created streams in the basin.",
       "type": "string",
       "enum": [
         "aegis-256",

--- a/cli/schema.json
+++ b/cli/schema.json
@@ -52,7 +52,7 @@
             }
           ]
         },
-        "stream_encryption_algorithm": {
+        "stream_cipher": {
           "description": "Encryption algorithm to apply to newly created streams in the basin.",
           "anyOf": [
             {

--- a/cli/schema.json
+++ b/cli/schema.json
@@ -53,7 +53,7 @@
           ]
         },
         "stream_cipher": {
-          "description": "Encryption algorithm to apply to newly created streams in the basin.",
+          "description": "Cipher to apply to newly created streams in the basin.",
           "anyOf": [
             {
               "$ref": "#/$defs/EncryptionAlgorithmSpec"
@@ -212,7 +212,7 @@
       ]
     },
     "EncryptionAlgorithmSpec": {
-      "description": "Encryption algorithm to apply to newly created streams in the basin.",
+      "description": "Cipher to apply to newly created streams in the basin.",
       "type": "string",
       "enum": [
         "aegis-256",

--- a/cli/src/apply.rs
+++ b/cli/src/apply.rs
@@ -99,8 +99,8 @@ fn basin_reconfiguration_from_spec(s: BasinConfigSpec) -> BasinReconfiguration {
     if let Some(dsc) = s.default_stream_config {
         r = r.with_default_stream_config(stream_reconfiguration_from_spec(dsc));
     }
-    if let Some(algorithm) = s.stream_encryption_algorithm {
-        r = r.with_stream_encryption_algorithm(encryption_algorithm_from_spec(algorithm));
+    if let Some(algorithm) = s.stream_cipher {
+        r = r.with_stream_cipher(encryption_algorithm_from_spec(algorithm));
     }
     if let Some(v) = s.create_stream_on_append {
         r = r.with_create_stream_on_append(v);
@@ -273,15 +273,15 @@ fn diff_basin_config(existing: &BasinConfig, spec: &BasinConfigSpec) -> Vec<Fiel
     let mut diffs = Vec::new();
 
     if let Some(algorithm) = spec
-        .stream_encryption_algorithm
+        .stream_cipher
         .clone()
         .map(encryption_algorithm_from_spec)
-        && existing.stream_encryption_algorithm != Some(algorithm)
+        && existing.stream_cipher != Some(algorithm)
     {
         diffs.push(FieldDiff {
-            field: "stream_encryption_algorithm",
+            field: "stream_cipher",
             old: existing
-                .stream_encryption_algorithm
+                .stream_cipher
                 .map(format_encryption_algorithm)
                 .unwrap_or("none")
                 .to_string(),
@@ -397,12 +397,12 @@ fn spec_basin_fields(spec: &BasinConfigSpec) -> Vec<FieldDiff> {
     let mut fields = Vec::new();
 
     if let Some(algorithm) = spec
-        .stream_encryption_algorithm
+        .stream_cipher
         .clone()
         .map(encryption_algorithm_from_spec)
     {
         fields.push(FieldDiff {
-            field: "stream_encryption_algorithm",
+            field: "stream_cipher",
             old: String::new(),
             new: format_encryption_algorithm(algorithm).to_string(),
         });

--- a/cli/src/apply.rs
+++ b/cli/src/apply.rs
@@ -12,9 +12,9 @@ use s2_sdk::{
     types::{
         BasinConfig, BasinName, BasinReconfiguration, CreateOrReconfigureBasinInput,
         CreateOrReconfigureStreamInput, CreateOrReconfigured, DeleteOnEmptyConfig,
-        DeleteOnEmptyReconfiguration, ErrorResponse, RetentionPolicy, S2Error, StorageClass,
-        StreamConfig, StreamName, StreamReconfiguration, TimestampingConfig, TimestampingMode,
-        TimestampingReconfiguration,
+        DeleteOnEmptyReconfiguration, EncryptionAlgorithm, ErrorResponse, RetentionPolicy, S2Error,
+        StorageClass, StreamConfig, StreamName, StreamReconfiguration, TimestampingConfig,
+        TimestampingMode, TimestampingReconfiguration,
     },
 };
 
@@ -37,6 +37,22 @@ fn timestamping_mode_from_spec(m: TimestampingModeSpec) -> TimestampingMode {
         TimestampingModeSpec::ClientPrefer => TimestampingMode::ClientPrefer,
         TimestampingModeSpec::ClientRequire => TimestampingMode::ClientRequire,
         TimestampingModeSpec::Arrival => TimestampingMode::Arrival,
+    }
+}
+
+fn encryption_algorithm_from_spec(
+    a: s2_lite::init::EncryptionAlgorithmSpec,
+) -> EncryptionAlgorithm {
+    match a {
+        s2_lite::init::EncryptionAlgorithmSpec::Aegis256 => EncryptionAlgorithm::Aegis256,
+        s2_lite::init::EncryptionAlgorithmSpec::Aes256Gcm => EncryptionAlgorithm::Aes256Gcm,
+    }
+}
+
+fn format_encryption_algorithm(algorithm: EncryptionAlgorithm) -> &'static str {
+    match algorithm {
+        EncryptionAlgorithm::Aegis256 => "aegis-256",
+        EncryptionAlgorithm::Aes256Gcm => "aes-256-gcm",
     }
 }
 
@@ -82,6 +98,9 @@ fn basin_reconfiguration_from_spec(s: BasinConfigSpec) -> BasinReconfiguration {
     let mut r = BasinReconfiguration::new();
     if let Some(dsc) = s.default_stream_config {
         r = r.with_default_stream_config(stream_reconfiguration_from_spec(dsc));
+    }
+    if let Some(algorithm) = s.stream_encryption_algorithm {
+        r = r.with_stream_encryption_algorithm(encryption_algorithm_from_spec(algorithm));
     }
     if let Some(v) = s.create_stream_on_append {
         r = r.with_create_stream_on_append(v);
@@ -253,6 +272,23 @@ fn effective_delete_on_empty_min_age_secs(doe: Option<&DeleteOnEmptyConfig>) -> 
 fn diff_basin_config(existing: &BasinConfig, spec: &BasinConfigSpec) -> Vec<FieldDiff> {
     let mut diffs = Vec::new();
 
+    if let Some(algorithm) = spec
+        .stream_encryption_algorithm
+        .clone()
+        .map(encryption_algorithm_from_spec)
+        && existing.stream_encryption_algorithm != Some(algorithm)
+    {
+        diffs.push(FieldDiff {
+            field: "stream_encryption_algorithm",
+            old: existing
+                .stream_encryption_algorithm
+                .map(format_encryption_algorithm)
+                .unwrap_or("none")
+                .to_string(),
+            new: format_encryption_algorithm(algorithm).to_string(),
+        });
+    }
+
     if let Some(v) = spec.create_stream_on_append
         && existing.create_stream_on_append != v
     {
@@ -360,6 +396,17 @@ fn diff_stream_config(existing: &StreamConfig, spec: &StreamConfigSpec) -> Vec<F
 fn spec_basin_fields(spec: &BasinConfigSpec) -> Vec<FieldDiff> {
     let mut fields = Vec::new();
 
+    if let Some(algorithm) = spec
+        .stream_encryption_algorithm
+        .clone()
+        .map(encryption_algorithm_from_spec)
+    {
+        fields.push(FieldDiff {
+            field: "stream_encryption_algorithm",
+            old: String::new(),
+            new: format_encryption_algorithm(algorithm).to_string(),
+        });
+    }
     if let Some(v) = spec.create_stream_on_append {
         fields.push(FieldDiff {
             field: "create_stream_on_append",

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -274,7 +274,7 @@ pub struct ReconfigureBasinArgs {
     /// Name of the basin to reconfigure.
     pub basin: S2BasinUri,
 
-    /// Cipher to apply to newly created streams in this basin.
+    /// Encryption algorithm to apply to newly created streams in this basin.
     #[arg(long)]
     pub stream_cipher: Option<EncryptionAlgorithm>,
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -274,7 +274,7 @@ pub struct ReconfigureBasinArgs {
     /// Name of the basin to reconfigure.
     pub basin: S2BasinUri,
 
-    /// Encryption algorithm to apply to newly created streams in this basin.
+    /// Cipher to apply to newly created streams in this basin.
     #[arg(long)]
     pub stream_cipher: Option<EncryptionAlgorithm>,
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -276,7 +276,7 @@ pub struct ReconfigureBasinArgs {
 
     /// Encryption algorithm to apply to newly created streams in this basin.
     #[arg(long)]
-    pub stream_encryption_algorithm: Option<EncryptionAlgorithm>,
+    pub stream_cipher: Option<EncryptionAlgorithm>,
 
     /// Create stream on append with basin defaults if it doesn't exist.
     #[arg(long)]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -476,7 +476,7 @@ pub struct AppendArgs {
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct EncryptionArgs {
-    /// Base64-encoded 32-byte encryption key.
+    /// Base64-encoded encryption key material.
     /// Alternatively, set `S2_ENCRYPTION_KEY`.
     #[arg(
         long,
@@ -487,7 +487,7 @@ pub struct EncryptionArgs {
     )]
     pub encryption_key: Option<EncryptionKey>,
 
-    /// Read a base64-encoded encryption key from file.
+    /// Read base64-encoded encryption key material from file.
     #[arg(
         long,
         conflicts_with = "encryption_key",

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -479,6 +479,7 @@ pub struct EncryptionKeyArgs {
     /// Base64-encoded encryption key material.
     /// Alternatively, set `S2_ENCRYPTION_KEY`.
     #[arg(
+        short = 'k',
         long = "encryption-key",
         env = "S2_ENCRYPTION_KEY",
         hide_env_values = true,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -274,7 +274,7 @@ pub struct ReconfigureBasinArgs {
     /// Name of the basin to reconfigure.
     pub basin: S2BasinUri,
 
-    /// Encryption algorithm materialized into streams created in this basin.
+    /// Encryption algorithm to apply to newly created streams in this basin.
     #[arg(long)]
     pub stream_encryption_algorithm: Option<EncryptionAlgorithm>,
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -471,30 +471,30 @@ pub struct AppendArgs {
     pub linger: humantime::Duration,
 
     #[command(flatten)]
-    pub encryption: EncryptionArgs,
+    pub encryption_key: EncryptionKeyArgs,
 }
 
 #[derive(Args, Debug, Clone, Default)]
-pub struct EncryptionArgs {
+pub struct EncryptionKeyArgs {
     /// Base64-encoded encryption key material.
     /// Alternatively, set `S2_ENCRYPTION_KEY`.
     #[arg(
-        long,
+        long = "encryption-key",
         env = "S2_ENCRYPTION_KEY",
         hide_env_values = true,
         value_name = "KEY",
-        group = "encryption_source"
+        group = "encryption_key_source"
     )]
-    pub encryption_key: Option<EncryptionKey>,
+    pub key: Option<EncryptionKey>,
 
     /// Read base64-encoded encryption key material from file.
     #[arg(
-        long,
-        conflicts_with = "encryption_key",
+        long = "encryption-key-file",
+        conflicts_with = "key",
         value_name = "FILE",
-        group = "encryption_source"
+        group = "encryption_key_source"
     )]
-    pub encryption_file: Option<PathBuf>,
+    pub key_file: Option<PathBuf>,
 }
 
 #[derive(Args, Debug)]
@@ -548,7 +548,7 @@ pub struct ReadArgs {
     pub output: RecordsOut,
 
     #[command(flatten)]
-    pub encryption: EncryptionArgs,
+    pub encryption_key: EncryptionKeyArgs,
 }
 
 #[derive(Args, Debug)]
@@ -575,7 +575,7 @@ pub struct TailArgs {
     pub output: RecordsOut,
 
     #[command(flatten)]
-    pub encryption: EncryptionArgs,
+    pub encryption_key: EncryptionKeyArgs,
 }
 
 #[derive(Args, Debug)]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -3,7 +3,8 @@ use std::{num::NonZeroU64, path::PathBuf};
 use clap::{Args, Parser, Subcommand, builder::styling};
 use s2_sdk::types::{
     AccessTokenId, AccessTokenIdPrefix, AccessTokenIdStartAfter, BasinNamePrefix,
-    BasinNameStartAfter, EncryptionSpec, FencingToken, StreamNamePrefix, StreamNameStartAfter,
+    BasinNameStartAfter, EncryptionAlgorithm, EncryptionKey, FencingToken, StreamNamePrefix,
+    StreamNameStartAfter,
 };
 
 use crate::{
@@ -273,6 +274,10 @@ pub struct ReconfigureBasinArgs {
     /// Name of the basin to reconfigure.
     pub basin: S2BasinUri,
 
+    /// Encryption algorithm materialized into streams created in this basin.
+    #[arg(long)]
+    pub stream_encryption_algorithm: Option<EncryptionAlgorithm>,
+
     /// Create stream on append with basin defaults if it doesn't exist.
     #[arg(long)]
     pub create_stream_on_append: Option<bool>,
@@ -471,21 +476,21 @@ pub struct AppendArgs {
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct EncryptionArgs {
-    /// Encryption spec. Use `plain` or `<alg>; <base64-key>`.
-    /// Alternatively, set `S2_ENCRYPTION`.
+    /// Base64-encoded 32-byte encryption key.
+    /// Alternatively, set `S2_ENCRYPTION_KEY`.
     #[arg(
         long,
-        env = "S2_ENCRYPTION",
+        env = "S2_ENCRYPTION_KEY",
         hide_env_values = true,
-        value_name = "SPEC",
+        value_name = "KEY",
         group = "encryption_source"
     )]
-    pub encryption: Option<EncryptionSpec>,
+    pub encryption_key: Option<EncryptionKey>,
 
-    /// Read an encryption spec from file.
+    /// Read a base64-encoded encryption key from file.
     #[arg(
         long,
-        conflicts_with = "encryption",
+        conflicts_with = "encryption_key",
         value_name = "FILE",
         group = "encryption_source"
     )]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -33,7 +33,7 @@ use s2_sdk::{
     S2,
     types::{
         AppendRetryPolicy, CreateStreamInput, DeleteOnEmptyConfig, DeleteStreamInput,
-        EncryptionSpec, MeteredBytes, Metric, RetentionPolicy, RetryConfig,
+        EncryptionKey, MeteredBytes, Metric, RetentionPolicy, RetryConfig,
         StreamConfig as SdkStreamConfig, StreamName, TimestampingConfig, TimestampingMode,
     },
 };
@@ -363,7 +363,7 @@ async fn run() -> Result<(), CliError> {
         }
 
         Command::Append(args) => {
-            let encryption = resolve_encryption(&args.encryption)?;
+            let encryption_key = resolve_encryption_key(&args.encryption)?;
             let records_in = args
                 .input
                 .reader()
@@ -382,7 +382,7 @@ async fn run() -> Result<(), CliError> {
                 &s2,
                 record_stream,
                 args.uri,
-                encryption.as_ref(),
+                encryption_key.as_ref(),
                 args.fencing_token,
                 args.match_seq_num,
                 *args.linger,
@@ -425,8 +425,8 @@ async fn run() -> Result<(), CliError> {
         }
 
         Command::Read(args) => {
-            let encryption = resolve_encryption(&args.encryption)?;
-            let mut batches = ops::read(&s2, &args, encryption.as_ref()).await?;
+            let encryption_key = resolve_encryption_key(&args.encryption)?;
+            let mut batches = ops::read(&s2, &args, encryption_key.as_ref()).await?;
             let mut writer = args
                 .output
                 .writer()
@@ -488,8 +488,8 @@ async fn run() -> Result<(), CliError> {
         }
 
         Command::Tail(args) => {
-            let encryption = resolve_encryption(&args.encryption)?;
-            let mut records = ops::tail(&s2, &args, encryption.as_ref()).await?;
+            let encryption_key = resolve_encryption_key(&args.encryption)?;
+            let mut records = ops::tail(&s2, &args, encryption_key.as_ref()).await?;
             let mut writer = args
                 .output
                 .writer()
@@ -801,14 +801,14 @@ fn print_metrics(metrics: &[Metric]) {
     }
 }
 
-fn resolve_encryption(args: &cli::EncryptionArgs) -> Result<Option<EncryptionSpec>, CliError> {
-    match (&args.encryption, &args.encryption_file) {
-        (Some(config), _) => Ok(Some(config.clone())),
+fn resolve_encryption_key(args: &cli::EncryptionArgs) -> Result<Option<EncryptionKey>, CliError> {
+    match (&args.encryption_key, &args.encryption_file) {
+        (Some(key), _) => Ok(Some(key.clone())),
         (_, Some(path)) => {
             let contents = std::fs::read_to_string(path).map_err(|e| {
-                CliError::InvalidArgs(miette::miette!("cannot read encryption spec file: {e}"))
+                CliError::InvalidArgs(miette::miette!("cannot read encryption key file: {e}"))
             })?;
-            Ok(Some(contents.trim().parse::<EncryptionSpec>().map_err(
+            Ok(Some(contents.trim().parse::<EncryptionKey>().map_err(
                 |e| CliError::InvalidArgs(miette::miette!("{e}")),
             )?))
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -363,7 +363,7 @@ async fn run() -> Result<(), CliError> {
         }
 
         Command::Append(args) => {
-            let encryption_key = resolve_encryption_key(&args.encryption)?;
+            let encryption_key = resolve_encryption_key(&args.encryption_key)?;
             let records_in = args
                 .input
                 .reader()
@@ -425,7 +425,7 @@ async fn run() -> Result<(), CliError> {
         }
 
         Command::Read(args) => {
-            let encryption_key = resolve_encryption_key(&args.encryption)?;
+            let encryption_key = resolve_encryption_key(&args.encryption_key)?;
             let mut batches = ops::read(&s2, &args, encryption_key.as_ref()).await?;
             let mut writer = args
                 .output
@@ -488,7 +488,7 @@ async fn run() -> Result<(), CliError> {
         }
 
         Command::Tail(args) => {
-            let encryption_key = resolve_encryption_key(&args.encryption)?;
+            let encryption_key = resolve_encryption_key(&args.encryption_key)?;
             let mut records = ops::tail(&s2, &args, encryption_key.as_ref()).await?;
             let mut writer = args
                 .output
@@ -801,8 +801,10 @@ fn print_metrics(metrics: &[Metric]) {
     }
 }
 
-fn resolve_encryption_key(args: &cli::EncryptionArgs) -> Result<Option<EncryptionKey>, CliError> {
-    match (&args.encryption_key, &args.encryption_file) {
+fn resolve_encryption_key(
+    args: &cli::EncryptionKeyArgs,
+) -> Result<Option<EncryptionKey>, CliError> {
+    match (&args.key, &args.key_file) {
         (Some(key), _) => Ok(Some(key.clone())),
         (_, Some(path)) => {
             let contents = std::fs::read_to_string(path).map_err(|e| {

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -9,7 +9,7 @@ use s2_sdk::{
         AccessTokenId, AccessTokenInfo, AccessTokenScopeInput, AccountMetricSet, AppendAck,
         AppendInput, AppendRecord, AppendRecordBatch, BasinInfo, BasinMetricSet, BasinName,
         BasinReconfiguration, CommandRecord, CreateBasinInput, CreateStreamInput, DeleteBasinInput,
-        DeleteStreamInput, EncryptionSpec, FencingToken, GetAccountMetricsInput,
+        DeleteStreamInput, EncryptionKey, FencingToken, GetAccountMetricsInput,
         GetBasinMetricsInput, GetStreamMetricsInput, IssueAccessTokenInput, ListAccessTokensInput,
         ListAllAccessTokensInput, ListAllBasinsInput, ListAllStreamsInput, ListBasinsInput,
         ListStreamsInput, MeteredBytes, Metric, ReadBatch, ReadFrom, ReadInput, ReadLimits,
@@ -22,11 +22,11 @@ use s2_sdk::{
 fn stream_with_encryption(
     s2: &S2,
     uri: S2BasinAndStreamUri,
-    encryption: Option<&EncryptionSpec>,
+    encryption_key: Option<&EncryptionKey>,
 ) -> S2Stream {
     let stream = s2.basin(uri.basin).stream(uri.stream);
-    match encryption {
-        Some(encryption) => stream.with_encryption(encryption.clone()),
+    match encryption_key {
+        Some(encryption_key) => stream.with_encryption_key(encryption_key.clone()),
         None => stream,
     }
 }
@@ -122,6 +122,9 @@ pub async fn reconfigure_basin(
     let mut reconfig = BasinReconfiguration::new();
     if !args.default_stream_config.is_empty() {
         reconfig = reconfig.with_default_stream_config(args.default_stream_config.into());
+    }
+    if let Some(algorithm) = args.stream_encryption_algorithm {
+        reconfig = reconfig.with_stream_encryption_algorithm(algorithm);
     }
     if let Some(val) = args.create_stream_on_append {
         reconfig = reconfig.with_create_stream_on_append(val);
@@ -439,11 +442,11 @@ pub async fn fence(s2: &S2, args: FenceArgs) -> Result<AppendAck, CliError> {
 pub async fn read(
     s2: &S2,
     args: &ReadArgs,
-    encryption: Option<&EncryptionSpec>,
+    encryption_key: Option<&EncryptionKey>,
 ) -> Result<Streaming<ReadBatch>, CliError> {
     use std::time::SystemTime;
 
-    let stream = stream_with_encryption(s2, args.uri.clone(), encryption);
+    let stream = stream_with_encryption(s2, args.uri.clone(), encryption_key);
 
     let from = match (args.seq_num, args.timestamp, args.tail_offset, args.ago) {
         (Some(seq), None, None, None) => ReadFrom::SeqNum(seq),
@@ -488,7 +491,7 @@ pub fn append<'a, S, E>(
     s2: &'a S2,
     records: S,
     uri: S2BasinAndStreamUri,
-    encryption: Option<&'a EncryptionSpec>,
+    encryption_key: Option<&'a EncryptionKey>,
     fencing_token: Option<FencingToken>,
     match_seq_num: Option<u64>,
     linger: Duration,
@@ -497,7 +500,7 @@ where
     S: Stream<Item = Result<AppendRecord, E>> + Send + Unpin + 'a,
     E: std::error::Error + Send + Sync + 'static,
 {
-    let stream = stream_with_encryption(s2, uri, encryption);
+    let stream = stream_with_encryption(s2, uri, encryption_key);
 
     let batching_config = BatchingConfig::new().with_linger(linger);
     let mut producer_config = ProducerConfig::new().with_batching(batching_config);
@@ -586,9 +589,9 @@ where
 pub async fn tail(
     s2: &S2,
     args: &TailArgs,
-    encryption: Option<&EncryptionSpec>,
+    encryption_key: Option<&EncryptionKey>,
 ) -> Result<Pin<Box<dyn Stream<Item = Result<SequencedRecord, CliError>> + Send>>, CliError> {
-    let stream = stream_with_encryption(s2, args.uri.clone(), encryption);
+    let stream = stream_with_encryption(s2, args.uri.clone(), encryption_key);
 
     // Use clamp_to_tail to handle empty streams gracefully - if we ask for
     // TailOffset(10) but there are fewer records, clamp to the actual start

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -123,8 +123,8 @@ pub async fn reconfigure_basin(
     if !args.default_stream_config.is_empty() {
         reconfig = reconfig.with_default_stream_config(args.default_stream_config.into());
     }
-    if let Some(algorithm) = args.stream_encryption_algorithm {
-        reconfig = reconfig.with_stream_encryption_algorithm(algorithm);
+    if let Some(algorithm) = args.stream_cipher {
+        reconfig = reconfig.with_stream_cipher(algorithm);
     }
     if let Some(val) = args.create_stream_on_append {
         reconfig = reconfig.with_create_stream_on_append(val);

--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -982,6 +982,7 @@ impl ReadFormat {
 /// Config for basin reconfiguration
 #[derive(Debug, Clone)]
 pub struct BasinReconfigureConfig {
+    pub stream_encryption_algorithm: Option<s2_sdk::types::EncryptionAlgorithm>,
     pub create_stream_on_append: Option<bool>,
     pub create_stream_on_read: Option<bool>,
     pub storage_class: Option<StorageClass>,
@@ -1064,8 +1065,8 @@ fn build_basin_config(
             retention_policy: retention,
             timestamping,
             delete_on_empty,
-            encryption: None,
         },
+        stream_encryption_algorithm: None,
         create_stream_on_append,
         create_stream_on_read,
     }
@@ -1113,7 +1114,6 @@ fn build_stream_config(
         retention_policy: retention,
         timestamping,
         delete_on_empty,
-        encryption: None,
     }
 }
 
@@ -2731,6 +2731,7 @@ impl App {
                     KeyCode::Char('s') => {
                         let b = basin.clone();
                         let config = BasinReconfigureConfig {
+                            stream_encryption_algorithm: None,
                             create_stream_on_append: *create_stream_on_append,
                             create_stream_on_read: *create_stream_on_read,
                             storage_class: storage_class.clone(),
@@ -4955,11 +4956,11 @@ impl App {
                 retention_policy,
                 timestamping,
                 delete_on_empty: None,
-                encryption: None,
             };
 
             let args = ReconfigureBasinArgs {
                 basin: S2BasinUri(basin),
+                stream_encryption_algorithm: config.stream_encryption_algorithm,
                 create_stream_on_append: config.create_stream_on_append,
                 create_stream_on_read: config.create_stream_on_read,
                 default_stream_config,
@@ -5030,7 +5031,6 @@ impl App {
                     retention_policy,
                     timestamping,
                     delete_on_empty,
-                    encryption: None,
                 },
             };
             match ops::reconfigure_stream(&s2, args).await {

--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -982,7 +982,7 @@ impl ReadFormat {
 /// Config for basin reconfiguration
 #[derive(Debug, Clone)]
 pub struct BasinReconfigureConfig {
-    pub stream_encryption_algorithm: Option<s2_sdk::types::EncryptionAlgorithm>,
+    pub stream_cipher: Option<s2_sdk::types::EncryptionAlgorithm>,
     pub create_stream_on_append: Option<bool>,
     pub create_stream_on_read: Option<bool>,
     pub storage_class: Option<StorageClass>,
@@ -1066,7 +1066,7 @@ fn build_basin_config(
             timestamping,
             delete_on_empty,
         },
-        stream_encryption_algorithm: None,
+        stream_cipher: None,
         create_stream_on_append,
         create_stream_on_read,
     }
@@ -2731,7 +2731,7 @@ impl App {
                     KeyCode::Char('s') => {
                         let b = basin.clone();
                         let config = BasinReconfigureConfig {
-                            stream_encryption_algorithm: None,
+                            stream_cipher: None,
                             create_stream_on_append: *create_stream_on_append,
                             create_stream_on_read: *create_stream_on_read,
                             storage_class: storage_class.clone(),
@@ -4960,7 +4960,7 @@ impl App {
 
             let args = ReconfigureBasinArgs {
                 basin: S2BasinUri(basin),
-                stream_encryption_algorithm: config.stream_encryption_algorithm,
+                stream_cipher: config.stream_cipher,
                 create_stream_on_append: config.create_stream_on_append,
                 create_stream_on_read: config.create_stream_on_read,
                 default_stream_config,

--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -4503,7 +4503,7 @@ impl App {
                 until: None,
                 format: RecordFormat::default(),
                 output: RecordsOut::Stdout,
-                encryption: Default::default(),
+                encryption_key: Default::default(),
             };
 
             match ops::read(&s2, &args, None).await {
@@ -4576,7 +4576,7 @@ impl App {
                 until: None,
                 format: RecordFormat::default(),
                 output: RecordsOut::Stdout,
-                encryption: Default::default(),
+                encryption_key: Default::default(),
             };
 
             match ops::read(&s2, &args, None).await {
@@ -4740,7 +4740,7 @@ impl App {
                 until,
                 format: record_format,
                 output: output.clone(),
-                encryption: Default::default(),
+                encryption_key: Default::default(),
             };
 
             // Open file writer if output file is specified

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -132,7 +132,7 @@ pub struct BasinConfig {
     pub default_stream_config: StreamConfig,
     /// Encryption algorithm to apply to newly created streams in this basin.
     #[arg(long)]
-    pub stream_encryption_algorithm: Option<EncryptionAlgorithm>,
+    pub stream_cipher: Option<EncryptionAlgorithm>,
     /// Create stream on append with basin defaults if it doesn't exist.
     #[arg(long, default_value_t = false)]
     pub create_stream_on_append: bool,
@@ -259,8 +259,8 @@ impl From<BasinConfig> for sdk::types::BasinConfig {
     fn from(config: BasinConfig) -> Self {
         let mut basin_config = sdk::types::BasinConfig::new()
             .with_default_stream_config(config.default_stream_config.into());
-        if let Some(algorithm) = config.stream_encryption_algorithm {
-            basin_config = basin_config.with_stream_encryption_algorithm(algorithm);
+        if let Some(algorithm) = config.stream_cipher {
+            basin_config = basin_config.with_stream_cipher(algorithm);
         }
         basin_config
             .with_create_stream_on_append(config.create_stream_on_append)
@@ -374,7 +374,7 @@ impl From<sdk::types::BasinConfig> for BasinConfig {
                 .default_stream_config
                 .map(Into::into)
                 .unwrap_or_default(),
-            stream_encryption_algorithm: config.stream_encryption_algorithm.map(Into::into),
+            stream_cipher: config.stream_cipher.map(Into::into),
             create_stream_on_append: config.create_stream_on_append,
             create_stream_on_read: config.create_stream_on_read,
         }

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -374,7 +374,7 @@ impl From<sdk::types::BasinConfig> for BasinConfig {
                 .default_stream_config
                 .map(Into::into)
                 .unwrap_or_default(),
-            stream_cipher: config.stream_cipher.map(Into::into),
+            stream_cipher: config.stream_cipher,
             create_stream_on_append: config.create_stream_on_append,
             create_stream_on_read: config.create_stream_on_read,
         }

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -130,7 +130,7 @@ impl FromStr for S2BasinAndStreamUri {
 pub struct BasinConfig {
     #[clap(flatten)]
     pub default_stream_config: StreamConfig,
-    /// Encryption algorithm to apply to newly created streams in this basin.
+    /// Cipher to apply to newly created streams in this basin.
     #[arg(long)]
     pub stream_cipher: Option<EncryptionAlgorithm>,
     /// Create stream on append with basin defaults if it doesn't exist.

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -130,7 +130,7 @@ impl FromStr for S2BasinAndStreamUri {
 pub struct BasinConfig {
     #[clap(flatten)]
     pub default_stream_config: StreamConfig,
-    /// Cipher to apply to newly created streams in this basin.
+    /// Encryption algorithm to apply to newly created streams in this basin.
     #[arg(long)]
     pub stream_cipher: Option<EncryptionAlgorithm>,
     /// Create stream on append with basin defaults if it doesn't exist.

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -130,7 +130,7 @@ impl FromStr for S2BasinAndStreamUri {
 pub struct BasinConfig {
     #[clap(flatten)]
     pub default_stream_config: StreamConfig,
-    /// Encryption algorithm materialized into streams created in this basin.
+    /// Encryption algorithm to apply to newly created streams in this basin.
     #[arg(long)]
     pub stream_encryption_algorithm: Option<EncryptionAlgorithm>,
     /// Create stream on append with basin defaults if it doesn't exist.

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -4,8 +4,8 @@ use clap::{Args, Parser, ValueEnum};
 use s2_sdk::{
     self as sdk,
     types::{
-        AccessTokenId, AccessTokenIdPrefix, BasinName, BasinNamePrefix, EncryptionMode, StreamName,
-        StreamNamePrefix, TimeseriesInterval,
+        AccessTokenId, AccessTokenIdPrefix, BasinName, BasinNamePrefix, EncryptionAlgorithm,
+        StreamName, StreamNamePrefix, TimeseriesInterval,
     },
 };
 use serde::Serialize;
@@ -130,6 +130,9 @@ impl FromStr for S2BasinAndStreamUri {
 pub struct BasinConfig {
     #[clap(flatten)]
     pub default_stream_config: StreamConfig,
+    /// Encryption algorithm materialized into streams created in this basin.
+    #[arg(long)]
+    pub stream_encryption_algorithm: Option<EncryptionAlgorithm>,
     /// Create stream on append with basin defaults if it doesn't exist.
     #[arg(long, default_value_t = false)]
     pub create_stream_on_append: bool,
@@ -152,9 +155,6 @@ pub struct StreamConfig {
     #[clap(flatten)]
     /// Delete-on-empty configuration.
     pub delete_on_empty: Option<DeleteOnEmptyConfig>,
-    #[clap(flatten)]
-    /// Encryption configuration.
-    pub encryption: Option<EncryptionConfig>,
 }
 
 impl StreamConfig {
@@ -164,13 +164,11 @@ impl StreamConfig {
             retention_policy,
             timestamping,
             delete_on_empty,
-            encryption,
         } = self;
         storage_class.is_none()
             && retention_policy.is_none()
             && timestamping.is_none()
             && delete_on_empty.is_none()
-            && encryption.is_none()
     }
 }
 
@@ -257,39 +255,14 @@ impl From<sdk::types::DeleteOnEmptyConfig> for DeleteOnEmptyConfig {
     }
 }
 
-#[derive(Parser, Debug, Clone, Serialize)]
-pub struct EncryptionConfig {
-    #[arg(long, value_delimiter = ',')]
-    /// Allowed encryption modes (comma-separated). If no default is configured, only plaintext is
-    /// allowed.
-    pub encryption_allowed_modes: Vec<EncryptionMode>,
-}
-
-impl From<EncryptionConfig> for sdk::types::EncryptionConfig {
-    fn from(value: EncryptionConfig) -> Self {
-        sdk::types::EncryptionConfig::new().with_allowed_modes(value.encryption_allowed_modes)
-    }
-}
-
-impl From<sdk::types::EncryptionConfig> for EncryptionConfig {
-    fn from(value: sdk::types::EncryptionConfig) -> Self {
-        Self {
-            encryption_allowed_modes: value.allowed_modes,
-        }
-    }
-}
-
-impl From<EncryptionConfig> for sdk::types::EncryptionReconfiguration {
-    fn from(value: EncryptionConfig) -> Self {
-        sdk::types::EncryptionReconfiguration::new()
-            .with_allowed_modes(value.encryption_allowed_modes)
-    }
-}
-
 impl From<BasinConfig> for sdk::types::BasinConfig {
     fn from(config: BasinConfig) -> Self {
-        sdk::types::BasinConfig::new()
-            .with_default_stream_config(config.default_stream_config.into())
+        let mut basin_config = sdk::types::BasinConfig::new()
+            .with_default_stream_config(config.default_stream_config.into());
+        if let Some(algorithm) = config.stream_encryption_algorithm {
+            basin_config = basin_config.with_stream_encryption_algorithm(algorithm);
+        }
+        basin_config
             .with_create_stream_on_append(config.create_stream_on_append)
             .with_create_stream_on_read(config.create_stream_on_read)
     }
@@ -309,9 +282,6 @@ impl From<StreamConfig> for sdk::types::StreamConfig {
         }
         if let Some(delete_on_empty) = config.delete_on_empty {
             stream_config = stream_config.with_delete_on_empty(delete_on_empty.into());
-        }
-        if let Some(encryption) = config.encryption {
-            stream_config = stream_config.with_encryption(encryption.into());
         }
         stream_config
     }
@@ -404,6 +374,7 @@ impl From<sdk::types::BasinConfig> for BasinConfig {
                 .default_stream_config
                 .map(Into::into)
                 .unwrap_or_default(),
+            stream_encryption_algorithm: config.stream_encryption_algorithm.map(Into::into),
             create_stream_on_append: config.create_stream_on_append,
             create_stream_on_read: config.create_stream_on_read,
         }
@@ -417,7 +388,6 @@ impl From<sdk::types::StreamConfig> for StreamConfig {
             retention_policy: config.retention_policy.map(Into::into),
             timestamping: config.timestamping.map(Into::into),
             delete_on_empty: config.delete_on_empty.map(Into::into),
-            encryption: config.encryption.map(Into::into),
         }
     }
 }
@@ -437,9 +407,6 @@ impl From<StreamConfig> for sdk::types::StreamReconfiguration {
         }
         if let Some(delete_on_empty) = config.delete_on_empty {
             reconfig = reconfig.with_delete_on_empty(delete_on_empty.into());
-        }
-        if let Some(encryption) = config.encryption {
-            reconfig = reconfig.with_encryption(encryption.into());
         }
         reconfig
     }

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -208,12 +208,6 @@ mod tests {
     ];
 
     #[test]
-    fn parse_key_header_roundtrips() {
-        let key = KEY_B64.parse::<EncryptionKey>().unwrap();
-        assert_eq!(key.expose_secret(), KEY_BYTES);
-    }
-
-    #[test]
     fn key_header_value_is_sensitive() {
         let value = EncryptionKey::new([7; 32]).to_header_value();
         assert!(value.is_sensitive());
@@ -239,16 +233,6 @@ mod tests {
             Err(actual) => assert_eq!(actual, expected),
             Ok(_) => panic!("expected invalid key for {header:?}"),
         }
-    }
-
-    #[rstest]
-    #[case(EncryptionAlgorithm::Aegis256, "\"aegis-256\"")]
-    #[case(EncryptionAlgorithm::Aes256Gcm, "\"aes-256-gcm\"")]
-    fn algorithm_serde_roundtrip(#[case] algorithm: EncryptionAlgorithm, #[case] expected: &str) {
-        let serialized = serde_json::to_string(&algorithm).unwrap();
-        assert_eq!(serialized, expected);
-        let deserialized: EncryptionAlgorithm = serde_json::from_str(expected).unwrap();
-        assert_eq!(deserialized, algorithm);
     }
 
     #[test]

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -12,7 +12,6 @@ use crate::http::ParseableHeader;
 
 pub static S2_ENCRYPTION_KEY_HEADER: HeaderName = HeaderName::from_static("s2-encryption-key");
 
-type SecretKey = Arc<SecretBox<[u8; 32]>>;
 type SecretKeyMaterial = Arc<SecretBox<[u8]>>;
 
 /// Encryption algorithm.
@@ -98,17 +97,26 @@ pub enum EncryptionResolutionError {
 }
 
 /// Resolved stream encryption after combining stream metadata with the request key.
-#[derive(Clone, Default)]
-pub struct EncryptionSpec {
-    algorithm: Option<EncryptionAlgorithm>,
-    key: Option<SecretKey>,
+#[derive(Clone)]
+pub enum EncryptionSpec {
+    Plaintext,
+    Aegis256(EncryptionKey),
+    Aes256Gcm(EncryptionKey),
+}
+
+impl Default for EncryptionSpec {
+    fn default() -> Self {
+        Self::Plaintext
+    }
 }
 
 impl std::fmt::Debug for EncryptionSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("EncryptionSpec")
-            .field("algorithm", &self.algorithm)
-            .finish()
+        match self {
+            Self::Plaintext => f.write_str("EncryptionSpec::Plaintext"),
+            Self::Aegis256(_) => f.write_str("EncryptionSpec::Aegis256(..)"),
+            Self::Aes256Gcm(_) => f.write_str("EncryptionSpec::Aes256Gcm(..)"),
+        }
     }
 }
 
@@ -123,52 +131,44 @@ impl EncryptionSpec {
     ) -> Result<Self, EncryptionResolutionError> {
         match (algorithm, key) {
             (None, _) => Ok(Self::plain()),
-            (Some(EncryptionAlgorithm::Aegis256), Some(key)) => Ok(Self::with_secret_key(
-                EncryptionAlgorithm::Aegis256,
-                resolve_secret_key(EncryptionAlgorithm::Aegis256, key)?,
-            )),
-            (Some(EncryptionAlgorithm::Aes256Gcm), Some(key)) => Ok(Self::with_secret_key(
-                EncryptionAlgorithm::Aes256Gcm,
-                resolve_secret_key(EncryptionAlgorithm::Aes256Gcm, key)?,
-            )),
+            (Some(EncryptionAlgorithm::Aegis256), Some(key)) => {
+                validate_key_length(EncryptionAlgorithm::Aegis256, &key)?;
+                Ok(Self::Aegis256(key))
+            }
+            (Some(EncryptionAlgorithm::Aes256Gcm), Some(key)) => {
+                validate_key_length(EncryptionAlgorithm::Aes256Gcm, &key)?;
+                Ok(Self::Aes256Gcm(key))
+            }
             (Some(algorithm), None) => Err(EncryptionResolutionError::MissingKey { algorithm }),
         }
     }
 
     pub fn aegis256(key: [u8; 32]) -> Self {
-        Self::with_secret_key(EncryptionAlgorithm::Aegis256, secret_key(key))
+        Self::Aegis256(EncryptionKey::new(key))
     }
 
     pub fn aes256_gcm(key: [u8; 32]) -> Self {
-        Self::with_secret_key(EncryptionAlgorithm::Aes256Gcm, secret_key(key))
+        Self::Aes256Gcm(EncryptionKey::new(key))
     }
 
     pub fn algorithm(&self) -> Option<EncryptionAlgorithm> {
-        self.algorithm
-    }
-
-    pub fn is_plain(&self) -> bool {
-        self.algorithm.is_none()
-    }
-
-    fn with_secret_key(algorithm: EncryptionAlgorithm, key: SecretKey) -> Self {
-        Self {
-            algorithm: Some(algorithm),
-            key: Some(key),
+        match self {
+            Self::Plaintext => None,
+            Self::Aegis256(_) => Some(EncryptionAlgorithm::Aegis256),
+            Self::Aes256Gcm(_) => Some(EncryptionAlgorithm::Aes256Gcm),
         }
     }
 
-    pub(crate) fn secret_key(&self) -> Option<&[u8; 32]> {
-        self.key.as_ref().map(|key| key.as_ref().expose_secret())
+    pub fn is_plain(&self) -> bool {
+        matches!(self, Self::Plaintext)
     }
 
-    pub(crate) fn secret_key_for_algorithm(
-        &self,
-        algorithm: EncryptionAlgorithm,
-    ) -> Option<&[u8; 32]> {
-        (self.algorithm == Some(algorithm))
-            .then(|| self.secret_key())
-            .flatten()
+    pub(crate) fn key_for_algorithm(&self, algorithm: EncryptionAlgorithm) -> Option<&[u8; 32]> {
+        match (self, algorithm) {
+            (Self::Aegis256(key), EncryptionAlgorithm::Aegis256)
+            | (Self::Aes256Gcm(key), EncryptionAlgorithm::Aes256Gcm) => Some(key_bytes_32(key)),
+            _ => None,
+        }
     }
 }
 
@@ -205,12 +205,10 @@ fn parse_encryption_key_material(key_b64: &str) -> Result<SecretKeyMaterial, Enc
     Ok(Arc::new(SecretBox::new(key.into_boxed_slice())))
 }
 
-fn resolve_secret_key(
+fn validate_key_length(
     algorithm: EncryptionAlgorithm,
-    key: EncryptionKey,
-) -> Result<SecretKey, EncryptionResolutionError> {
-    // Parse the request header as opaque bytes and validate the current
-    // algorithm-specific raw key requirement only at resolution time.
+    key: &EncryptionKey,
+) -> Result<(), EncryptionResolutionError> {
     let bytes = key.bytes();
     if bytes.len() != 32 {
         return Err(EncryptionResolutionError::InvalidKeyLength {
@@ -220,9 +218,7 @@ fn resolve_secret_key(
         });
     }
 
-    let mut secret = Box::new([0u8; 32]);
-    secret.copy_from_slice(bytes);
-    Ok(Arc::new(SecretBox::new(secret)))
+    Ok(())
 }
 
 fn header_value_for_key_material(key: &[u8]) -> HeaderValue {
@@ -231,8 +227,10 @@ fn header_value_for_key_material(key: &[u8]) -> HeaderValue {
     HeaderValue::from_bytes(&value).expect("encryption key header value should be ASCII")
 }
 
-fn secret_key(key: [u8; 32]) -> SecretKey {
-    Arc::new(SecretBox::new(Box::new(key)))
+fn key_bytes_32(key: &EncryptionKey) -> &[u8; 32] {
+    key.bytes()
+        .try_into()
+        .expect("encryption key should be 32 bytes after validation")
 }
 
 #[cfg(test)]

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -14,12 +14,8 @@ pub static S2_ENCRYPTION_KEY_HEADER: HeaderName = HeaderName::from_static("s2-en
 
 type SecretKeyMaterial = Arc<SecretBox<[u8]>>;
 
-const CURRENT_ENCRYPTION_KEY_LEN: usize = 32;
-const MAX_ENCRYPTION_KEY_HEADER_LEN: usize = base64_encoded_len(CURRENT_ENCRYPTION_KEY_LEN);
-
-const fn base64_encoded_len(bytes_len: usize) -> usize {
-    ((bytes_len + 2) / 3) * 4
-}
+// 32 bytes incl padding
+const MAX_ENCRYPTION_KEY_HEADER_LEN: usize = 44;
 
 /// Encryption algorithm.
 #[derive(
@@ -54,17 +50,16 @@ pub enum EncryptionAlgorithm {
 pub struct EncryptionKey(SecretKeyMaterial);
 
 impl EncryptionKey {
-    pub fn new(key: [u8; 32]) -> Self {
-        Self::from_bytes(Box::new(key)).expect("32-byte encryption key should fit header length")
+    pub fn new<const N: usize>(key: [u8; N]) -> Self {
+        Self::from_bytes(Box::new(key))
     }
 
     pub fn from_base64(key_b64: &str) -> Result<Self, EncryptionKeyError> {
         parse_encryption_key_material(key_b64).map(Self)
     }
 
-    pub fn from_bytes(bytes: Box<[u8]>) -> Result<Self, EncryptionKeyError> {
-        validate_key_material_len(base64_encoded_len(bytes.len()))?;
-        Ok(Self(Arc::new(SecretBox::new(bytes))))
+    pub fn from_bytes(bytes: Box<[u8]>) -> Self {
+        Self(Arc::new(SecretBox::new(bytes)))
     }
 
     pub fn bytes(&self) -> &[u8] {
@@ -160,7 +155,12 @@ fn parse_encryption_key_material(key_b64: &str) -> Result<SecretKeyMaterial, Enc
     use base64ct::{Base64, Encoding};
     use secrecy::zeroize::Zeroize;
 
-    validate_key_material_len(key_b64.len())?;
+    if key_b64.len() > MAX_ENCRYPTION_KEY_HEADER_LEN {
+        return Err(EncryptionKeyError::TooLong {
+            max: MAX_ENCRYPTION_KEY_HEADER_LEN,
+            actual: key_b64.len(),
+        });
+    }
 
     let mut key = match Base64::decode_vec(key_b64) {
         Ok(decoded) => decoded,
@@ -175,17 +175,6 @@ fn parse_encryption_key_material(key_b64: &str) -> Result<SecretKeyMaterial, Enc
     }
 
     Ok(Arc::new(SecretBox::new(key.into_boxed_slice())))
-}
-
-fn validate_key_material_len(len: usize) -> Result<(), EncryptionKeyError> {
-    if len > MAX_ENCRYPTION_KEY_HEADER_LEN {
-        return Err(EncryptionKeyError::TooLong {
-            max: MAX_ENCRYPTION_KEY_HEADER_LEN,
-            actual: len,
-        });
-    }
-
-    Ok(())
 }
 
 fn validate_key_length(
@@ -289,7 +278,7 @@ mod tests {
     fn resolve_encrypted_validates_key_length_per_algorithm() {
         let err = EncryptionSpec::resolve(
             Some(EncryptionAlgorithm::Aegis256),
-            Some(EncryptionKey::from_bytes(vec![0x42; 4].into_boxed_slice()).unwrap()),
+            Some(EncryptionKey::from_bytes(vec![0x42; 4].into_boxed_slice())),
         )
         .unwrap_err();
         assert_eq!(
@@ -311,18 +300,6 @@ mod tests {
             EncryptionKeyError::TooLong {
                 max: MAX_ENCRYPTION_KEY_HEADER_LEN,
                 actual: MAX_ENCRYPTION_KEY_HEADER_LEN + 1,
-            }
-        );
-    }
-
-    #[test]
-    fn from_bytes_rejects_key_material_that_would_overflow_header_limit() {
-        let result = EncryptionKey::from_bytes(vec![0x42; 34].into_boxed_slice());
-        assert_eq!(
-            result.unwrap_err(),
-            EncryptionKeyError::TooLong {
-                max: MAX_ENCRYPTION_KEY_HEADER_LEN,
-                actual: base64_encoded_len(34),
             }
         );
     }

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -44,9 +44,7 @@ pub enum EncryptionAlgorithm {
 
 /// Customer-supplied encryption key material for append/read operations.
 #[derive(Debug, Clone)]
-pub struct EncryptionKey {
-    bytes: SecretKeyMaterial,
-}
+pub struct EncryptionKey(SecretKeyMaterial);
 
 impl EncryptionKey {
     pub fn new(key: [u8; 32]) -> Self {
@@ -54,17 +52,15 @@ impl EncryptionKey {
     }
 
     pub fn from_base64(key_b64: &str) -> Result<Self, EncryptionKeyError> {
-        parse_encryption_key_material(key_b64).map(|bytes| Self { bytes })
+        parse_encryption_key_material(key_b64).map(Self)
     }
 
     pub fn from_bytes(bytes: Box<[u8]>) -> Self {
-        Self {
-            bytes: Arc::new(SecretBox::new(bytes)),
-        }
+        Self(Arc::new(SecretBox::new(bytes)))
     }
 
     pub fn bytes(&self) -> &[u8] {
-        self.bytes.as_ref().expose_secret()
+        self.0.as_ref().expose_secret()
     }
 
     pub fn to_header_value(&self) -> HeaderValue {
@@ -97,27 +93,12 @@ pub enum EncryptionResolutionError {
 }
 
 /// Resolved stream encryption after combining stream metadata with the request key.
-#[derive(Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum EncryptionSpec {
+    #[default]
     Plaintext,
     Aegis256(EncryptionKey),
     Aes256Gcm(EncryptionKey),
-}
-
-impl Default for EncryptionSpec {
-    fn default() -> Self {
-        Self::Plaintext
-    }
-}
-
-impl std::fmt::Debug for EncryptionSpec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Plaintext => f.write_str("EncryptionSpec::Plaintext"),
-            Self::Aegis256(_) => f.write_str("EncryptionSpec::Aegis256(..)"),
-            Self::Aes256Gcm(_) => f.write_str("EncryptionSpec::Aes256Gcm(..)"),
-        }
-    }
 }
 
 impl EncryptionSpec {

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -63,6 +63,12 @@ impl EncryptionKey {
         self.0.as_ref().expose_secret()
     }
 
+    pub(crate) fn bytes_32(&self) -> &[u8; 32] {
+        self.bytes()
+            .try_into()
+            .expect("encryption key should be 32 bytes after validation")
+    }
+
     pub fn to_header_value(&self) -> HeaderValue {
         let mut value = header_value_for_key_material(self.bytes());
         value.set_sensitive(true);
@@ -92,9 +98,13 @@ pub enum EncryptionResolutionError {
     },
 }
 
-/// Resolved stream encryption after combining stream metadata with the request key.
+/// Resolved stream encryption after combining stream metadata with customer-supplied encryption
+/// key, if any.
 #[derive(Debug, Clone, Default)]
-pub enum EncryptionSpec {
+pub struct EncryptionSpec(EncryptionSpecInner);
+
+#[derive(Debug, Clone, Default)]
+pub(crate) enum EncryptionSpecInner {
     #[default]
     Plaintext,
     Aegis256(EncryptionKey),
@@ -114,42 +124,38 @@ impl EncryptionSpec {
             (None, _) => Ok(Self::plain()),
             (Some(EncryptionAlgorithm::Aegis256), Some(key)) => {
                 validate_key_length(EncryptionAlgorithm::Aegis256, &key)?;
-                Ok(Self::Aegis256(key))
+                Ok(Self(EncryptionSpecInner::Aegis256(key)))
             }
             (Some(EncryptionAlgorithm::Aes256Gcm), Some(key)) => {
                 validate_key_length(EncryptionAlgorithm::Aes256Gcm, &key)?;
-                Ok(Self::Aes256Gcm(key))
+                Ok(Self(EncryptionSpecInner::Aes256Gcm(key)))
             }
             (Some(algorithm), None) => Err(EncryptionResolutionError::MissingKey { algorithm }),
         }
     }
 
     pub fn aegis256(key: [u8; 32]) -> Self {
-        Self::Aegis256(EncryptionKey::new(key))
+        Self(EncryptionSpecInner::Aegis256(EncryptionKey::new(key)))
     }
 
     pub fn aes256_gcm(key: [u8; 32]) -> Self {
-        Self::Aes256Gcm(EncryptionKey::new(key))
+        Self(EncryptionSpecInner::Aes256Gcm(EncryptionKey::new(key)))
     }
 
     pub fn algorithm(&self) -> Option<EncryptionAlgorithm> {
-        match self {
-            Self::Plaintext => None,
-            Self::Aegis256(_) => Some(EncryptionAlgorithm::Aegis256),
-            Self::Aes256Gcm(_) => Some(EncryptionAlgorithm::Aes256Gcm),
+        match self.inner() {
+            EncryptionSpecInner::Plaintext => None,
+            EncryptionSpecInner::Aegis256(_) => Some(EncryptionAlgorithm::Aegis256),
+            EncryptionSpecInner::Aes256Gcm(_) => Some(EncryptionAlgorithm::Aes256Gcm),
         }
     }
 
     pub fn is_plain(&self) -> bool {
-        matches!(self, Self::Plaintext)
+        matches!(self.inner(), EncryptionSpecInner::Plaintext)
     }
 
-    pub(crate) fn key_for_algorithm(&self, algorithm: EncryptionAlgorithm) -> Option<&[u8; 32]> {
-        match (self, algorithm) {
-            (Self::Aegis256(key), EncryptionAlgorithm::Aegis256)
-            | (Self::Aes256Gcm(key), EncryptionAlgorithm::Aes256Gcm) => Some(key_bytes_32(key)),
-            _ => None,
-        }
+    pub(crate) fn inner(&self) -> &EncryptionSpecInner {
+        &self.0
     }
 }
 
@@ -190,12 +196,11 @@ fn validate_key_length(
     algorithm: EncryptionAlgorithm,
     key: &EncryptionKey,
 ) -> Result<(), EncryptionResolutionError> {
-    let bytes = key.bytes();
-    if bytes.len() != 32 {
+    if key.0.expose_secret().len() != 32 {
         return Err(EncryptionResolutionError::InvalidKeyLength {
             algorithm,
             expected: 32,
-            actual: bytes.len(),
+            actual: key.0.expose_secret().len(),
         });
     }
 
@@ -206,12 +211,6 @@ fn header_value_for_key_material(key: &[u8]) -> HeaderValue {
     let mut value = vec![0u8; base64ct::Base64::encoded_len(key)];
     base64ct::Base64::encode(key, &mut value).expect("base64 output length should match buffer");
     HeaderValue::from_bytes(&value).expect("encryption key header value should be ASCII")
-}
-
-fn key_bytes_32(key: &EncryptionKey) -> &[u8; 32] {
-    key.bytes()
-        .try_into()
-        .expect("encryption key should be 32 bytes after validation")
 }
 
 #[cfg(test)]

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -3,19 +3,20 @@
 use core::str::FromStr;
 use std::sync::Arc;
 
-use base64ct::Encoding;
+use base64ct::{Base64, Decoder, Encoding};
 use http::{HeaderName, HeaderValue};
-use secrecy::{ExposeSecret, SecretBox, zeroize::Zeroizing};
+use secrecy::{ExposeSecret, SecretBox, SecretString, zeroize::Zeroize};
 use strum::{Display, EnumString};
 
 use crate::http::ParseableHeader;
 
 pub static S2_ENCRYPTION_KEY_HEADER: HeaderName = HeaderName::from_static("s2-encryption-key");
 
-type SecretKeyMaterial = Arc<SecretBox<[u8]>>;
+// 32 bytes in Base 64
+const MAX_ENCRYPTION_KEY_HEADER_VALUE_LEN: usize = 44;
 
-// 32 bytes incl padding
-const MAX_ENCRYPTION_KEY_HEADER_LEN: usize = 44;
+type EncodedKeyMaterial = Arc<SecretString>;
+type DecodedKeyMaterial<const N: usize> = Arc<SecretBox<[u8; N]>>;
 
 /// Encryption algorithm.
 #[derive(
@@ -46,74 +47,52 @@ pub enum EncryptionAlgorithm {
 }
 
 /// Customer-supplied encryption key material for append/read operations.
+///
+/// The request header value remains opaque until it is resolved into a
+/// fixed-size key for a specific stream cipher.
 #[derive(Debug, Clone)]
-pub struct EncryptionKey(SecretKeyMaterial);
+pub struct EncryptionKey(EncodedKeyMaterial);
 
 impl EncryptionKey {
     pub fn new<const N: usize>(key: [u8; N]) -> Self {
-        Self(Arc::new(SecretBox::new(Box::new(key))))
+        Self(Arc::new(Base64::encode_string(&key).into()))
     }
 
-    pub fn from_base64(key_b64: &str) -> Result<Self, EncryptionKeyError> {
-        parse_encryption_key_material(key_b64).map(Self)
-    }
-
-    pub(crate) fn expose_secret(&self) -> &[u8] {
+    pub(crate) fn expose_secret(&self) -> &str {
         self.0.expose_secret()
     }
 
     pub fn to_header_value(&self) -> HeaderValue {
-        let mut value = header_value_for_key_material(self.expose_secret());
+        let mut value = header_value_for_encoded_key_material(self.expose_secret());
         value.set_sensitive(true);
         value
     }
 }
 
-/// Fixed-size customer-supplied encryption key material.
+/// Decoded fixed-size customer-supplied encryption key material.
 #[derive(Debug, Clone)]
-pub struct FixedSizeEncryptionKey<const N: usize>(EncryptionKey);
+pub struct DecodedEncryptionKey<const N: usize>(DecodedKeyMaterial<N>);
 
-impl<const N: usize> FixedSizeEncryptionKey<N> {
+impl<const N: usize> DecodedEncryptionKey<N> {
     pub fn new(key: [u8; N]) -> Self {
-        Self(EncryptionKey::new(key))
+        Self(Arc::new(SecretBox::new(Box::new(key))))
     }
 
     pub(crate) fn expose_secret(&self) -> &[u8; N] {
-        self.0
-            .expose_secret()
-            .try_into()
-            .expect("fixed-size encryption key length validated at construction")
+        self.0.expose_secret()
     }
 }
 
-impl<const N: usize> TryFrom<EncryptionKey> for FixedSizeEncryptionKey<N> {
-    type Error = usize;
-
-    fn try_from(key: EncryptionKey) -> Result<Self, Self::Error> {
-        let actual = key.expose_secret().len();
-        if actual != N {
-            return Err(actual);
-        }
-        Ok(Self(key))
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum EncryptionKeyError {
-    #[error("invalid encryption key: key is not valid base64")]
-    InvalidBase64,
-    #[error("invalid encryption key: key material must not be empty")]
-    Empty,
-    #[error(
-        "invalid encryption key: encoded key material exceeds maximum length of {max} characters (got {actual})"
-    )]
-    TooLong { max: usize, actual: usize },
-}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("invalid encryption key: key material length {0} is out of range")]
+pub struct EncryptionKeyLengthError(usize);
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum EncryptionSpecResolutionError {
     #[error("missing encryption key for stream cipher '{cipher}'")]
     MissingKey { cipher: EncryptionAlgorithm },
+    #[error("invalid encryption key for stream cipher '{cipher}': invalid base64")]
+    InvalidBase64 { cipher: EncryptionAlgorithm },
     #[error("invalid encryption key length for stream cipher '{cipher}': {length}")]
     InvalidKeyLength {
         cipher: EncryptionAlgorithm,
@@ -127,8 +106,8 @@ pub enum EncryptionSpecResolutionError {
 pub enum EncryptionSpec {
     #[default]
     Plain,
-    Aegis256(FixedSizeEncryptionKey<32>),
-    Aes256Gcm(FixedSizeEncryptionKey<32>),
+    Aegis256(DecodedEncryptionKey<32>),
+    Aes256Gcm(DecodedEncryptionKey<32>),
 }
 
 impl EncryptionSpec {
@@ -139,39 +118,34 @@ impl EncryptionSpec {
         match (cipher, key) {
             (None, _) => Ok(Self::Plain),
             (Some(cipher @ EncryptionAlgorithm::Aegis256), Some(key)) => {
-                Ok(Self::Aegis256(key.try_into().map_err(|actual| {
-                    EncryptionSpecResolutionError::InvalidKeyLength {
-                        cipher,
-                        length: actual,
-                    }
-                })?))
+                Ok(Self::Aegis256(resolve_fixed_size_key(cipher, key)?))
             }
             (Some(cipher @ EncryptionAlgorithm::Aes256Gcm), Some(key)) => {
-                Ok(Self::Aes256Gcm(key.try_into().map_err(|actual| {
-                    EncryptionSpecResolutionError::InvalidKeyLength {
-                        cipher,
-                        length: actual,
-                    }
-                })?))
+                Ok(Self::Aes256Gcm(resolve_fixed_size_key(cipher, key)?))
             }
             (Some(cipher), None) => Err(EncryptionSpecResolutionError::MissingKey { cipher }),
         }
     }
 
     pub fn aegis256(key: [u8; 32]) -> Self {
-        Self::Aegis256(FixedSizeEncryptionKey::new(key))
+        Self::Aegis256(DecodedEncryptionKey::new(key))
     }
 
     pub fn aes256_gcm(key: [u8; 32]) -> Self {
-        Self::Aes256Gcm(FixedSizeEncryptionKey::new(key))
+        Self::Aes256Gcm(DecodedEncryptionKey::new(key))
     }
 }
 
 impl FromStr for EncryptionKey {
-    type Err = EncryptionKeyError;
+    type Err = EncryptionKeyLengthError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::from_base64(s.trim())
+        let trimmed = s.trim();
+        if (1..=MAX_ENCRYPTION_KEY_HEADER_VALUE_LEN).contains(&trimmed.len()) {
+            Ok(Self(Arc::new(trimmed.to_owned().into())))
+        } else {
+            Err(EncryptionKeyLengthError(trimmed.len()))
+        }
     }
 }
 
@@ -181,40 +155,44 @@ impl ParseableHeader for EncryptionKey {
     }
 }
 
-fn parse_encryption_key_material(key_b64: &str) -> Result<SecretKeyMaterial, EncryptionKeyError> {
-    use base64ct::{Base64, Encoding};
-
-    if key_b64.len() > MAX_ENCRYPTION_KEY_HEADER_LEN {
-        return Err(EncryptionKeyError::TooLong {
-            max: MAX_ENCRYPTION_KEY_HEADER_LEN,
-            actual: key_b64.len(),
-        });
-    }
-
-    let key = match Base64::decode_vec(key_b64) {
-        Ok(decoded) => decoded,
-        Err(_) => {
-            return Err(EncryptionKeyError::InvalidBase64);
+fn resolve_fixed_size_key<const N: usize>(
+    cipher: EncryptionAlgorithm,
+    key: EncryptionKey,
+) -> Result<DecodedEncryptionKey<N>, EncryptionSpecResolutionError> {
+    let mut decoder = Decoder::<Base64>::new(key.expose_secret().as_bytes())
+        .map_err(|_| EncryptionSpecResolutionError::InvalidBase64 { cipher })?;
+    let mut key_material = Box::new([0u8; N]);
+    match decoder.decode(key_material.as_mut()) {
+        Ok(_) if decoder.is_finished() => {
+            Ok(DecodedEncryptionKey(Arc::new(SecretBox::new(key_material))))
         }
-    };
-
-    if key.is_empty() {
-        return Err(EncryptionKeyError::Empty);
+        Ok(_) => {
+            let length = N
+                .checked_add(decoder.remaining_len())
+                .expect("decoded key length should fit usize");
+            key_material.as_mut().zeroize();
+            Err(EncryptionSpecResolutionError::InvalidKeyLength { cipher, length })
+        }
+        Err(base64ct::Error::InvalidEncoding) => {
+            key_material.as_mut().zeroize();
+            Err(EncryptionSpecResolutionError::InvalidBase64 { cipher })
+        }
+        Err(base64ct::Error::InvalidLength) => {
+            let length = decoder.remaining_len();
+            key_material.as_mut().zeroize();
+            Err(EncryptionSpecResolutionError::InvalidKeyLength { cipher, length })
+        }
     }
-
-    Ok(Arc::new(SecretBox::new(key.into_boxed_slice())))
 }
 
-fn header_value_for_key_material(key: &[u8]) -> HeaderValue {
-    let mut value = Zeroizing::new(vec![0u8; base64ct::Base64::encoded_len(key)]);
-    base64ct::Base64::encode(key, &mut value).expect("base64 output length should match buffer");
-    HeaderValue::from_bytes(&value).expect("encryption key header value should be ASCII")
+fn header_value_for_encoded_key_material(key_b64: &str) -> HeaderValue {
+    HeaderValue::from_bytes(key_b64.as_bytes())
+        .expect("encryption key header value should be ASCII")
 }
 
 #[cfg(test)]
 mod tests {
     use http::header::HeaderValue;
-    use rstest::rstest;
 
     use super::*;
 
@@ -238,18 +216,7 @@ mod tests {
         assert!(value.is_sensitive());
 
         let parsed = value.to_str().unwrap().parse::<EncryptionKey>().unwrap();
-        assert_eq!(parsed.expose_secret(), KEY_BYTES);
-    }
-
-    #[rstest]
-    #[case("", EncryptionKeyError::Empty)]
-    #[case("not-valid-base64!!!", EncryptionKeyError::InvalidBase64)]
-    fn parse_key_header_invalid_cases(#[case] header: &str, #[case] expected: EncryptionKeyError) {
-        let result = header.parse::<EncryptionKey>();
-        match result {
-            Err(actual) => assert_eq!(actual, expected),
-            Ok(_) => panic!("expected invalid key for {header:?}"),
-        }
+        assert_eq!(parsed.to_header_value().to_str().unwrap(), KEY_B64);
     }
 
     #[test]
@@ -282,33 +249,6 @@ mod tests {
             EncryptionSpecResolutionError::InvalidKeyLength {
                 cipher: EncryptionAlgorithm::Aegis256,
                 length: 4,
-            }
-        );
-    }
-
-    #[test]
-    fn resolve_encrypted_reuses_decoded_key_material() {
-        let key = EncryptionKey::new(KEY_BYTES);
-        let secret_ptr = key.0.expose_secret().as_ptr();
-
-        let encryption = EncryptionSpec::resolve(Some(EncryptionAlgorithm::Aegis256), Some(key))
-            .expect("resolve typed encryption key");
-
-        let EncryptionSpec::Aegis256(key) = encryption else {
-            panic!("expected AEGIS-256 encryption");
-        };
-        assert_eq!(key.expose_secret().as_ptr(), secret_ptr);
-    }
-
-    #[test]
-    fn parse_key_header_rejects_overlong_encoded_material() {
-        let header = "A".repeat(MAX_ENCRYPTION_KEY_HEADER_LEN + 1);
-        let result = header.parse::<EncryptionKey>();
-        assert_eq!(
-            result.unwrap_err(),
-            EncryptionKeyError::TooLong {
-                max: MAX_ENCRYPTION_KEY_HEADER_LEN,
-                actual: MAX_ENCRYPTION_KEY_HEADER_LEN + 1,
             }
         );
     }

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -69,6 +69,35 @@ impl EncryptionKey {
     }
 }
 
+/// Fixed-size customer-supplied encryption key material.
+#[derive(Debug, Clone)]
+pub struct FixedSizeEncryptionKey<const N: usize>(EncryptionKey);
+
+impl<const N: usize> FixedSizeEncryptionKey<N> {
+    pub fn new(key: [u8; N]) -> Self {
+        Self(EncryptionKey::new(key))
+    }
+
+    pub(crate) fn expose_secret(&self) -> &[u8; N] {
+        self.0
+            .expose_secret()
+            .try_into()
+            .expect("fixed-size encryption key length validated at construction")
+    }
+}
+
+impl<const N: usize> TryFrom<EncryptionKey> for FixedSizeEncryptionKey<N> {
+    type Error = usize;
+
+    fn try_from(key: EncryptionKey) -> Result<Self, Self::Error> {
+        let actual = key.expose_secret().len();
+        if actual != N {
+            return Err(actual);
+        }
+        Ok(Self(key))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum EncryptionKeyError {
     #[error("invalid encryption key: key is not valid base64")]
@@ -82,16 +111,13 @@ pub enum EncryptionKeyError {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum EncryptionResolutionError {
-    #[error("missing encryption key for stream encryption algorithm '{algorithm}'")]
-    MissingKey { algorithm: EncryptionAlgorithm },
-    #[error(
-        "invalid encryption key length for stream encryption algorithm '{algorithm}': expected {expected} bytes, got {actual} bytes"
-    )]
+pub enum EncryptionSpecResolutionError {
+    #[error("missing encryption key for stream cipher '{cipher}'")]
+    MissingKey { cipher: EncryptionAlgorithm },
+    #[error("invalid encryption key length for stream cipher '{cipher}': {length}")]
     InvalidKeyLength {
-        algorithm: EncryptionAlgorithm,
-        expected: usize,
-        actual: usize,
+        cipher: EncryptionAlgorithm,
+        length: usize,
     },
 }
 
@@ -101,35 +127,43 @@ pub enum EncryptionResolutionError {
 pub enum EncryptionSpec {
     #[default]
     Plain,
-    Aegis256(EncryptionKey),
-    Aes256Gcm(EncryptionKey),
+    Aegis256(FixedSizeEncryptionKey<32>),
+    Aes256Gcm(FixedSizeEncryptionKey<32>),
 }
 
 impl EncryptionSpec {
     pub fn resolve(
-        algorithm: Option<EncryptionAlgorithm>,
+        cipher: Option<EncryptionAlgorithm>,
         key: Option<EncryptionKey>,
-    ) -> Result<Self, EncryptionResolutionError> {
-        match (algorithm, key) {
+    ) -> Result<Self, EncryptionSpecResolutionError> {
+        match (cipher, key) {
             (None, _) => Ok(Self::Plain),
-            (Some(EncryptionAlgorithm::Aegis256), Some(key)) => {
-                validate_key_length(EncryptionAlgorithm::Aegis256, &key)?;
-                Ok(Self::Aegis256(key))
+            (Some(cipher @ EncryptionAlgorithm::Aegis256), Some(key)) => {
+                Ok(Self::Aegis256(key.try_into().map_err(|actual| {
+                    EncryptionSpecResolutionError::InvalidKeyLength {
+                        cipher,
+                        length: actual,
+                    }
+                })?))
             }
-            (Some(EncryptionAlgorithm::Aes256Gcm), Some(key)) => {
-                validate_key_length(EncryptionAlgorithm::Aes256Gcm, &key)?;
-                Ok(Self::Aes256Gcm(key))
+            (Some(cipher @ EncryptionAlgorithm::Aes256Gcm), Some(key)) => {
+                Ok(Self::Aes256Gcm(key.try_into().map_err(|actual| {
+                    EncryptionSpecResolutionError::InvalidKeyLength {
+                        cipher,
+                        length: actual,
+                    }
+                })?))
             }
-            (Some(algorithm), None) => Err(EncryptionResolutionError::MissingKey { algorithm }),
+            (Some(cipher), None) => Err(EncryptionSpecResolutionError::MissingKey { cipher }),
         }
     }
 
     pub fn aegis256(key: [u8; 32]) -> Self {
-        Self::Aegis256(EncryptionKey::new(key))
+        Self::Aegis256(FixedSizeEncryptionKey::new(key))
     }
 
     pub fn aes256_gcm(key: [u8; 32]) -> Self {
-        Self::Aes256Gcm(EncryptionKey::new(key))
+        Self::Aes256Gcm(FixedSizeEncryptionKey::new(key))
     }
 }
 
@@ -169,24 +203,6 @@ fn parse_encryption_key_material(key_b64: &str) -> Result<SecretKeyMaterial, Enc
     }
 
     Ok(Arc::new(SecretBox::new(key.into_boxed_slice())))
-}
-
-fn validate_key_length(
-    algorithm: EncryptionAlgorithm,
-    key: &EncryptionKey,
-) -> Result<(), EncryptionResolutionError> {
-    let expected = match algorithm {
-        EncryptionAlgorithm::Aegis256 | EncryptionAlgorithm::Aes256Gcm => 32,
-    };
-    let actual = key.0.expose_secret().len();
-    if expected != actual {
-        return Err(EncryptionResolutionError::InvalidKeyLength {
-            algorithm,
-            expected,
-            actual,
-        });
-    }
-    Ok(())
 }
 
 fn header_value_for_key_material(key: &[u8]) -> HeaderValue {
@@ -248,8 +264,8 @@ mod tests {
         let err = EncryptionSpec::resolve(Some(EncryptionAlgorithm::Aegis256), None).unwrap_err();
         assert_eq!(
             err,
-            EncryptionResolutionError::MissingKey {
-                algorithm: EncryptionAlgorithm::Aegis256,
+            EncryptionSpecResolutionError::MissingKey {
+                cipher: EncryptionAlgorithm::Aegis256,
             }
         );
     }
@@ -263,12 +279,25 @@ mod tests {
         .unwrap_err();
         assert_eq!(
             err,
-            EncryptionResolutionError::InvalidKeyLength {
-                algorithm: EncryptionAlgorithm::Aegis256,
-                expected: 32,
-                actual: 4,
+            EncryptionSpecResolutionError::InvalidKeyLength {
+                cipher: EncryptionAlgorithm::Aegis256,
+                length: 4,
             }
         );
+    }
+
+    #[test]
+    fn resolve_encrypted_reuses_decoded_key_material() {
+        let key = EncryptionKey::new(KEY_BYTES);
+        let secret_ptr = key.0.expose_secret().as_ptr();
+
+        let encryption = EncryptionSpec::resolve(Some(EncryptionAlgorithm::Aegis256), Some(key))
+            .expect("resolve typed encryption key");
+
+        let EncryptionSpec::Aegis256(key) = encryption else {
+            panic!("expected AEGIS-256 encryption");
+        };
+        assert_eq!(key.expose_secret().as_ptr(), secret_ptr);
     }
 
     #[test]

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -51,23 +51,19 @@ pub struct EncryptionKey(SecretKeyMaterial);
 
 impl EncryptionKey {
     pub fn new<const N: usize>(key: [u8; N]) -> Self {
-        Self::from_bytes(Box::new(key))
+        Self(Arc::new(SecretBox::new(Box::new(key))))
     }
 
     pub fn from_base64(key_b64: &str) -> Result<Self, EncryptionKeyError> {
         parse_encryption_key_material(key_b64).map(Self)
     }
 
-    pub fn from_bytes(bytes: Box<[u8]>) -> Self {
-        Self(Arc::new(SecretBox::new(bytes)))
-    }
-
-    pub fn bytes(&self) -> &[u8] {
-        self.0.as_ref().expose_secret()
+    pub fn expose_secret(&self) -> &[u8] {
+        self.0.expose_secret()
     }
 
     pub fn to_header_value(&self) -> HeaderValue {
-        let mut value = header_value_for_key_material(self.bytes());
+        let mut value = header_value_for_key_material(self.expose_secret());
         value.set_sensitive(true);
         value
     }
@@ -181,15 +177,14 @@ fn validate_key_length(
     algorithm: EncryptionAlgorithm,
     key: &EncryptionKey,
 ) -> Result<(), EncryptionResolutionError> {
-    let bytes = key.bytes();
-    if bytes.len() != 32 {
+    let num_bytes = key.0.expose_secret().len();
+    if num_bytes != 32 {
         return Err(EncryptionResolutionError::InvalidKeyLength {
             algorithm,
             expected: 32,
-            actual: bytes.len(),
+            actual: num_bytes,
         });
     }
-
     Ok(())
 }
 
@@ -215,7 +210,7 @@ mod tests {
     #[test]
     fn parse_key_header_roundtrips() {
         let key = KEY_B64.parse::<EncryptionKey>().unwrap();
-        assert_eq!(key.bytes(), KEY_BYTES);
+        assert_eq!(key.expose_secret(), KEY_BYTES);
     }
 
     #[test]
@@ -232,7 +227,7 @@ mod tests {
         assert!(value.is_sensitive());
 
         let parsed = value.to_str().unwrap().parse::<EncryptionKey>().unwrap();
-        assert_eq!(parsed.bytes(), KEY_BYTES);
+        assert_eq!(parsed.expose_secret(), KEY_BYTES);
     }
 
     #[rstest]
@@ -278,7 +273,7 @@ mod tests {
     fn resolve_encrypted_validates_key_length_per_algorithm() {
         let err = EncryptionSpec::resolve(
             Some(EncryptionAlgorithm::Aegis256),
-            Some(EncryptionKey::from_bytes(vec![0x42; 4].into_boxed_slice())),
+            Some(EncryptionKey::new([0x42; 4])),
         )
         .unwrap_err();
         assert_eq!(

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -185,7 +185,7 @@ fn resolve_key<const N: usize>(
 
 #[cfg(test)]
 mod tests {
-    use http::header::HeaderValue;
+    use rstest::rstest;
 
     use super::*;
 
@@ -195,15 +195,15 @@ mod tests {
         26, 27, 28, 29, 30, 31, 32,
     ];
 
-    #[test]
-    fn key_header_value_is_sensitive() {
-        let value = EncryptionKey::new([7; 32]).to_header_value();
-        assert!(value.is_sensitive());
-        assert_ne!(value, HeaderValue::from_static("plain"));
+    fn resolve_encrypted(
+        cipher: EncryptionAlgorithm,
+        key: EncryptionKey,
+    ) -> Result<EncryptionSpec, EncryptionSpecResolutionError> {
+        EncryptionSpec::resolve(Some(cipher), Some(key))
     }
 
     #[test]
-    fn key_header_value_roundtrips() {
+    fn key_header_value_roundtrips_and_is_sensitive() {
         let value = EncryptionKey::new(KEY_BYTES).to_header_value();
         assert_eq!(value.to_str().unwrap(), KEY_B64);
         assert!(value.is_sensitive());
@@ -213,36 +213,75 @@ mod tests {
     }
 
     #[test]
-    fn resolve_plain_ignores_key() {
-        let encryption =
-            EncryptionSpec::resolve(None, Some(EncryptionKey::new(KEY_BYTES))).unwrap();
-        assert!(matches!(encryption, EncryptionSpec::Plain));
-    }
+    fn encryption_key_parsing_trims_and_enforces_bounds() {
+        let parsed = format!("  {KEY_B64}\n").parse::<EncryptionKey>().unwrap();
+        assert_eq!(parsed.to_header_value().to_str().unwrap(), KEY_B64);
 
-    #[test]
-    fn resolve_encrypted_requires_key() {
-        let err = EncryptionSpec::resolve(Some(EncryptionAlgorithm::Aegis256), None).unwrap_err();
         assert_eq!(
-            err,
-            EncryptionSpecResolutionError::MissingKey {
-                cipher: EncryptionAlgorithm::Aegis256,
-            }
+            "   ".parse::<EncryptionKey>().unwrap_err(),
+            EncryptionKeyLengthError(0)
+        );
+
+        let too_long = "A".repeat(MAX_ENCRYPTION_KEY_HEADER_VALUE_LEN + 1);
+        assert_eq!(
+            too_long.parse::<EncryptionKey>().unwrap_err(),
+            EncryptionKeyLengthError(MAX_ENCRYPTION_KEY_HEADER_VALUE_LEN + 1)
         );
     }
 
     #[test]
-    fn resolve_encrypted_validates_key_length_per_algorithm() {
-        let err = EncryptionSpec::resolve(
-            Some(EncryptionAlgorithm::Aegis256),
-            Some(EncryptionKey::new([0x42; 4])),
-        )
-        .unwrap_err();
-        assert_eq!(
-            err,
-            EncryptionSpecResolutionError::InvalidKeyLength {
-                cipher: EncryptionAlgorithm::Aegis256,
-                length: 4,
+    fn resolve_plain_ignores_supplied_key() {
+        let encryption = EncryptionSpec::resolve(None, Some("!!!!".parse().unwrap())).unwrap();
+        assert!(matches!(encryption, EncryptionSpec::Plain));
+    }
+
+    #[rstest]
+    #[case(EncryptionAlgorithm::Aegis256)]
+    #[case(EncryptionAlgorithm::Aes256Gcm)]
+    fn resolve_encrypted_requires_key(#[case] cipher: EncryptionAlgorithm) {
+        let err = EncryptionSpec::resolve(Some(cipher), None).unwrap_err();
+        assert_eq!(err, EncryptionSpecResolutionError::MissingKey { cipher });
+    }
+
+    #[rstest]
+    #[case(EncryptionAlgorithm::Aegis256)]
+    #[case(EncryptionAlgorithm::Aes256Gcm)]
+    fn resolve_encrypted_decodes_key_for_each_algorithm(#[case] cipher: EncryptionAlgorithm) {
+        let encryption = resolve_encrypted(cipher, EncryptionKey::new(KEY_BYTES)).unwrap();
+
+        match (cipher, encryption) {
+            (EncryptionAlgorithm::Aegis256, EncryptionSpec::Aegis256(key)) => {
+                assert_eq!(key.expose_secret(), &KEY_BYTES);
             }
+            (EncryptionAlgorithm::Aes256Gcm, EncryptionSpec::Aes256Gcm(key)) => {
+                assert_eq!(key.expose_secret(), &KEY_BYTES);
+            }
+            _ => panic!("resolved encryption spec did not match requested algorithm"),
+        }
+    }
+
+    #[rstest]
+    #[case(EncryptionAlgorithm::Aegis256)]
+    #[case(EncryptionAlgorithm::Aes256Gcm)]
+    fn resolve_encrypted_rejects_invalid_base64(#[case] cipher: EncryptionAlgorithm) {
+        let err = resolve_encrypted(cipher, "!!!!".parse().unwrap()).unwrap_err();
+        assert_eq!(err, EncryptionSpecResolutionError::InvalidBase64 { cipher });
+    }
+
+    #[test]
+    fn resolve_encrypted_rejects_non_32_byte_keys() {
+        let cipher = EncryptionAlgorithm::Aegis256;
+
+        let short_err = resolve_encrypted(cipher, EncryptionKey::new([0x42; 4])).unwrap_err();
+        assert_eq!(
+            short_err,
+            EncryptionSpecResolutionError::InvalidKeyLength { cipher, length: 4 }
+        );
+
+        let long_err = resolve_encrypted(cipher, EncryptionKey::new([0x42; 33])).unwrap_err();
+        assert_eq!(
+            long_err,
+            EncryptionSpecResolutionError::InvalidKeyLength { cipher, length: 33 }
         );
     }
 }

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -1,4 +1,4 @@
-//! Encryption algorithm, key parsing, and key-only header handling.
+//! Encryption algorithm, key material parsing, and request header handling.
 
 use core::str::FromStr;
 use std::sync::Arc;
@@ -13,6 +13,7 @@ use crate::http::ParseableHeader;
 pub static S2_ENCRYPTION_KEY_HEADER: HeaderName = HeaderName::from_static("s2-encryption-key");
 
 type SecretKey = Arc<SecretBox<[u8; 32]>>;
+type SecretKeyMaterial = Arc<SecretBox<[u8]>>;
 
 /// Encryption algorithm.
 #[derive(
@@ -42,25 +43,33 @@ pub enum EncryptionAlgorithm {
     Aes256Gcm,
 }
 
-/// Customer-supplied encryption key shared by all supported algorithms.
+/// Customer-supplied encryption key material for append/read operations.
 #[derive(Debug, Clone)]
-pub struct EncryptionKey(SecretKey);
+pub struct EncryptionKey {
+    bytes: SecretKeyMaterial,
+}
 
 impl EncryptionKey {
     pub fn new(key: [u8; 32]) -> Self {
-        Self(Arc::new(SecretBox::new(Box::new(key))))
+        Self::from_bytes(Box::new(key))
     }
 
     pub fn from_base64(key_b64: &str) -> Result<Self, EncryptionKeyError> {
-        parse_encryption_key(key_b64).map(Self)
+        parse_encryption_key_material(key_b64).map(|bytes| Self { bytes })
     }
 
-    pub(crate) fn secret(&self) -> &[u8; 32] {
-        self.0.as_ref().expose_secret()
+    pub fn from_bytes(bytes: Box<[u8]>) -> Self {
+        Self {
+            bytes: Arc::new(SecretBox::new(bytes)),
+        }
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        self.bytes.as_ref().expose_secret()
     }
 
     pub fn to_header_value(&self) -> HeaderValue {
-        let mut value = header_value_for_key(self.secret());
+        let mut value = header_value_for_key_material(self.bytes());
         value.set_sensitive(true);
         value
     }
@@ -70,52 +79,96 @@ impl EncryptionKey {
 pub enum EncryptionKeyError {
     #[error("invalid encryption key: key is not valid base64")]
     InvalidBase64,
-    #[error("invalid encryption key: key must be exactly {expected} bytes, got {actual} bytes")]
-    InvalidLength { expected: usize, actual: usize },
+    #[error("invalid encryption key: key material must not be empty")]
+    Empty,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum EncryptionResolutionError {
     #[error("missing encryption key for stream encryption algorithm '{algorithm}'")]
     MissingKey { algorithm: EncryptionAlgorithm },
+    #[error(
+        "invalid encryption key length for stream encryption algorithm '{algorithm}': expected {expected} bytes, got {actual} bytes"
+    )]
+    InvalidKeyLength {
+        algorithm: EncryptionAlgorithm,
+        expected: usize,
+        actual: usize,
+    },
 }
 
 /// Resolved stream encryption after combining stream metadata with the request key.
-#[derive(Debug, Clone, Default)]
-pub enum Encryption {
-    #[default]
-    Plain,
-    Aegis256(EncryptionKey),
-    Aes256Gcm(EncryptionKey),
+#[derive(Clone, Default)]
+pub struct EncryptionSpec {
+    algorithm: Option<EncryptionAlgorithm>,
+    key: Option<SecretKey>,
 }
 
-impl Encryption {
+impl std::fmt::Debug for EncryptionSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncryptionSpec")
+            .field("algorithm", &self.algorithm)
+            .finish()
+    }
+}
+
+impl EncryptionSpec {
+    pub fn plain() -> Self {
+        Self::default()
+    }
+
     pub fn resolve(
         algorithm: Option<EncryptionAlgorithm>,
         key: Option<EncryptionKey>,
     ) -> Result<Self, EncryptionResolutionError> {
         match (algorithm, key) {
-            (None, _) => Ok(Self::Plain),
-            (Some(EncryptionAlgorithm::Aegis256), Some(key)) => Ok(Self::Aegis256(key)),
-            (Some(EncryptionAlgorithm::Aes256Gcm), Some(key)) => Ok(Self::Aes256Gcm(key)),
+            (None, _) => Ok(Self::plain()),
+            (Some(EncryptionAlgorithm::Aegis256), Some(key)) => Ok(Self::with_secret_key(
+                EncryptionAlgorithm::Aegis256,
+                resolve_secret_key(EncryptionAlgorithm::Aegis256, key)?,
+            )),
+            (Some(EncryptionAlgorithm::Aes256Gcm), Some(key)) => Ok(Self::with_secret_key(
+                EncryptionAlgorithm::Aes256Gcm,
+                resolve_secret_key(EncryptionAlgorithm::Aes256Gcm, key)?,
+            )),
             (Some(algorithm), None) => Err(EncryptionResolutionError::MissingKey { algorithm }),
         }
     }
 
     pub fn aegis256(key: [u8; 32]) -> Self {
-        Self::Aegis256(EncryptionKey::new(key))
+        Self::with_secret_key(EncryptionAlgorithm::Aegis256, secret_key(key))
     }
 
     pub fn aes256_gcm(key: [u8; 32]) -> Self {
-        Self::Aes256Gcm(EncryptionKey::new(key))
+        Self::with_secret_key(EncryptionAlgorithm::Aes256Gcm, secret_key(key))
     }
 
     pub fn algorithm(&self) -> Option<EncryptionAlgorithm> {
-        match self {
-            Self::Plain => None,
-            Self::Aegis256(_) => Some(EncryptionAlgorithm::Aegis256),
-            Self::Aes256Gcm(_) => Some(EncryptionAlgorithm::Aes256Gcm),
+        self.algorithm
+    }
+
+    pub fn is_plain(&self) -> bool {
+        self.algorithm.is_none()
+    }
+
+    fn with_secret_key(algorithm: EncryptionAlgorithm, key: SecretKey) -> Self {
+        Self {
+            algorithm: Some(algorithm),
+            key: Some(key),
         }
+    }
+
+    pub(crate) fn secret_key(&self) -> Option<&[u8; 32]> {
+        self.key.as_ref().map(|key| key.as_ref().expose_secret())
+    }
+
+    pub(crate) fn secret_key_for_algorithm(
+        &self,
+        algorithm: EncryptionAlgorithm,
+    ) -> Option<&[u8; 32]> {
+        (self.algorithm == Some(algorithm))
+            .then(|| self.secret_key())
+            .flatten()
     }
 }
 
@@ -133,35 +186,53 @@ impl ParseableHeader for EncryptionKey {
     }
 }
 
-fn parse_encryption_key(key_b64: &str) -> Result<SecretKey, EncryptionKeyError> {
+fn parse_encryption_key_material(key_b64: &str) -> Result<SecretKeyMaterial, EncryptionKeyError> {
     use base64ct::{Base64, Encoding};
     use secrecy::zeroize::Zeroize;
 
-    let mut key = Box::new([0u8; 32]);
-    let decoded = match Base64::decode(key_b64, key.as_mut()) {
+    let mut key = match Base64::decode_vec(key_b64) {
         Ok(decoded) => decoded,
         Err(_) => {
-            key.as_mut().zeroize();
             return Err(EncryptionKeyError::InvalidBase64);
         }
     };
 
-    if decoded.len() != 32 {
-        let len = decoded.len();
-        key.as_mut().zeroize();
-        return Err(EncryptionKeyError::InvalidLength {
+    if key.is_empty() {
+        key.zeroize();
+        return Err(EncryptionKeyError::Empty);
+    }
+
+    Ok(Arc::new(SecretBox::new(key.into_boxed_slice())))
+}
+
+fn resolve_secret_key(
+    algorithm: EncryptionAlgorithm,
+    key: EncryptionKey,
+) -> Result<SecretKey, EncryptionResolutionError> {
+    // Parse the request header as opaque bytes and validate the current
+    // algorithm-specific raw key requirement only at resolution time.
+    let bytes = key.bytes();
+    if bytes.len() != 32 {
+        return Err(EncryptionResolutionError::InvalidKeyLength {
+            algorithm,
             expected: 32,
-            actual: len,
+            actual: bytes.len(),
         });
     }
 
-    Ok(Arc::new(SecretBox::new(key)))
+    let mut secret = Box::new([0u8; 32]);
+    secret.copy_from_slice(bytes);
+    Ok(Arc::new(SecretBox::new(secret)))
 }
 
-fn header_value_for_key(key: &[u8; 32]) -> HeaderValue {
+fn header_value_for_key_material(key: &[u8]) -> HeaderValue {
     let mut value = vec![0u8; base64ct::Base64::encoded_len(key)];
     base64ct::Base64::encode(key, &mut value).expect("base64 output length should match buffer");
     HeaderValue::from_bytes(&value).expect("encryption key header value should be ASCII")
+}
+
+fn secret_key(key: [u8; 32]) -> SecretKey {
+    Arc::new(SecretBox::new(Box::new(key)))
 }
 
 #[cfg(test)]
@@ -180,7 +251,7 @@ mod tests {
     #[test]
     fn parse_key_header_roundtrips() {
         let key = KEY_B64.parse::<EncryptionKey>().unwrap();
-        assert_eq!(key.secret(), &KEY_BYTES);
+        assert_eq!(key.bytes(), KEY_BYTES);
     }
 
     #[test]
@@ -197,18 +268,11 @@ mod tests {
         assert!(value.is_sensitive());
 
         let parsed = value.to_str().unwrap().parse::<EncryptionKey>().unwrap();
-        assert_eq!(parsed.secret(), &KEY_BYTES);
+        assert_eq!(parsed.bytes(), KEY_BYTES);
     }
 
     #[rstest]
-    #[case("", EncryptionKeyError::InvalidLength {
-        expected: 32,
-        actual: 0
-    })]
-    #[case("3q2+7w==", EncryptionKeyError::InvalidLength {
-        expected: 32,
-        actual: 4
-    })]
+    #[case("", EncryptionKeyError::Empty)]
     #[case("not-valid-base64!!!", EncryptionKeyError::InvalidBase64)]
     fn parse_key_header_invalid_cases(#[case] header: &str, #[case] expected: EncryptionKeyError) {
         let result = header.parse::<EncryptionKey>();
@@ -230,17 +294,35 @@ mod tests {
 
     #[test]
     fn resolve_plain_ignores_key() {
-        let encryption = Encryption::resolve(None, Some(EncryptionKey::new(KEY_BYTES))).unwrap();
-        assert!(matches!(encryption, Encryption::Plain));
+        let encryption =
+            EncryptionSpec::resolve(None, Some(EncryptionKey::new(KEY_BYTES))).unwrap();
+        assert!(encryption.is_plain());
     }
 
     #[test]
     fn resolve_encrypted_requires_key() {
-        let err = Encryption::resolve(Some(EncryptionAlgorithm::Aegis256), None).unwrap_err();
+        let err = EncryptionSpec::resolve(Some(EncryptionAlgorithm::Aegis256), None).unwrap_err();
         assert_eq!(
             err,
             EncryptionResolutionError::MissingKey {
                 algorithm: EncryptionAlgorithm::Aegis256,
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_encrypted_validates_key_length_per_algorithm() {
+        let err = EncryptionSpec::resolve(
+            Some(EncryptionAlgorithm::Aegis256),
+            Some(EncryptionKey::from_bytes(vec![0x42; 4].into_boxed_slice())),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            EncryptionResolutionError::InvalidKeyLength {
+                algorithm: EncryptionAlgorithm::Aegis256,
+                expected: 32,
+                actual: 4,
             }
         );
     }

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use base64ct::Encoding;
 use http::{HeaderName, HeaderValue};
-use secrecy::{ExposeSecret, SecretBox};
+use secrecy::{ExposeSecret, SecretBox, zeroize::Zeroizing};
 use strum::{Display, EnumString};
 
 use crate::http::ParseableHeader;
@@ -206,7 +206,7 @@ fn parse_encryption_key_material(key_b64: &str) -> Result<SecretKeyMaterial, Enc
 }
 
 fn header_value_for_key_material(key: &[u8]) -> HeaderValue {
-    let mut value = vec![0u8; base64ct::Base64::encoded_len(key)];
+    let mut value = Zeroizing::new(vec![0u8; base64ct::Base64::encoded_len(key)]);
     base64ct::Base64::encode(key, &mut value).expect("base64 output length should match buffer");
     HeaderValue::from_bytes(&value).expect("encryption key header value should be ASCII")
 }

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -175,12 +175,15 @@ fn validate_key_length(
     algorithm: EncryptionAlgorithm,
     key: &EncryptionKey,
 ) -> Result<(), EncryptionResolutionError> {
-    let num_bytes = key.0.expose_secret().len();
-    if num_bytes != 32 {
+    let expected = match algorithm {
+        EncryptionAlgorithm::Aegis256 | EncryptionAlgorithm::Aes256Gcm => 32,
+    };
+    let actual = key.0.expose_secret().len();
+    if expected != actual {
         return Err(EncryptionResolutionError::InvalidKeyLength {
             algorithm,
-            expected: 32,
-            actual: num_bytes,
+            expected,
+            actual,
         });
     }
     Ok(())

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -1,28 +1,44 @@
-//! Encryption spec parsing, header parsing, and key parsing.
+//! Encryption algorithm, key parsing, and key-only header handling.
 
 use core::str::FromStr;
 use std::sync::Arc;
 
 use base64ct::Encoding;
 use http::{HeaderName, HeaderValue};
-use secrecy::{ExposeSecret, SecretBox, zeroize::Zeroizing};
+use secrecy::{ExposeSecret, SecretBox};
 use strum::{Display, EnumString};
 
 use crate::http::ParseableHeader;
 
-pub static S2_ENCRYPTION_HEADER: HeaderName = HeaderName::from_static("s2-encryption");
+pub static S2_ENCRYPTION_KEY_HEADER: HeaderName = HeaderName::from_static("s2-encryption-key");
 
-type EncryptionKey<const N: usize> = Arc<SecretBox<[u8; N]>>;
+type SecretKey = Arc<SecretBox<[u8; 32]>>;
 
 /// Encryption algorithm.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Display, EnumString)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+    Display,
+    EnumString,
+)]
 #[strum(ascii_case_insensitive)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum EncryptionAlgorithm {
     /// AEGIS-256
     #[strum(serialize = "aegis-256")]
+    #[serde(rename = "aegis-256")]
+    #[cfg_attr(feature = "clap", value(name = "aegis-256"))]
     Aegis256,
     /// AES-256-GCM
     #[strum(serialize = "aes-256-gcm")]
+    #[serde(rename = "aes-256-gcm")]
+    #[cfg_attr(feature = "clap", value(name = "aes-256-gcm"))]
     Aes256Gcm,
 }
 
@@ -66,75 +82,72 @@ impl From<EncryptionAlgorithm> for EncryptionMode {
     }
 }
 
+/// Customer-supplied encryption key shared by all supported algorithms.
 #[derive(Debug, Clone)]
-pub struct Aegis256Key(EncryptionKey<32>);
+pub struct EncryptionKey(SecretKey);
 
-impl Aegis256Key {
+impl EncryptionKey {
     pub fn new(key: [u8; 32]) -> Self {
         Self(Arc::new(SecretBox::new(Box::new(key))))
     }
 
-    pub fn from_base64(key_b64: &str) -> Result<Self, EncryptionSpecError> {
-        parse_encryption_key::<32>(key_b64).map(Self)
+    pub fn from_base64(key_b64: &str) -> Result<Self, EncryptionKeyError> {
+        parse_encryption_key(key_b64).map(Self)
     }
 
     pub(crate) fn secret(&self) -> &[u8; 32] {
         self.0.as_ref().expose_secret()
     }
-}
 
-#[derive(Debug, Clone)]
-pub struct Aes256GcmKey(EncryptionKey<32>);
-
-impl Aes256GcmKey {
-    pub fn new(key: [u8; 32]) -> Self {
-        Self(Arc::new(SecretBox::new(Box::new(key))))
-    }
-
-    pub fn from_base64(key_b64: &str) -> Result<Self, EncryptionSpecError> {
-        parse_encryption_key::<32>(key_b64).map(Self)
-    }
-
-    pub(crate) fn secret(&self) -> &[u8; 32] {
-        self.0.as_ref().expose_secret()
+    pub fn to_header_value(&self) -> HeaderValue {
+        let mut value = header_value_for_key(self.secret());
+        value.set_sensitive(true);
+        value
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum EncryptionSpecError {
-    #[error("Invalid encryption spec: expected '<mode>; <key>' or 'plain'")]
-    InvalidSyntax,
-    #[error("Invalid encryption spec: missing encryption mode")]
-    MissingMode,
-    #[error(
-        "Invalid encryption spec: unknown encryption mode {mode:?}; expected 'plain', 'aegis-256', or 'aes-256-gcm'"
-    )]
-    UnknownMode { mode: String },
-    #[error("Invalid encryption spec: key is not allowed when mode is 'plain'")]
-    UnexpectedKeyForPlain,
-    #[error("Invalid encryption spec: missing key for '{mode}'")]
-    MissingKey { mode: EncryptionMode },
-    #[error("Invalid encryption spec: key is not valid base64")]
-    InvalidKeyBase64,
-    #[error("Invalid encryption spec: key must be exactly {expected} bytes, got {actual} bytes")]
-    InvalidKeyLength { expected: usize, actual: usize },
+pub enum EncryptionKeyError {
+    #[error("invalid encryption key: key is not valid base64")]
+    InvalidBase64,
+    #[error("invalid encryption key: key must be exactly {expected} bytes, got {actual} bytes")]
+    InvalidLength { expected: usize, actual: usize },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum EncryptionResolutionError {
+    #[error("missing encryption key for stream encryption algorithm '{algorithm}'")]
+    MissingKey { algorithm: EncryptionAlgorithm },
+}
+
+/// Resolved stream encryption after combining stream metadata with the request key.
 #[derive(Debug, Clone, Default)]
-pub enum EncryptionSpec {
+pub enum Encryption {
     #[default]
     Plain,
-    Aegis256(Aegis256Key),
-    Aes256Gcm(Aes256GcmKey),
+    Aegis256(EncryptionKey),
+    Aes256Gcm(EncryptionKey),
 }
 
-impl EncryptionSpec {
+impl Encryption {
+    pub fn resolve(
+        algorithm: Option<EncryptionAlgorithm>,
+        key: Option<EncryptionKey>,
+    ) -> Result<Self, EncryptionResolutionError> {
+        match (algorithm, key) {
+            (None, _) => Ok(Self::Plain),
+            (Some(EncryptionAlgorithm::Aegis256), Some(key)) => Ok(Self::Aegis256(key)),
+            (Some(EncryptionAlgorithm::Aes256Gcm), Some(key)) => Ok(Self::Aes256Gcm(key)),
+            (Some(algorithm), None) => Err(EncryptionResolutionError::MissingKey { algorithm }),
+        }
+    }
+
     pub fn aegis256(key: [u8; 32]) -> Self {
-        Self::Aegis256(Aegis256Key::new(key))
+        Self::Aegis256(EncryptionKey::new(key))
     }
 
     pub fn aes256_gcm(key: [u8; 32]) -> Self {
-        Self::Aes256Gcm(Aes256GcmKey::new(key))
+        Self::Aes256Gcm(EncryptionKey::new(key))
     }
 
     pub fn mode(&self) -> EncryptionMode {
@@ -144,84 +157,40 @@ impl EncryptionSpec {
             Self::Aes256Gcm(_) => EncryptionMode::Aes256Gcm,
         }
     }
-
-    pub fn to_header_value(&self) -> HeaderValue {
-        let mut value = match self {
-            Self::Plain => HeaderValue::from_static("plain"),
-            Self::Aegis256(key) => {
-                header_value_for_key(EncryptionAlgorithm::Aegis256, key.secret())
-            }
-            Self::Aes256Gcm(key) => {
-                header_value_for_key(EncryptionAlgorithm::Aes256Gcm, key.secret())
-            }
-        };
-        value.set_sensitive(true);
-        value
-    }
 }
 
-impl FromStr for EncryptionSpec {
-    type Err = EncryptionSpecError;
+impl FromStr for EncryptionKey {
+    type Err = EncryptionKeyError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.trim();
-        let mut parts = s.splitn(3, ';');
-        let mode_str = parts.next().unwrap_or_default().trim();
-        let key_b64 = parts.next().map(str::trim);
-        if parts.next().is_some() {
-            return Err(EncryptionSpecError::InvalidSyntax);
-        }
-
-        if mode_str.is_empty() {
-            return Err(EncryptionSpecError::MissingMode);
-        }
-
-        let key_b64 = key_b64.filter(|key| !key.is_empty());
-        match (parse_mode(mode_str)?, key_b64) {
-            (EncryptionMode::Plain, None) => Ok(Self::Plain),
-            (EncryptionMode::Plain, Some(_)) => Err(EncryptionSpecError::UnexpectedKeyForPlain),
-            (EncryptionMode::Aegis256, Some(key_b64)) => {
-                Ok(Self::Aegis256(Aegis256Key::from_base64(key_b64)?))
-            }
-            (EncryptionMode::Aegis256, None) => Err(EncryptionSpecError::MissingKey {
-                mode: EncryptionMode::Aegis256,
-            }),
-            (EncryptionMode::Aes256Gcm, Some(key_b64)) => {
-                Ok(Self::Aes256Gcm(Aes256GcmKey::from_base64(key_b64)?))
-            }
-            (EncryptionMode::Aes256Gcm, None) => Err(EncryptionSpecError::MissingKey {
-                mode: EncryptionMode::Aes256Gcm,
-            }),
-        }
+        Self::from_base64(s.trim())
     }
 }
 
-impl ParseableHeader for EncryptionSpec {
+impl ParseableHeader for EncryptionKey {
     fn name() -> &'static HeaderName {
-        &S2_ENCRYPTION_HEADER
+        &S2_ENCRYPTION_KEY_HEADER
     }
 }
 
-fn parse_encryption_key<const N: usize>(
-    key_b64: &str,
-) -> Result<EncryptionKey<N>, EncryptionSpecError> {
+fn parse_encryption_key(key_b64: &str) -> Result<SecretKey, EncryptionKeyError> {
     use base64ct::{Base64, Encoding};
     use secrecy::zeroize::Zeroize;
 
-    let mut key = Box::new([0u8; N]);
+    let mut key = Box::new([0u8; 32]);
     let decoded = match Base64::decode(key_b64, key.as_mut()) {
         Ok(decoded) => decoded,
         Err(_) => {
             key.as_mut().zeroize();
-            return Err(EncryptionSpecError::InvalidKeyBase64);
+            return Err(EncryptionKeyError::InvalidBase64);
         }
     };
 
-    if decoded.len() != N {
+    if decoded.len() != 32 {
         let len = decoded.len();
         key.as_mut().zeroize();
-        return Err(EncryptionSpecError::InvalidKeyLength {
-            expected: N,
+        return Err(EncryptionKeyError::InvalidLength {
+            expected: 32,
             actual: len,
         });
     }
@@ -229,24 +198,10 @@ fn parse_encryption_key<const N: usize>(
     Ok(Arc::new(SecretBox::new(key)))
 }
 
-fn header_value_for_key(algorithm: EncryptionAlgorithm, key: &[u8; 32]) -> HeaderValue {
-    let algorithm = algorithm.to_string();
-    let encoded_len = base64ct::Base64::encoded_len(key);
-    let mut value = Zeroizing::new(vec![0u8; algorithm.len() + 2 + encoded_len]);
-    value[..algorithm.len()].copy_from_slice(algorithm.as_bytes());
-    value[algorithm.len()..algorithm.len() + 2].copy_from_slice(b"; ");
-    base64ct::Base64::encode(key, &mut value[algorithm.len() + 2..])
-        .expect("base64 output length should match buffer");
-
-    HeaderValue::from_bytes(&value).expect("encryption header value should be ASCII")
-}
-
-fn parse_mode(mode_str: &str) -> Result<EncryptionMode, EncryptionSpecError> {
-    mode_str
-        .parse::<EncryptionMode>()
-        .map_err(|_| EncryptionSpecError::UnknownMode {
-            mode: mode_str.to_owned(),
-        })
+fn header_value_for_key(key: &[u8; 32]) -> HeaderValue {
+    let mut value = vec![0u8; base64ct::Base64::encoded_len(key)];
+    base64ct::Base64::encode(key, &mut value).expect("base64 output length should match buffer");
+    HeaderValue::from_bytes(&value).expect("encryption key header value should be ASCII")
 }
 
 #[cfg(test)]
@@ -262,76 +217,45 @@ mod tests {
         26, 27, 28, 29, 30, 31, 32,
     ];
 
-    fn assert_encrypted_spec(
-        spec: EncryptionSpec,
-        algorithm: EncryptionAlgorithm,
-        expected: &[u8; 32],
-    ) {
-        match (algorithm, spec) {
-            (EncryptionAlgorithm::Aegis256, EncryptionSpec::Aegis256(key)) => {
-                assert_eq!(key.secret(), expected)
-            }
-            (EncryptionAlgorithm::Aes256Gcm, EncryptionSpec::Aes256Gcm(key)) => {
-                assert_eq!(key.secret(), expected)
-            }
-            (_, EncryptionSpec::Plain) => panic!("expected encrypted spec"),
-            (expected_algorithm, actual_spec) => {
-                panic!("expected {expected_algorithm:?}, got {actual_spec:?}")
-            }
-        }
+    #[test]
+    fn parse_key_header_roundtrips() {
+        let key = KEY_B64.parse::<EncryptionKey>().unwrap();
+        assert_eq!(key.secret(), &KEY_BYTES);
     }
 
-    fn assert_invalid_parse(header: &str, expected: EncryptionSpecError) {
-        let result = header.parse::<EncryptionSpec>();
+    #[test]
+    fn key_header_value_is_sensitive() {
+        let value = EncryptionKey::new([7; 32]).to_header_value();
+        assert!(value.is_sensitive());
+        assert_ne!(value, HeaderValue::from_static("plain"));
+    }
+
+    #[test]
+    fn key_header_value_roundtrips() {
+        let value = EncryptionKey::new(KEY_BYTES).to_header_value();
+        assert_eq!(value.to_str().unwrap(), KEY_B64);
+        assert!(value.is_sensitive());
+
+        let parsed = value.to_str().unwrap().parse::<EncryptionKey>().unwrap();
+        assert_eq!(parsed.secret(), &KEY_BYTES);
+    }
+
+    #[rstest]
+    #[case("", EncryptionKeyError::InvalidLength {
+        expected: 32,
+        actual: 0
+    })]
+    #[case("3q2+7w==", EncryptionKeyError::InvalidLength {
+        expected: 32,
+        actual: 4
+    })]
+    #[case("not-valid-base64!!!", EncryptionKeyError::InvalidBase64)]
+    fn parse_key_header_invalid_cases(#[case] header: &str, #[case] expected: EncryptionKeyError) {
+        let result = header.parse::<EncryptionKey>();
         match result {
             Err(actual) => assert_eq!(actual, expected),
-            Ok(actual) => panic!("expected invalid spec for {header:?}, got {actual:?}"),
+            Ok(_) => panic!("expected invalid key for {header:?}"),
         }
-    }
-
-    #[rstest]
-    #[case("aegis-256", EncryptionAlgorithm::Aegis256)]
-    #[case("aes-256-gcm", EncryptionAlgorithm::Aes256Gcm)]
-    #[case("AEGIS-256", EncryptionAlgorithm::Aegis256)]
-    #[case("AES-256-GCM", EncryptionAlgorithm::Aes256Gcm)]
-    fn parse_header_valid_encrypted(
-        #[case] algorithm: &str,
-        #[case] expected: EncryptionAlgorithm,
-    ) {
-        let spec = format!("{algorithm}; {KEY_B64}")
-            .parse::<EncryptionSpec>()
-            .unwrap();
-        assert_encrypted_spec(spec, expected, &KEY_BYTES);
-    }
-
-    #[test]
-    fn parse_header_aes_with_whitespace() {
-        let spec = format!(" aes-256-gcm ; {KEY_B64} ")
-            .parse::<EncryptionSpec>()
-            .unwrap();
-        assert_encrypted_spec(spec, EncryptionAlgorithm::Aes256Gcm, &KEY_BYTES);
-    }
-
-    #[rstest]
-    #[case("plain")]
-    #[case("PLAIN")]
-    #[case("plain; ")]
-    fn parse_header_plain_variants(#[case] header: &str) {
-        let spec = header.parse::<EncryptionSpec>().unwrap();
-        assert!(matches!(spec, EncryptionSpec::Plain));
-    }
-
-    #[test]
-    fn spec_mode_matches_variant() {
-        assert_eq!(EncryptionSpec::Plain.mode(), EncryptionMode::Plain);
-        assert_eq!(
-            EncryptionSpec::aegis256(KEY_BYTES).mode(),
-            EncryptionMode::Aegis256
-        );
-        assert_eq!(
-            EncryptionSpec::aes256_gcm(KEY_BYTES).mode(),
-            EncryptionMode::Aes256Gcm
-        );
     }
 
     #[rstest]
@@ -346,80 +270,29 @@ mod tests {
     }
 
     #[rstest]
-    #[case(EncryptionMode::Plain, "plain")]
-    #[case(EncryptionMode::Aegis256, "aegis-256")]
-    #[case(EncryptionMode::Aes256Gcm, "aes-256-gcm")]
-    fn mode_display_matches_spec(#[case] mode: EncryptionMode, #[case] expected: &str) {
-        assert_eq!(mode.to_string(), expected);
-    }
-
-    #[rstest]
-    #[case("", EncryptionSpecError::MissingMode)]
-    #[case(
-        "aegis-256",
-        EncryptionSpecError::MissingKey {
-            mode: EncryptionMode::Aegis256
-        }
-    )]
-    #[case(
-        "aegis-256; AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=; extra",
-        EncryptionSpecError::InvalidSyntax
-    )]
-    #[case(
-        "aegis-256; 3q2+7w==",
-        EncryptionSpecError::InvalidKeyLength {
-            expected: 32,
-            actual: 4
-        }
-    )]
-    #[case(
-        "aegis-256; not-valid-base64!!!",
-        EncryptionSpecError::InvalidKeyBase64
-    )]
-    #[case(
-        "bogus; AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=",
-        EncryptionSpecError::UnknownMode {
-            mode: "bogus".to_owned()
-        }
-    )]
-    #[case(
-        "plain; AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=",
-        EncryptionSpecError::UnexpectedKeyForPlain
-    )]
-    fn parse_header_invalid_cases(#[case] header: &str, #[case] expected: EncryptionSpecError) {
-        assert_invalid_parse(header, expected);
+    #[case(EncryptionAlgorithm::Aegis256, "\"aegis-256\"")]
+    #[case(EncryptionAlgorithm::Aes256Gcm, "\"aes-256-gcm\"")]
+    fn algorithm_serde_roundtrip(#[case] algorithm: EncryptionAlgorithm, #[case] expected: &str) {
+        let serialized = serde_json::to_string(&algorithm).unwrap();
+        assert_eq!(serialized, expected);
+        let deserialized: EncryptionAlgorithm = serde_json::from_str(expected).unwrap();
+        assert_eq!(deserialized, algorithm);
     }
 
     #[test]
-    fn header_value_is_sensitive() {
-        let value = EncryptionSpec::aegis256([7; 32]).to_header_value();
-        assert!(value.is_sensitive());
-        assert_ne!(value, HeaderValue::from_static("plain"));
+    fn resolve_plain_ignores_key() {
+        let encryption = Encryption::resolve(None, Some(EncryptionKey::new(KEY_BYTES))).unwrap();
+        assert!(matches!(encryption, Encryption::Plain));
     }
 
     #[test]
-    fn plain_header_value_roundtrips() {
-        let value = EncryptionSpec::Plain.to_header_value();
-        assert_eq!(value.to_str().unwrap(), "plain");
-        assert!(value.is_sensitive());
-
-        let parsed = value.to_str().unwrap().parse::<EncryptionSpec>().unwrap();
-        assert!(matches!(parsed, EncryptionSpec::Plain));
-    }
-
-    #[rstest]
-    #[case(EncryptionAlgorithm::Aegis256)]
-    #[case(EncryptionAlgorithm::Aes256Gcm)]
-    fn encrypted_header_value_roundtrips(#[case] algorithm: EncryptionAlgorithm) {
-        let value = match algorithm {
-            EncryptionAlgorithm::Aegis256 => EncryptionSpec::aegis256(KEY_BYTES),
-            EncryptionAlgorithm::Aes256Gcm => EncryptionSpec::aes256_gcm(KEY_BYTES),
-        }
-        .to_header_value();
-        assert_eq!(value.to_str().unwrap(), format!("{algorithm}; {KEY_B64}"));
-        assert!(value.is_sensitive());
-
-        let parsed = value.to_str().unwrap().parse::<EncryptionSpec>().unwrap();
-        assert_encrypted_spec(parsed, algorithm, &KEY_BYTES);
+    fn resolve_encrypted_requires_key() {
+        let err = Encryption::resolve(Some(EncryptionAlgorithm::Aegis256), None).unwrap_err();
+        assert_eq!(
+            err,
+            EncryptionResolutionError::MissingKey {
+                algorithm: EncryptionAlgorithm::Aegis256,
+            }
+        );
     }
 }

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -104,7 +104,7 @@ pub enum EncryptionResolutionError {
 #[derive(Debug, Clone, Default)]
 pub enum EncryptionSpec {
     #[default]
-    Plaintext,
+    Plain,
     Aegis256(EncryptionKey),
     Aes256Gcm(EncryptionKey),
 }
@@ -115,7 +115,7 @@ impl EncryptionSpec {
         key: Option<EncryptionKey>,
     ) -> Result<Self, EncryptionResolutionError> {
         match (algorithm, key) {
-            (None, _) => Ok(Self::Plaintext),
+            (None, _) => Ok(Self::Plain),
             (Some(EncryptionAlgorithm::Aegis256), Some(key)) => {
                 validate_key_length(EncryptionAlgorithm::Aegis256, &key)?;
                 Ok(Self::Aegis256(key))
@@ -260,7 +260,7 @@ mod tests {
     fn resolve_plain_ignores_key() {
         let encryption =
             EncryptionSpec::resolve(None, Some(EncryptionKey::new(KEY_BYTES))).unwrap();
-        assert!(matches!(encryption, EncryptionSpec::Plaintext));
+        assert!(matches!(encryption, EncryptionSpec::Plain));
     }
 
     #[test]

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -14,7 +14,7 @@ pub static S2_ENCRYPTION_KEY_HEADER: HeaderName = HeaderName::from_static("s2-en
 
 type SecretKeyMaterial = Arc<SecretBox<[u8]>>;
 
-// 32 bytes in base64 with padding
+// 32 bytes incl padding
 const MAX_ENCRYPTION_KEY_HEADER_LEN: usize = 44;
 
 /// Encryption algorithm.

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -102,16 +102,12 @@ pub enum EncryptionSpec {
 }
 
 impl EncryptionSpec {
-    pub fn plain() -> Self {
-        Self::default()
-    }
-
     pub fn resolve(
         algorithm: Option<EncryptionAlgorithm>,
         key: Option<EncryptionKey>,
     ) -> Result<Self, EncryptionResolutionError> {
         match (algorithm, key) {
-            (None, _) => Ok(Self::plain()),
+            (None, _) => Ok(Self::Plaintext),
             (Some(EncryptionAlgorithm::Aegis256), Some(key)) => {
                 validate_key_length(EncryptionAlgorithm::Aegis256, &key)?;
                 Ok(Self::Aegis256(key))
@@ -130,26 +126,6 @@ impl EncryptionSpec {
 
     pub fn aes256_gcm(key: [u8; 32]) -> Self {
         Self::Aes256Gcm(EncryptionKey::new(key))
-    }
-
-    pub fn algorithm(&self) -> Option<EncryptionAlgorithm> {
-        match self {
-            Self::Plaintext => None,
-            Self::Aegis256(_) => Some(EncryptionAlgorithm::Aegis256),
-            Self::Aes256Gcm(_) => Some(EncryptionAlgorithm::Aes256Gcm),
-        }
-    }
-
-    pub fn is_plain(&self) -> bool {
-        matches!(self, Self::Plaintext)
-    }
-
-    pub(crate) fn key_for_algorithm(&self, algorithm: EncryptionAlgorithm) -> Option<&[u8; 32]> {
-        match (self, algorithm) {
-            (Self::Aegis256(key), EncryptionAlgorithm::Aegis256)
-            | (Self::Aes256Gcm(key), EncryptionAlgorithm::Aes256Gcm) => Some(key_bytes_32(key)),
-            _ => None,
-        }
     }
 }
 
@@ -206,12 +182,6 @@ fn header_value_for_key_material(key: &[u8]) -> HeaderValue {
     let mut value = vec![0u8; base64ct::Base64::encoded_len(key)];
     base64ct::Base64::encode(key, &mut value).expect("base64 output length should match buffer");
     HeaderValue::from_bytes(&value).expect("encryption key header value should be ASCII")
-}
-
-fn key_bytes_32(key: &EncryptionKey) -> &[u8; 32] {
-    key.bytes()
-        .try_into()
-        .expect("encryption key should be 32 bytes after validation")
 }
 
 #[cfg(test)]
@@ -275,7 +245,7 @@ mod tests {
     fn resolve_plain_ignores_key() {
         let encryption =
             EncryptionSpec::resolve(None, Some(EncryptionKey::new(KEY_BYTES))).unwrap();
-        assert!(encryption.is_plain());
+        assert!(matches!(encryption, EncryptionSpec::Plaintext));
     }
 
     #[test]

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -58,7 +58,7 @@ impl EncryptionKey {
         parse_encryption_key_material(key_b64).map(Self)
     }
 
-    pub fn expose_secret(&self) -> &[u8] {
+    pub(crate) fn expose_secret(&self) -> &[u8] {
         self.0.expose_secret()
     }
 

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -60,7 +60,8 @@ impl EncryptionKey {
     }
 
     pub fn to_header_value(&self) -> HeaderValue {
-        let mut value = header_value_for_encoded_key_material(self.expose_secret());
+        let mut value = HeaderValue::from_bytes(self.expose_secret().as_bytes())
+            .expect("encryption key header value should be ASCII");
         value.set_sensitive(true);
         value
     }
@@ -115,10 +116,10 @@ impl EncryptionSpec {
         match (cipher, key) {
             (None, _) => Ok(Self::Plain),
             (Some(cipher @ EncryptionAlgorithm::Aegis256), Some(key)) => {
-                Ok(Self::Aegis256(resolve_fixed_size_key(cipher, key)?))
+                Ok(Self::Aegis256(resolve_key(cipher, key)?))
             }
             (Some(cipher @ EncryptionAlgorithm::Aes256Gcm), Some(key)) => {
-                Ok(Self::Aes256Gcm(resolve_fixed_size_key(cipher, key)?))
+                Ok(Self::Aes256Gcm(resolve_key(cipher, key)?))
             }
             (Some(cipher), None) => Err(EncryptionSpecResolutionError::MissingKey { cipher }),
         }
@@ -152,7 +153,7 @@ impl ParseableHeader for EncryptionKey {
     }
 }
 
-fn resolve_fixed_size_key<const N: usize>(
+fn resolve_key<const N: usize>(
     cipher: EncryptionAlgorithm,
     key: EncryptionKey,
 ) -> Result<DecodedEncryptionKey<N>, EncryptionSpecResolutionError> {
@@ -180,11 +181,6 @@ fn resolve_fixed_size_key<const N: usize>(
             Err(EncryptionSpecResolutionError::InvalidKeyLength { cipher, length })
         }
     }
-}
-
-fn header_value_for_encoded_key_material(key_b64: &str) -> HeaderValue {
-    HeaderValue::from_bytes(key_b64.as_bytes())
-        .expect("encryption key header value should be ASCII")
 }
 
 #[cfg(test)]

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -47,9 +47,6 @@ pub enum EncryptionAlgorithm {
 }
 
 /// Customer-supplied encryption key material for append/read operations.
-///
-/// The request header value remains opaque until it is resolved into a
-/// fixed-size key for a specific stream cipher.
 #[derive(Debug, Clone)]
 pub struct EncryptionKey(EncodedKeyMaterial);
 

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -63,12 +63,6 @@ impl EncryptionKey {
         self.0.as_ref().expose_secret()
     }
 
-    pub(crate) fn bytes_32(&self) -> &[u8; 32] {
-        self.bytes()
-            .try_into()
-            .expect("encryption key should be 32 bytes after validation")
-    }
-
     pub fn to_header_value(&self) -> HeaderValue {
         let mut value = header_value_for_key_material(self.bytes());
         value.set_sensitive(true);
@@ -98,13 +92,9 @@ pub enum EncryptionResolutionError {
     },
 }
 
-/// Resolved stream encryption after combining stream metadata with customer-supplied encryption
-/// key, if any.
+/// Resolved stream encryption after combining stream metadata with the request key.
 #[derive(Debug, Clone, Default)]
-pub struct EncryptionSpec(EncryptionSpecInner);
-
-#[derive(Debug, Clone, Default)]
-pub(crate) enum EncryptionSpecInner {
+pub enum EncryptionSpec {
     #[default]
     Plaintext,
     Aegis256(EncryptionKey),
@@ -124,38 +114,42 @@ impl EncryptionSpec {
             (None, _) => Ok(Self::plain()),
             (Some(EncryptionAlgorithm::Aegis256), Some(key)) => {
                 validate_key_length(EncryptionAlgorithm::Aegis256, &key)?;
-                Ok(Self(EncryptionSpecInner::Aegis256(key)))
+                Ok(Self::Aegis256(key))
             }
             (Some(EncryptionAlgorithm::Aes256Gcm), Some(key)) => {
                 validate_key_length(EncryptionAlgorithm::Aes256Gcm, &key)?;
-                Ok(Self(EncryptionSpecInner::Aes256Gcm(key)))
+                Ok(Self::Aes256Gcm(key))
             }
             (Some(algorithm), None) => Err(EncryptionResolutionError::MissingKey { algorithm }),
         }
     }
 
     pub fn aegis256(key: [u8; 32]) -> Self {
-        Self(EncryptionSpecInner::Aegis256(EncryptionKey::new(key)))
+        Self::Aegis256(EncryptionKey::new(key))
     }
 
     pub fn aes256_gcm(key: [u8; 32]) -> Self {
-        Self(EncryptionSpecInner::Aes256Gcm(EncryptionKey::new(key)))
+        Self::Aes256Gcm(EncryptionKey::new(key))
     }
 
     pub fn algorithm(&self) -> Option<EncryptionAlgorithm> {
-        match self.inner() {
-            EncryptionSpecInner::Plaintext => None,
-            EncryptionSpecInner::Aegis256(_) => Some(EncryptionAlgorithm::Aegis256),
-            EncryptionSpecInner::Aes256Gcm(_) => Some(EncryptionAlgorithm::Aes256Gcm),
+        match self {
+            Self::Plaintext => None,
+            Self::Aegis256(_) => Some(EncryptionAlgorithm::Aegis256),
+            Self::Aes256Gcm(_) => Some(EncryptionAlgorithm::Aes256Gcm),
         }
     }
 
     pub fn is_plain(&self) -> bool {
-        matches!(self.inner(), EncryptionSpecInner::Plaintext)
+        matches!(self, Self::Plaintext)
     }
 
-    pub(crate) fn inner(&self) -> &EncryptionSpecInner {
-        &self.0
+    pub(crate) fn key_for_algorithm(&self, algorithm: EncryptionAlgorithm) -> Option<&[u8; 32]> {
+        match (self, algorithm) {
+            (Self::Aegis256(key), EncryptionAlgorithm::Aegis256)
+            | (Self::Aes256Gcm(key), EncryptionAlgorithm::Aes256Gcm) => Some(key_bytes_32(key)),
+            _ => None,
+        }
     }
 }
 
@@ -196,11 +190,12 @@ fn validate_key_length(
     algorithm: EncryptionAlgorithm,
     key: &EncryptionKey,
 ) -> Result<(), EncryptionResolutionError> {
-    if key.0.expose_secret().len() != 32 {
+    let bytes = key.bytes();
+    if bytes.len() != 32 {
         return Err(EncryptionResolutionError::InvalidKeyLength {
             algorithm,
             expected: 32,
-            actual: key.0.expose_secret().len(),
+            actual: bytes.len(),
         });
     }
 
@@ -211,6 +206,12 @@ fn header_value_for_key_material(key: &[u8]) -> HeaderValue {
     let mut value = vec![0u8; base64ct::Base64::encoded_len(key)];
     base64ct::Base64::encode(key, &mut value).expect("base64 output length should match buffer");
     HeaderValue::from_bytes(&value).expect("encryption key header value should be ASCII")
+}
+
+fn key_bytes_32(key: &EncryptionKey) -> &[u8; 32] {
+    key.bytes()
+        .try_into()
+        .expect("encryption key should be 32 bytes after validation")
 }
 
 #[cfg(test)]

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -14,6 +14,13 @@ pub static S2_ENCRYPTION_KEY_HEADER: HeaderName = HeaderName::from_static("s2-en
 
 type SecretKeyMaterial = Arc<SecretBox<[u8]>>;
 
+const CURRENT_ENCRYPTION_KEY_LEN: usize = 32;
+const MAX_ENCRYPTION_KEY_HEADER_LEN: usize = base64_encoded_len(CURRENT_ENCRYPTION_KEY_LEN);
+
+const fn base64_encoded_len(bytes_len: usize) -> usize {
+    ((bytes_len + 2) / 3) * 4
+}
+
 /// Encryption algorithm.
 #[derive(
     Debug,
@@ -48,15 +55,16 @@ pub struct EncryptionKey(SecretKeyMaterial);
 
 impl EncryptionKey {
     pub fn new(key: [u8; 32]) -> Self {
-        Self::from_bytes(Box::new(key))
+        Self::from_bytes(Box::new(key)).expect("32-byte encryption key should fit header length")
     }
 
     pub fn from_base64(key_b64: &str) -> Result<Self, EncryptionKeyError> {
         parse_encryption_key_material(key_b64).map(Self)
     }
 
-    pub fn from_bytes(bytes: Box<[u8]>) -> Self {
-        Self(Arc::new(SecretBox::new(bytes)))
+    pub fn from_bytes(bytes: Box<[u8]>) -> Result<Self, EncryptionKeyError> {
+        validate_key_material_len(base64_encoded_len(bytes.len()))?;
+        Ok(Self(Arc::new(SecretBox::new(bytes))))
     }
 
     pub fn bytes(&self) -> &[u8] {
@@ -76,6 +84,10 @@ pub enum EncryptionKeyError {
     InvalidBase64,
     #[error("invalid encryption key: key material must not be empty")]
     Empty,
+    #[error(
+        "invalid encryption key: encoded key material exceeds maximum length of {max} characters (got {actual})"
+    )]
+    TooLong { max: usize, actual: usize },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -93,6 +105,7 @@ pub enum EncryptionResolutionError {
 }
 
 /// Resolved encryption spec after combining stream metadata with the customer-supplied encryption key, if any.
+#[rustfmt::skip]
 #[derive(Debug, Clone, Default)]
 pub enum EncryptionSpec {
     #[default]
@@ -147,6 +160,8 @@ fn parse_encryption_key_material(key_b64: &str) -> Result<SecretKeyMaterial, Enc
     use base64ct::{Base64, Encoding};
     use secrecy::zeroize::Zeroize;
 
+    validate_key_material_len(key_b64.len())?;
+
     let mut key = match Base64::decode_vec(key_b64) {
         Ok(decoded) => decoded,
         Err(_) => {
@@ -160,6 +175,17 @@ fn parse_encryption_key_material(key_b64: &str) -> Result<SecretKeyMaterial, Enc
     }
 
     Ok(Arc::new(SecretBox::new(key.into_boxed_slice())))
+}
+
+fn validate_key_material_len(len: usize) -> Result<(), EncryptionKeyError> {
+    if len > MAX_ENCRYPTION_KEY_HEADER_LEN {
+        return Err(EncryptionKeyError::TooLong {
+            max: MAX_ENCRYPTION_KEY_HEADER_LEN,
+            actual: len,
+        });
+    }
+
+    Ok(())
 }
 
 fn validate_key_length(
@@ -263,7 +289,7 @@ mod tests {
     fn resolve_encrypted_validates_key_length_per_algorithm() {
         let err = EncryptionSpec::resolve(
             Some(EncryptionAlgorithm::Aegis256),
-            Some(EncryptionKey::from_bytes(vec![0x42; 4].into_boxed_slice())),
+            Some(EncryptionKey::from_bytes(vec![0x42; 4].into_boxed_slice()).unwrap()),
         )
         .unwrap_err();
         assert_eq!(
@@ -272,6 +298,31 @@ mod tests {
                 algorithm: EncryptionAlgorithm::Aegis256,
                 expected: 32,
                 actual: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_key_header_rejects_overlong_encoded_material() {
+        let header = "A".repeat(MAX_ENCRYPTION_KEY_HEADER_LEN + 1);
+        let result = header.parse::<EncryptionKey>();
+        assert_eq!(
+            result.unwrap_err(),
+            EncryptionKeyError::TooLong {
+                max: MAX_ENCRYPTION_KEY_HEADER_LEN,
+                actual: MAX_ENCRYPTION_KEY_HEADER_LEN + 1,
+            }
+        );
+    }
+
+    #[test]
+    fn from_bytes_rejects_key_material_that_would_overflow_header_limit() {
+        let result = EncryptionKey::from_bytes(vec![0x42; 34].into_boxed_slice());
+        assert_eq!(
+            result.unwrap_err(),
+            EncryptionKeyError::TooLong {
+                max: MAX_ENCRYPTION_KEY_HEADER_LEN,
+                actual: base64_encoded_len(34),
             }
         );
     }

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -92,7 +92,7 @@ pub enum EncryptionResolutionError {
     },
 }
 
-/// Resolved stream encryption after combining stream metadata with the request key.
+/// Resolved encryption spec after combining stream metadata with the customer-supplied encryption key, if any.
 #[derive(Debug, Clone, Default)]
 pub enum EncryptionSpec {
     #[default]

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -42,46 +42,6 @@ pub enum EncryptionAlgorithm {
     Aes256Gcm,
 }
 
-/// Encryption mode, including plaintext.
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    serde::Serialize,
-    serde::Deserialize,
-    Display,
-    EnumString,
-    enumset::EnumSetType,
-)]
-#[strum(ascii_case_insensitive)]
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[enumset(no_super_impls)]
-pub enum EncryptionMode {
-    #[strum(serialize = "plain")]
-    #[serde(rename = "plain")]
-    Plain,
-    #[strum(serialize = "aegis-256")]
-    #[serde(rename = "aegis-256")]
-    #[cfg_attr(feature = "clap", value(name = "aegis-256"))]
-    Aegis256,
-    #[strum(serialize = "aes-256-gcm")]
-    #[serde(rename = "aes-256-gcm")]
-    #[cfg_attr(feature = "clap", value(name = "aes-256-gcm"))]
-    Aes256Gcm,
-}
-
-impl From<EncryptionAlgorithm> for EncryptionMode {
-    fn from(value: EncryptionAlgorithm) -> Self {
-        match value {
-            EncryptionAlgorithm::Aegis256 => Self::Aegis256,
-            EncryptionAlgorithm::Aes256Gcm => Self::Aes256Gcm,
-        }
-    }
-}
-
 /// Customer-supplied encryption key shared by all supported algorithms.
 #[derive(Debug, Clone)]
 pub struct EncryptionKey(SecretKey);
@@ -150,11 +110,11 @@ impl Encryption {
         Self::Aes256Gcm(EncryptionKey::new(key))
     }
 
-    pub fn mode(&self) -> EncryptionMode {
+    pub fn algorithm(&self) -> Option<EncryptionAlgorithm> {
         match self {
-            Self::Plain => EncryptionMode::Plain,
-            Self::Aegis256(_) => EncryptionMode::Aegis256,
-            Self::Aes256Gcm(_) => EncryptionMode::Aes256Gcm,
+            Self::Plain => None,
+            Self::Aegis256(_) => Some(EncryptionAlgorithm::Aegis256),
+            Self::Aes256Gcm(_) => Some(EncryptionAlgorithm::Aes256Gcm),
         }
     }
 }
@@ -256,17 +216,6 @@ mod tests {
             Err(actual) => assert_eq!(actual, expected),
             Ok(_) => panic!("expected invalid key for {header:?}"),
         }
-    }
-
-    #[rstest]
-    #[case(EncryptionMode::Plain, "\"plain\"")]
-    #[case(EncryptionMode::Aegis256, "\"aegis-256\"")]
-    #[case(EncryptionMode::Aes256Gcm, "\"aes-256-gcm\"")]
-    fn mode_serde_roundtrip(#[case] mode: EncryptionMode, #[case] expected: &str) {
-        let serialized = serde_json::to_string(&mode).unwrap();
-        assert_eq!(serialized, expected);
-        let deserialized: EncryptionMode = serde_json::from_str(expected).unwrap();
-        assert_eq!(deserialized, mode);
     }
 
     #[rstest]

--- a/common/src/encryption.rs
+++ b/common/src/encryption.rs
@@ -14,7 +14,7 @@ pub static S2_ENCRYPTION_KEY_HEADER: HeaderName = HeaderName::from_static("s2-en
 
 type SecretKeyMaterial = Arc<SecretBox<[u8]>>;
 
-// 32 bytes incl padding
+// 32 bytes in base64 with padding
 const MAX_ENCRYPTION_KEY_HEADER_LEN: usize = 44;
 
 /// Encryption algorithm.
@@ -149,7 +149,6 @@ impl ParseableHeader for EncryptionKey {
 
 fn parse_encryption_key_material(key_b64: &str) -> Result<SecretKeyMaterial, EncryptionKeyError> {
     use base64ct::{Base64, Encoding};
-    use secrecy::zeroize::Zeroize;
 
     if key_b64.len() > MAX_ENCRYPTION_KEY_HEADER_LEN {
         return Err(EncryptionKeyError::TooLong {
@@ -158,7 +157,7 @@ fn parse_encryption_key_material(key_b64: &str) -> Result<SecretKeyMaterial, Enc
         });
     }
 
-    let mut key = match Base64::decode_vec(key_b64) {
+    let key = match Base64::decode_vec(key_b64) {
         Ok(decoded) => decoded,
         Err(_) => {
             return Err(EncryptionKeyError::InvalidBase64);
@@ -166,7 +165,6 @@ fn parse_encryption_key_material(key_b64: &str) -> Result<SecretKeyMaterial, Enc
     };
 
     if key.is_empty() {
-        key.zeroize();
         return Err(EncryptionKeyError::Empty);
     }
 

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -209,7 +209,7 @@ pub fn encrypt_record(
             let encrypted = encrypt_payload(
                 &envelope,
                 EncryptionAlgorithm::Aegis256,
-                key_bytes_32(key),
+                key.expose_secret(),
                 aad,
             );
             StoredRecord::encrypted(encrypted, metered_size)
@@ -218,7 +218,7 @@ pub fn encrypt_record(
             let encrypted = encrypt_payload(
                 &envelope,
                 EncryptionAlgorithm::Aes256Gcm,
-                key_bytes_32(key),
+                key.expose_secret(),
                 aad,
             );
             StoredRecord::encrypted(encrypted, metered_size)
@@ -230,7 +230,7 @@ pub fn encrypt_record(
 fn encrypt_payload(
     plaintext: &(impl Encodable + ?Sized),
     alg: EncryptionAlgorithm,
-    key: &[u8; 32],
+    key: &[u8],
     aad: &[u8],
 ) -> EncryptedRecord {
     let format = EncryptedRecordFormat::current_for_algorithm(alg);
@@ -246,9 +246,8 @@ fn encrypt_payload(
 
     match format {
         EncryptedRecordFormat::Aegis256V1 => {
-            let nonce: &[u8; 32] = nonce
-                .try_into()
-                .expect("AEGIS-256 nonce should match the encoded record framing");
+            let key: &[u8; 32] = key.try_into().expect("AEGIS-256 key must be 32 bytes");
+            let nonce: &[u8; 32] = nonce.try_into().expect("AEGIS-256 nonce must be 32 bytes");
             let tag = Aegis256::<16>::new(key, nonce).encrypt_in_place(payload, aad);
             encoded.put_slice(tag.as_ref());
         }
@@ -330,23 +329,24 @@ fn decrypt_payload(
 
     match (format, encryption) {
         (EncryptedRecordFormat::Aegis256V1, EncryptionSpec::Aegis256(key)) => {
-            {
-                let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
-                let nonce: &[u8; 32] = prefix
-                    .get(FORMAT_ID_LEN..)
-                    .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?
-                    .try_into()
-                    .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
-                let (ciphertext, tag) = payload_and_tag.split_at_mut(plaintext_len);
-                let tag: &[u8; 16] = tag
-                    .as_ref()
-                    .try_into()
-                    .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
-
-                Aegis256::<16>::new(key_bytes_32(key), nonce)
-                    .decrypt_in_place(ciphertext, tag, aad)
-                    .map_err(|_| RecordDecryptionError::AuthenticationFailed)?;
-            }
+            let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
+            let key: &[u8; 32] = key
+                .expose_secret()
+                .try_into()
+                .expect("AEGIS-256 key must be 32 bytes");
+            let nonce: &[u8; 32] = prefix
+                .get(FORMAT_ID_LEN..)
+                .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?
+                .try_into()
+                .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
+            let (ciphertext, tag) = payload_and_tag.split_at_mut(plaintext_len);
+            let tag: &[u8; 16] = tag
+                .as_ref()
+                .try_into()
+                .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
+            Aegis256::<16>::new(key, nonce)
+                .decrypt_in_place(ciphertext, tag, aad)
+                .map_err(|_| RecordDecryptionError::AuthenticationFailed)?;
             Ok(decryption_finish(encoded, payload_start, plaintext_len))
         }
         (EncryptedRecordFormat::Aegis256V1, EncryptionSpec::Plain) => {
@@ -362,25 +362,23 @@ fn decrypt_payload(
             })
         }
         (EncryptedRecordFormat::Aes256GcmV1, EncryptionSpec::Aes256Gcm(key)) => {
-            let cipher = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key_bytes_32(key)));
-            {
-                let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
-                let nonce: &[u8; 12] = prefix
-                    .get(FORMAT_ID_LEN..)
-                    .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?
-                    .try_into()
-                    .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
-                let nonce = aes_gcm::Nonce::from_slice(nonce);
-                let (ciphertext, tag) = payload_and_tag.split_at_mut(plaintext_len);
-                let tag: &[u8; 16] = tag
-                    .as_ref()
-                    .try_into()
-                    .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
-                let tag = aes_gcm::Tag::from_slice(tag);
-                cipher
-                    .decrypt_in_place_detached(nonce, aad, ciphertext, tag)
-                    .map_err(|_| RecordDecryptionError::AuthenticationFailed)?;
-            }
+            let cipher = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key.expose_secret()));
+            let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
+            let nonce: &[u8; 12] = prefix
+                .get(FORMAT_ID_LEN..)
+                .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?
+                .try_into()
+                .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
+            let nonce = aes_gcm::Nonce::from_slice(nonce);
+            let (ciphertext, tag) = payload_and_tag.split_at_mut(plaintext_len);
+            let tag: &[u8; 16] = tag
+                .as_ref()
+                .try_into()
+                .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
+            let tag = aes_gcm::Tag::from_slice(tag);
+            cipher
+                .decrypt_in_place_detached(nonce, aad, ciphertext, tag)
+                .map_err(|_| RecordDecryptionError::AuthenticationFailed)?;
             Ok(decryption_finish(encoded, payload_start, plaintext_len))
         }
         (EncryptedRecordFormat::Aes256GcmV1, EncryptionSpec::Plain) => {
@@ -396,12 +394,6 @@ fn decrypt_payload(
             })
         }
     }
-}
-
-fn key_bytes_32(key: &crate::encryption::EncryptionKey) -> &[u8; 32] {
-    key.bytes()
-        .try_into()
-        .expect("encryption key should be 32 bytes after validation")
 }
 
 fn decryption_layout(
@@ -509,13 +501,13 @@ mod tests {
             EncryptionSpec::Aegis256(key) => encrypt_payload(
                 &plaintext,
                 EncryptionAlgorithm::Aegis256,
-                key_bytes_32(key),
+                key.expose_secret(),
                 aad,
             ),
             EncryptionSpec::Aes256Gcm(key) => encrypt_payload(
                 &plaintext,
                 EncryptionAlgorithm::Aes256Gcm,
-                key_bytes_32(key),
+                key.expose_secret(),
                 aad,
             ),
         };

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -52,14 +52,6 @@ pub(crate) enum EncryptedRecordFormat {
 }
 
 impl EncryptedRecordFormat {
-    /// Current write format for newly encrypted records with this algorithm.
-    const fn current_for_algorithm(algorithm: EncryptionAlgorithm) -> Self {
-        match algorithm {
-            EncryptionAlgorithm::Aegis256 => Self::Aegis256V1,
-            EncryptionAlgorithm::Aes256Gcm => Self::Aes256GcmV1,
-        }
-    }
-
     const fn try_from_format_id(format_id: u8) -> Result<Self, RecordDecodeError> {
         match format_id {
             FORMAT_ID_AEGIS256_V1 => Ok(Self::Aegis256V1),
@@ -206,60 +198,47 @@ pub fn encrypt_record(
         (record @ Record::Command(_), _) => StoredRecord::Plaintext(record),
         (record @ Record::Envelope(_), EncryptionSpec::Plain) => StoredRecord::Plaintext(record),
         (Record::Envelope(envelope), EncryptionSpec::Aegis256(key)) => {
-            let encrypted = encrypt_payload(
-                &envelope,
-                EncryptionAlgorithm::Aegis256,
-                key.expose_secret(),
-                aad,
-            );
+            let format = EncryptedRecordFormat::Aegis256V1;
+            let (mut encoded, payload_start) = prep_encryption_buffer(&envelope, format);
+            let (prefix, payload) = encoded.split_at_mut(payload_start);
+            let nonce: &[u8; 32] = prefix[FORMAT_ID_LEN..]
+                .try_into()
+                .expect("AEGIS-256 nonce must be 32 bytes");
+            let tag =
+                Aegis256::<16>::new(key.expose_secret(), nonce).encrypt_in_place(payload, aad);
+            encoded.put_slice(tag.as_ref());
+
+            let encrypted = EncryptedRecord::new(encoded.freeze(), format);
             StoredRecord::encrypted(encrypted, metered_size)
         }
         (Record::Envelope(envelope), EncryptionSpec::Aes256Gcm(key)) => {
-            let encrypted = encrypt_payload(
-                &envelope,
-                EncryptionAlgorithm::Aes256Gcm,
-                key.expose_secret(),
-                aad,
-            );
+            let format = EncryptedRecordFormat::Aes256GcmV1;
+            let (mut encoded, payload_start) = prep_encryption_buffer(&envelope, format);
+            let (prefix, payload) = encoded.split_at_mut(payload_start);
+            let nonce = aes_gcm::Nonce::from_slice(&prefix[FORMAT_ID_LEN..]);
+            let tag = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key.expose_secret()))
+                .encrypt_in_place_detached(nonce, aad, payload)
+                .expect("AES-256-GCM encryption should not fail on size validation");
+            encoded.put_slice(tag.as_ref());
+
+            let encrypted = EncryptedRecord::new(encoded.freeze(), format);
             StoredRecord::encrypted(encrypted, metered_size)
         }
     };
     Metered::with_size(metered_size, record)
 }
 
-fn encrypt_payload(
-    plaintext: &(impl Encodable + ?Sized),
-    alg: EncryptionAlgorithm,
-    key: &[u8; 32],
-    aad: &[u8],
-) -> EncryptedRecord {
-    let format = EncryptedRecordFormat::current_for_algorithm(alg);
+fn prep_encryption_buffer(
+    envelope: &super::EnvelopeRecord,
+    format: EncryptedRecordFormat,
+) -> (BytesMut, usize) {
     let payload_start = FORMAT_ID_LEN + format.nonce_len();
     let mut encoded =
-        BytesMut::with_capacity(payload_start + plaintext.encoded_size() + format.tag_len());
+        BytesMut::with_capacity(payload_start + envelope.encoded_size() + format.tag_len());
     encoded.put_u8(format.format_id());
     format.put_random_nonce(&mut encoded);
-    plaintext.encode_into(&mut encoded);
-
-    let (prefix, payload) = encoded.split_at_mut(payload_start);
-    let nonce = &prefix[FORMAT_ID_LEN..];
-
-    match format {
-        EncryptedRecordFormat::Aegis256V1 => {
-            let nonce: &[u8; 32] = nonce.try_into().expect("AEGIS-256 nonce must be 32 bytes");
-            let tag = Aegis256::<16>::new(key, nonce).encrypt_in_place(payload, aad);
-            encoded.put_slice(tag.as_ref());
-        }
-        EncryptedRecordFormat::Aes256GcmV1 => {
-            let nonce = aes_gcm::Nonce::from_slice(nonce);
-            let tag = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key))
-                .encrypt_in_place_detached(nonce, aad, payload)
-                .expect("AES-256-GCM encryption should not fail on size validation");
-            encoded.put_slice(tag.as_ref());
-        }
-    }
-
-    EncryptedRecord::new(encoded.freeze(), format)
+    envelope.encode_into(&mut encoded);
+    (encoded, payload_start)
 }
 
 impl TryFrom<Bytes> for EncryptedRecord {
@@ -439,11 +418,20 @@ mod tests {
     }
 
     fn encrypt_test_record(
-        plaintext: &(impl Encodable + ?Sized),
+        plaintext: EnvelopeRecord,
         alg: EncryptionAlgorithm,
         aad: &[u8],
     ) -> EncryptedRecord {
-        encrypt_payload(plaintext, alg, &TEST_KEY, aad)
+        let stored = encrypt_record(
+            Record::Envelope(plaintext).metered(),
+            &test_encryption(alg),
+            aad,
+        )
+        .into_inner();
+        let StoredRecord::Encrypted { record, .. } = stored else {
+            panic!("expected encrypted envelope record");
+        };
+        record
     }
 
     fn make_encrypted_record(
@@ -487,26 +475,16 @@ mod tests {
         body: Bytes,
         aad: &[u8],
     ) -> StoredRecord {
-        let metered_size = make_plaintext_envelope(headers.clone(), body.clone()).metered_size();
-        let plaintext = make_envelope(headers, body);
-        let encrypted = match encryption {
-            EncryptionSpec::Plain => {
-                panic!("plain encryption should not produce an encrypted record")
-            }
-            EncryptionSpec::Aegis256(key) => encrypt_payload(
-                &plaintext,
-                EncryptionAlgorithm::Aegis256,
-                key.expose_secret(),
-                aad,
-            ),
-            EncryptionSpec::Aes256Gcm(key) => encrypt_payload(
-                &plaintext,
-                EncryptionAlgorithm::Aes256Gcm,
-                key.expose_secret(),
-                aad,
-            ),
+        let stored = encrypt_record(
+            make_plaintext_envelope(headers, body).metered(),
+            encryption,
+            aad,
+        )
+        .into_inner();
+        let StoredRecord::Encrypted { .. } = &stored else {
+            panic!("plain encryption should not produce an encrypted record");
         };
-        StoredRecord::encrypted(encrypted, metered_size)
+        stored
     }
 
     #[rstest]
@@ -527,7 +505,7 @@ mod tests {
         let aad = aad();
         let plaintext = make_envelope(headers.clone(), body.clone());
         let encryption = test_encryption(algorithm);
-        let encrypted_record = encrypt_test_record(&plaintext, algorithm, &aad);
+        let encrypted_record = encrypt_test_record(plaintext, algorithm, &aad);
         let encrypted_record = if shared_encoded_record_buffer {
             let shared = encrypted_record.encoded.clone();
             EncryptedRecord::try_from(shared).unwrap()
@@ -547,7 +525,7 @@ mod tests {
     fn wrong_key_fails(#[case] algorithm: EncryptionAlgorithm) {
         let aad = aad();
         let plaintext = make_envelope(vec![], Bytes::from_static(b"data"));
-        let encrypted_record = encrypt_test_record(&plaintext, algorithm, &aad);
+        let encrypted_record = encrypt_test_record(plaintext, algorithm, &aad);
         let result = decrypt_payload(encrypted_record, &other_test_encryption(algorithm), &aad);
         assert!(matches!(
             result,
@@ -568,7 +546,7 @@ mod tests {
     fn format_id_byte_present() {
         let aad = aad();
         let plaintext = make_envelope(vec![], Bytes::from_static(b"data"));
-        let encrypted_record = encrypt_test_record(&plaintext, EncryptionAlgorithm::Aegis256, &aad);
+        let encrypted_record = encrypt_test_record(plaintext, EncryptionAlgorithm::Aegis256, &aad);
         let encoded = encrypted_record.to_bytes();
         assert_eq!(encrypted_record.format, EncryptedRecordFormat::Aegis256V1);
         assert_eq!(encrypted_record.algorithm(), EncryptionAlgorithm::Aegis256);
@@ -580,7 +558,7 @@ mod tests {
         let aad = aad();
         let plaintext = make_envelope(vec![], Bytes::from_static(b"data"));
         let mut encoded_record =
-            encrypt_test_record(&plaintext, EncryptionAlgorithm::Aegis256, &aad)
+            encrypt_test_record(plaintext, EncryptionAlgorithm::Aegis256, &aad)
                 .to_bytes()
                 .to_vec();
         assert_eq!(encoded_record[0], 0x01);
@@ -605,7 +583,7 @@ mod tests {
         let aad = aad();
         let other_aad = [0x5A; 32];
         let plaintext = make_envelope(vec![], Bytes::from_static(b"data"));
-        let encrypted_record = encrypt_test_record(&plaintext, EncryptionAlgorithm::Aegis256, &aad);
+        let encrypted_record = encrypt_test_record(plaintext, EncryptionAlgorithm::Aegis256, &aad);
         let result = decrypt_payload(
             encrypted_record,
             &test_encryption(EncryptionAlgorithm::Aegis256),

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -210,8 +210,8 @@ pub fn encrypt_record(
                 .algorithm()
                 .expect("non-plain encryption should carry an algorithm");
             let key = encryption
-                .secret_key()
-                .expect("non-plain encryption should carry a secret key");
+                .key_for_algorithm(algorithm)
+                .expect("non-plain encryption should carry a matching key");
             let encrypted = encrypt_payload(&envelope, algorithm, key, aad);
             StoredRecord::encrypted(encrypted, metered_size)
         }
@@ -322,8 +322,7 @@ fn decrypt_payload(
 
     match format {
         EncryptedRecordFormat::Aegis256V1 => {
-            let Some(key) = encryption.secret_key_for_algorithm(EncryptionAlgorithm::Aegis256)
-            else {
+            let Some(key) = encryption.key_for_algorithm(EncryptionAlgorithm::Aegis256) else {
                 return Err(RecordDecryptionError::AlgorithmMismatch {
                     expected,
                     actual: Some(EncryptionAlgorithm::Aegis256),
@@ -349,8 +348,7 @@ fn decrypt_payload(
             Ok(decryption_finish(encoded, payload_start, plaintext_len))
         }
         EncryptedRecordFormat::Aes256GcmV1 => {
-            let Some(key) = encryption.secret_key_for_algorithm(EncryptionAlgorithm::Aes256Gcm)
-            else {
+            let Some(key) = encryption.key_for_algorithm(EncryptionAlgorithm::Aes256Gcm) else {
                 return Err(RecordDecryptionError::AlgorithmMismatch {
                     expected,
                     actual: Some(EncryptionAlgorithm::Aes256Gcm),
@@ -482,8 +480,8 @@ mod tests {
             .algorithm()
             .expect("plain mode should not produce an encrypted record");
         let key = encryption
-            .secret_key()
-            .expect("encrypted test record should carry a secret key");
+            .key_for_algorithm(algorithm)
+            .expect("encrypted test record should carry a matching key");
         let encrypted = encrypt_payload(&plaintext, algorithm, key, aad);
         StoredRecord::encrypted(encrypted, metered_size)
     }

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -36,7 +36,7 @@ use rand::random;
 use super::{Encodable, Metered, MeteredSize, Record, RecordDecodeError, StoredRecord};
 use crate::{
     deep_size::DeepSize,
-    encryption::{Encryption, EncryptionAlgorithm, EncryptionMode},
+    encryption::{Encryption, EncryptionAlgorithm},
     record::MeteredExt as _,
 };
 
@@ -109,10 +109,10 @@ impl EncryptedRecordFormat {
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum RecordDecryptionError {
-    #[error("record encryption mode mismatch")]
-    ModeMismatch {
-        expected: EncryptionMode,
-        actual: EncryptionMode,
+    #[error("record encryption algorithm mismatch")]
+    AlgorithmMismatch {
+        expected: Option<EncryptionAlgorithm>,
+        actual: Option<EncryptionAlgorithm>,
     },
     #[error("record decryption failed")]
     AuthenticationFailed,
@@ -284,9 +284,9 @@ pub fn decrypt_stored_record(
         StoredRecord::Plaintext(record @ Record::Command(_)) => Ok(record.metered()),
         StoredRecord::Plaintext(record @ Record::Envelope(_)) => match encryption {
             Encryption::Plain => Ok(record.metered()),
-            _ => Err(RecordDecryptionError::ModeMismatch {
-                expected: encryption.mode(),
-                actual: EncryptionMode::Plain,
+            _ => Err(RecordDecryptionError::AlgorithmMismatch {
+                expected: encryption.algorithm(),
+                actual: None,
             }),
         },
         StoredRecord::Encrypted {
@@ -313,7 +313,7 @@ fn decrypt_payload(
     aad: &[u8],
 ) -> Result<Bytes, RecordDecryptionError> {
     let format = record.format;
-    let expected = encryption.mode();
+    let expected = encryption.algorithm();
     let (mut encoded, payload_start, payload_end) = decryption_layout(record, format)?;
     let plaintext_len = payload_end - payload_start;
 
@@ -322,9 +322,9 @@ fn decrypt_payload(
             let key = match encryption {
                 Encryption::Aegis256(key) => key,
                 _ => {
-                    return Err(RecordDecryptionError::ModeMismatch {
+                    return Err(RecordDecryptionError::AlgorithmMismatch {
                         expected,
-                        actual: EncryptionMode::Aegis256,
+                        actual: Some(EncryptionAlgorithm::Aegis256),
                     });
                 }
             };
@@ -351,9 +351,9 @@ fn decrypt_payload(
             let key = match encryption {
                 Encryption::Aes256Gcm(key) => key,
                 _ => {
-                    return Err(RecordDecryptionError::ModeMismatch {
+                    return Err(RecordDecryptionError::AlgorithmMismatch {
                         expected,
-                        actual: EncryptionMode::Aes256Gcm,
+                        actual: Some(EncryptionAlgorithm::Aes256Gcm),
                     });
                 }
             };
@@ -580,9 +580,9 @@ mod tests {
         );
         assert!(matches!(
             result,
-            Err(RecordDecryptionError::ModeMismatch {
-                expected: EncryptionMode::Aegis256,
-                actual: EncryptionMode::Aes256Gcm,
+            Err(RecordDecryptionError::AlgorithmMismatch {
+                expected: Some(EncryptionAlgorithm::Aegis256),
+                actual: Some(EncryptionAlgorithm::Aes256Gcm),
             })
         ));
     }
@@ -752,9 +752,9 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(RecordDecryptionError::ModeMismatch {
-                expected: EncryptionMode::Plain,
-                actual: EncryptionMode::Aegis256,
+            Err(RecordDecryptionError::AlgorithmMismatch {
+                expected: None,
+                actual: Some(EncryptionAlgorithm::Aegis256),
             })
         ));
     }

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -36,7 +36,7 @@ use rand::random;
 use super::{Encodable, Metered, MeteredSize, Record, RecordDecodeError, StoredRecord};
 use crate::{
     deep_size::DeepSize,
-    encryption::{EncryptionAlgorithm, EncryptionSpec},
+    encryption::{EncryptionAlgorithm, EncryptionSpec, EncryptionSpecInner},
     record::MeteredExt as _,
 };
 
@@ -204,17 +204,27 @@ pub fn encrypt_record(
     let metered_size = record.metered_size();
     let record = match record.into_inner() {
         record @ Record::Command(_) => StoredRecord::Plaintext(record),
-        record @ Record::Envelope(_) if encryption.is_plain() => StoredRecord::Plaintext(record),
-        Record::Envelope(envelope) => {
-            let algorithm = encryption
-                .algorithm()
-                .expect("non-plain encryption should carry an algorithm");
-            let key = encryption
-                .key_for_algorithm(algorithm)
-                .expect("non-plain encryption should carry a matching key");
-            let encrypted = encrypt_payload(&envelope, algorithm, key, aad);
-            StoredRecord::encrypted(encrypted, metered_size)
-        }
+        Record::Envelope(envelope) => match encryption.inner() {
+            EncryptionSpecInner::Plaintext => StoredRecord::Plaintext(Record::Envelope(envelope)),
+            EncryptionSpecInner::Aegis256(key) => StoredRecord::encrypted(
+                encrypt_payload(
+                    &envelope,
+                    EncryptionAlgorithm::Aegis256,
+                    key.bytes_32(),
+                    aad,
+                ),
+                metered_size,
+            ),
+            EncryptionSpecInner::Aes256Gcm(key) => StoredRecord::encrypted(
+                encrypt_payload(
+                    &envelope,
+                    EncryptionAlgorithm::Aes256Gcm,
+                    key.bytes_32(),
+                    aad,
+                ),
+                metered_size,
+            ),
+        },
     };
     Metered::with_size(metered_size, record)
 }
@@ -222,7 +232,7 @@ pub fn encrypt_record(
 fn encrypt_payload(
     plaintext: &(impl Encodable + ?Sized),
     alg: EncryptionAlgorithm,
-    key: &[u8; 32],
+    key: &[u8],
     aad: &[u8],
 ) -> EncryptedRecord {
     let format = EncryptedRecordFormat::current_for_algorithm(alg);
@@ -238,6 +248,7 @@ fn encrypt_payload(
 
     match format {
         EncryptedRecordFormat::Aegis256V1 => {
+            let key: &[u8; 32] = key.try_into().expect("AEGIS-256 key should be 32 bytes");
             let nonce: &[u8; 32] = nonce
                 .try_into()
                 .expect("AEGIS-256 nonce should match the encoded record framing");
@@ -282,16 +293,15 @@ pub fn decrypt_stored_record(
 ) -> Result<Metered<Record>, RecordDecryptionError> {
     match record {
         StoredRecord::Plaintext(record @ Record::Command(_)) => Ok(record.metered()),
-        StoredRecord::Plaintext(record @ Record::Envelope(_)) => {
-            if encryption.is_plain() {
-                Ok(record.metered())
-            } else {
+        StoredRecord::Plaintext(record @ Record::Envelope(_)) => match encryption.inner() {
+            EncryptionSpecInner::Plaintext => Ok(record.metered()),
+            EncryptionSpecInner::Aegis256(_) | EncryptionSpecInner::Aes256Gcm(_) => {
                 Err(RecordDecryptionError::AlgorithmMismatch {
                     expected: encryption.algorithm(),
                     actual: None,
                 })
             }
-        }
+        },
         StoredRecord::Encrypted {
             metered_size,
             record: encrypted,
@@ -320,14 +330,9 @@ fn decrypt_payload(
     let (mut encoded, payload_start, payload_end) = decryption_layout(record, format)?;
     let plaintext_len = payload_end - payload_start;
 
-    match format {
-        EncryptedRecordFormat::Aegis256V1 => {
-            let Some(key) = encryption.key_for_algorithm(EncryptionAlgorithm::Aegis256) else {
-                return Err(RecordDecryptionError::AlgorithmMismatch {
-                    expected,
-                    actual: Some(EncryptionAlgorithm::Aegis256),
-                });
-            };
+    match (format, encryption.inner()) {
+        (EncryptedRecordFormat::Aegis256V1, EncryptionSpecInner::Aegis256(key)) => {
+            let key = key.bytes_32();
             {
                 let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
                 let nonce: &[u8; 32] = prefix
@@ -347,14 +352,12 @@ fn decrypt_payload(
             }
             Ok(decryption_finish(encoded, payload_start, plaintext_len))
         }
-        EncryptedRecordFormat::Aes256GcmV1 => {
-            let Some(key) = encryption.key_for_algorithm(EncryptionAlgorithm::Aes256Gcm) else {
-                return Err(RecordDecryptionError::AlgorithmMismatch {
-                    expected,
-                    actual: Some(EncryptionAlgorithm::Aes256Gcm),
-                });
-            };
-            let cipher = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key));
+        (EncryptedRecordFormat::Aegis256V1, _) => Err(RecordDecryptionError::AlgorithmMismatch {
+            expected,
+            actual: Some(EncryptionAlgorithm::Aegis256),
+        }),
+        (EncryptedRecordFormat::Aes256GcmV1, EncryptionSpecInner::Aes256Gcm(key)) => {
+            let cipher = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key.bytes_32()));
             {
                 let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
                 let nonce: &[u8; 12] = prefix
@@ -375,6 +378,10 @@ fn decrypt_payload(
             }
             Ok(decryption_finish(encoded, payload_start, plaintext_len))
         }
+        (EncryptedRecordFormat::Aes256GcmV1, _) => Err(RecordDecryptionError::AlgorithmMismatch {
+            expected,
+            actual: Some(EncryptionAlgorithm::Aes256Gcm),
+        }),
     }
 }
 
@@ -476,13 +483,23 @@ mod tests {
     ) -> StoredRecord {
         let metered_size = make_plaintext_envelope(headers.clone(), body.clone()).metered_size();
         let plaintext = make_envelope(headers, body);
-        let algorithm = encryption
-            .algorithm()
-            .expect("plain mode should not produce an encrypted record");
-        let key = encryption
-            .key_for_algorithm(algorithm)
-            .expect("encrypted test record should carry a matching key");
-        let encrypted = encrypt_payload(&plaintext, algorithm, key, aad);
+        let encrypted = match encryption.inner() {
+            EncryptionSpecInner::Plaintext => {
+                panic!("plain mode should not produce an encrypted record")
+            }
+            EncryptionSpecInner::Aegis256(key) => encrypt_payload(
+                &plaintext,
+                EncryptionAlgorithm::Aegis256,
+                key.bytes_32(),
+                aad,
+            ),
+            EncryptionSpecInner::Aes256Gcm(key) => encrypt_payload(
+                &plaintext,
+                EncryptionAlgorithm::Aes256Gcm,
+                key.bytes_32(),
+                aad,
+            ),
+        };
         StoredRecord::encrypted(encrypted, metered_size)
     }
 

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -204,9 +204,7 @@ pub fn encrypt_record(
     let metered_size = record.metered_size();
     let record = match (record.into_inner(), encryption) {
         (record @ Record::Command(_), _) => StoredRecord::Plaintext(record),
-        (record @ Record::Envelope(_), EncryptionSpec::Plaintext) => {
-            StoredRecord::Plaintext(record)
-        }
+        (record @ Record::Envelope(_), EncryptionSpec::Plain) => StoredRecord::Plaintext(record),
         (Record::Envelope(envelope), EncryptionSpec::Aegis256(key)) => {
             let encrypted = encrypt_payload(
                 &envelope,
@@ -293,7 +291,7 @@ pub fn decrypt_stored_record(
     match record {
         StoredRecord::Plaintext(record @ Record::Command(_)) => Ok(record.metered()),
         StoredRecord::Plaintext(record @ Record::Envelope(_)) => match encryption {
-            EncryptionSpec::Plaintext => Ok(record.metered()),
+            EncryptionSpec::Plain => Ok(record.metered()),
             EncryptionSpec::Aegis256(_) => Err(RecordDecryptionError::AlgorithmMismatch {
                 expected: Some(EncryptionAlgorithm::Aegis256),
                 actual: None,
@@ -351,7 +349,7 @@ fn decrypt_payload(
             }
             Ok(decryption_finish(encoded, payload_start, plaintext_len))
         }
-        (EncryptedRecordFormat::Aegis256V1, EncryptionSpec::Plaintext) => {
+        (EncryptedRecordFormat::Aegis256V1, EncryptionSpec::Plain) => {
             Err(RecordDecryptionError::AlgorithmMismatch {
                 expected: None,
                 actual: Some(EncryptionAlgorithm::Aegis256),
@@ -385,7 +383,7 @@ fn decrypt_payload(
             }
             Ok(decryption_finish(encoded, payload_start, plaintext_len))
         }
-        (EncryptedRecordFormat::Aes256GcmV1, EncryptionSpec::Plaintext) => {
+        (EncryptedRecordFormat::Aes256GcmV1, EncryptionSpec::Plain) => {
             Err(RecordDecryptionError::AlgorithmMismatch {
                 expected: None,
                 actual: Some(EncryptionAlgorithm::Aes256Gcm),
@@ -505,7 +503,7 @@ mod tests {
         let metered_size = make_plaintext_envelope(headers.clone(), body.clone()).metered_size();
         let plaintext = make_envelope(headers, body);
         let encrypted = match encryption {
-            EncryptionSpec::Plaintext => {
+            EncryptionSpec::Plain => {
                 panic!("plain mode should not produce an encrypted record")
             }
             EncryptionSpec::Aegis256(key) => encrypt_payload(
@@ -776,7 +774,7 @@ mod tests {
             &aad,
         );
 
-        let result = decrypt_stored_record(record, &EncryptionSpec::Plaintext, &aad);
+        let result = decrypt_stored_record(record, &EncryptionSpec::Plain, &aad);
 
         assert!(matches!(
             result,

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -36,7 +36,7 @@ use rand::random;
 use super::{Encodable, Metered, MeteredSize, Record, RecordDecodeError, StoredRecord};
 use crate::{
     deep_size::DeepSize,
-    encryption::{EncryptionAlgorithm, EncryptionSpec, EncryptionSpecInner},
+    encryption::{EncryptionAlgorithm, EncryptionSpec},
     record::MeteredExt as _,
 };
 
@@ -204,27 +204,17 @@ pub fn encrypt_record(
     let metered_size = record.metered_size();
     let record = match record.into_inner() {
         record @ Record::Command(_) => StoredRecord::Plaintext(record),
-        Record::Envelope(envelope) => match encryption.inner() {
-            EncryptionSpecInner::Plaintext => StoredRecord::Plaintext(Record::Envelope(envelope)),
-            EncryptionSpecInner::Aegis256(key) => StoredRecord::encrypted(
-                encrypt_payload(
-                    &envelope,
-                    EncryptionAlgorithm::Aegis256,
-                    key.bytes_32(),
-                    aad,
-                ),
-                metered_size,
-            ),
-            EncryptionSpecInner::Aes256Gcm(key) => StoredRecord::encrypted(
-                encrypt_payload(
-                    &envelope,
-                    EncryptionAlgorithm::Aes256Gcm,
-                    key.bytes_32(),
-                    aad,
-                ),
-                metered_size,
-            ),
-        },
+        record @ Record::Envelope(_) if encryption.is_plain() => StoredRecord::Plaintext(record),
+        Record::Envelope(envelope) => {
+            let algorithm = encryption
+                .algorithm()
+                .expect("non-plain encryption should carry an algorithm");
+            let key = encryption
+                .key_for_algorithm(algorithm)
+                .expect("non-plain encryption should carry a matching key");
+            let encrypted = encrypt_payload(&envelope, algorithm, key, aad);
+            StoredRecord::encrypted(encrypted, metered_size)
+        }
     };
     Metered::with_size(metered_size, record)
 }
@@ -232,7 +222,7 @@ pub fn encrypt_record(
 fn encrypt_payload(
     plaintext: &(impl Encodable + ?Sized),
     alg: EncryptionAlgorithm,
-    key: &[u8],
+    key: &[u8; 32],
     aad: &[u8],
 ) -> EncryptedRecord {
     let format = EncryptedRecordFormat::current_for_algorithm(alg);
@@ -248,7 +238,6 @@ fn encrypt_payload(
 
     match format {
         EncryptedRecordFormat::Aegis256V1 => {
-            let key: &[u8; 32] = key.try_into().expect("AEGIS-256 key should be 32 bytes");
             let nonce: &[u8; 32] = nonce
                 .try_into()
                 .expect("AEGIS-256 nonce should match the encoded record framing");
@@ -293,15 +282,16 @@ pub fn decrypt_stored_record(
 ) -> Result<Metered<Record>, RecordDecryptionError> {
     match record {
         StoredRecord::Plaintext(record @ Record::Command(_)) => Ok(record.metered()),
-        StoredRecord::Plaintext(record @ Record::Envelope(_)) => match encryption.inner() {
-            EncryptionSpecInner::Plaintext => Ok(record.metered()),
-            EncryptionSpecInner::Aegis256(_) | EncryptionSpecInner::Aes256Gcm(_) => {
+        StoredRecord::Plaintext(record @ Record::Envelope(_)) => {
+            if encryption.is_plain() {
+                Ok(record.metered())
+            } else {
                 Err(RecordDecryptionError::AlgorithmMismatch {
                     expected: encryption.algorithm(),
                     actual: None,
                 })
             }
-        },
+        }
         StoredRecord::Encrypted {
             metered_size,
             record: encrypted,
@@ -330,9 +320,14 @@ fn decrypt_payload(
     let (mut encoded, payload_start, payload_end) = decryption_layout(record, format)?;
     let plaintext_len = payload_end - payload_start;
 
-    match (format, encryption.inner()) {
-        (EncryptedRecordFormat::Aegis256V1, EncryptionSpecInner::Aegis256(key)) => {
-            let key = key.bytes_32();
+    match format {
+        EncryptedRecordFormat::Aegis256V1 => {
+            let Some(key) = encryption.key_for_algorithm(EncryptionAlgorithm::Aegis256) else {
+                return Err(RecordDecryptionError::AlgorithmMismatch {
+                    expected,
+                    actual: Some(EncryptionAlgorithm::Aegis256),
+                });
+            };
             {
                 let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
                 let nonce: &[u8; 32] = prefix
@@ -352,12 +347,14 @@ fn decrypt_payload(
             }
             Ok(decryption_finish(encoded, payload_start, plaintext_len))
         }
-        (EncryptedRecordFormat::Aegis256V1, _) => Err(RecordDecryptionError::AlgorithmMismatch {
-            expected,
-            actual: Some(EncryptionAlgorithm::Aegis256),
-        }),
-        (EncryptedRecordFormat::Aes256GcmV1, EncryptionSpecInner::Aes256Gcm(key)) => {
-            let cipher = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key.bytes_32()));
+        EncryptedRecordFormat::Aes256GcmV1 => {
+            let Some(key) = encryption.key_for_algorithm(EncryptionAlgorithm::Aes256Gcm) else {
+                return Err(RecordDecryptionError::AlgorithmMismatch {
+                    expected,
+                    actual: Some(EncryptionAlgorithm::Aes256Gcm),
+                });
+            };
+            let cipher = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key));
             {
                 let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
                 let nonce: &[u8; 12] = prefix
@@ -378,10 +375,6 @@ fn decrypt_payload(
             }
             Ok(decryption_finish(encoded, payload_start, plaintext_len))
         }
-        (EncryptedRecordFormat::Aes256GcmV1, _) => Err(RecordDecryptionError::AlgorithmMismatch {
-            expected,
-            actual: Some(EncryptionAlgorithm::Aes256Gcm),
-        }),
     }
 }
 
@@ -483,23 +476,13 @@ mod tests {
     ) -> StoredRecord {
         let metered_size = make_plaintext_envelope(headers.clone(), body.clone()).metered_size();
         let plaintext = make_envelope(headers, body);
-        let encrypted = match encryption.inner() {
-            EncryptionSpecInner::Plaintext => {
-                panic!("plain mode should not produce an encrypted record")
-            }
-            EncryptionSpecInner::Aegis256(key) => encrypt_payload(
-                &plaintext,
-                EncryptionAlgorithm::Aegis256,
-                key.bytes_32(),
-                aad,
-            ),
-            EncryptionSpecInner::Aes256Gcm(key) => encrypt_payload(
-                &plaintext,
-                EncryptionAlgorithm::Aes256Gcm,
-                key.bytes_32(),
-                aad,
-            ),
-        };
+        let algorithm = encryption
+            .algorithm()
+            .expect("plain mode should not produce an encrypted record");
+        let key = encryption
+            .key_for_algorithm(algorithm)
+            .expect("encrypted test record should carry a matching key");
+        let encrypted = encrypt_payload(&plaintext, algorithm, key, aad);
         StoredRecord::encrypted(encrypted, metered_size)
     }
 

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -36,7 +36,7 @@ use rand::random;
 use super::{Encodable, Metered, MeteredSize, Record, RecordDecodeError, StoredRecord};
 use crate::{
     deep_size::DeepSize,
-    encryption::{EncryptionAlgorithm, EncryptionMode, EncryptionSpec},
+    encryption::{Encryption, EncryptionAlgorithm, EncryptionMode},
     record::MeteredExt as _,
 };
 
@@ -198,19 +198,19 @@ impl Encodable for EncryptedRecord {
 
 pub fn encrypt_record(
     record: Metered<Record>,
-    encryption: &EncryptionSpec,
+    encryption: &Encryption,
     aad: &[u8],
 ) -> Metered<StoredRecord> {
     let metered_size = record.metered_size();
     let record = match (record.into_inner(), encryption) {
         (record @ Record::Command(_), _) => StoredRecord::Plaintext(record),
-        (record @ Record::Envelope(_), EncryptionSpec::Plain) => StoredRecord::Plaintext(record),
-        (Record::Envelope(envelope), EncryptionSpec::Aegis256(key)) => {
+        (record @ Record::Envelope(_), Encryption::Plain) => StoredRecord::Plaintext(record),
+        (Record::Envelope(envelope), Encryption::Aegis256(key)) => {
             let encrypted =
                 encrypt_payload(&envelope, EncryptionAlgorithm::Aegis256, key.secret(), aad);
             StoredRecord::encrypted(encrypted, metered_size)
         }
-        (Record::Envelope(envelope), EncryptionSpec::Aes256Gcm(key)) => {
+        (Record::Envelope(envelope), Encryption::Aes256Gcm(key)) => {
             let encrypted =
                 encrypt_payload(&envelope, EncryptionAlgorithm::Aes256Gcm, key.secret(), aad);
             StoredRecord::encrypted(encrypted, metered_size)
@@ -277,11 +277,18 @@ impl TryFrom<Bytes> for EncryptedRecord {
 
 pub fn decrypt_stored_record(
     record: StoredRecord,
-    encryption: &EncryptionSpec,
+    encryption: &Encryption,
     aad: &[u8],
 ) -> Result<Metered<Record>, RecordDecryptionError> {
     match record {
-        StoredRecord::Plaintext(record) => Ok(record.metered()),
+        StoredRecord::Plaintext(record @ Record::Command(_)) => Ok(record.metered()),
+        StoredRecord::Plaintext(record @ Record::Envelope(_)) => match encryption {
+            Encryption::Plain => Ok(record.metered()),
+            _ => Err(RecordDecryptionError::ModeMismatch {
+                expected: encryption.mode(),
+                actual: EncryptionMode::Plain,
+            }),
+        },
         StoredRecord::Encrypted {
             metered_size,
             record: encrypted,
@@ -302,7 +309,7 @@ pub fn decrypt_stored_record(
 
 fn decrypt_payload(
     record: EncryptedRecord,
-    encryption: &EncryptionSpec,
+    encryption: &Encryption,
     aad: &[u8],
 ) -> Result<Bytes, RecordDecryptionError> {
     let format = record.format;
@@ -313,7 +320,7 @@ fn decrypt_payload(
     match format {
         EncryptedRecordFormat::Aegis256V1 => {
             let key = match encryption {
-                EncryptionSpec::Aegis256(key) => key,
+                Encryption::Aegis256(key) => key,
                 _ => {
                     return Err(RecordDecryptionError::ModeMismatch {
                         expected,
@@ -342,7 +349,7 @@ fn decrypt_payload(
         }
         EncryptedRecordFormat::Aes256GcmV1 => {
             let key = match encryption {
-                EncryptionSpec::Aes256Gcm(key) => key,
+                Encryption::Aes256Gcm(key) => key,
                 _ => {
                     return Err(RecordDecryptionError::ModeMismatch {
                         expected,
@@ -402,22 +409,22 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::record::{EnvelopeRecord, Header, MeteredExt};
+    use crate::record::{CommandRecord, EnvelopeRecord, Header, MeteredExt};
 
     const TEST_KEY: [u8; 32] = [0x42; 32];
     const OTHER_TEST_KEY: [u8; 32] = [0x99; 32];
 
-    fn test_encryption(alg: EncryptionAlgorithm) -> EncryptionSpec {
+    fn test_encryption(alg: EncryptionAlgorithm) -> Encryption {
         match alg {
-            EncryptionAlgorithm::Aegis256 => EncryptionSpec::aegis256(TEST_KEY),
-            EncryptionAlgorithm::Aes256Gcm => EncryptionSpec::aes256_gcm(TEST_KEY),
+            EncryptionAlgorithm::Aegis256 => Encryption::aegis256(TEST_KEY),
+            EncryptionAlgorithm::Aes256Gcm => Encryption::aes256_gcm(TEST_KEY),
         }
     }
 
-    fn other_test_encryption(alg: EncryptionAlgorithm) -> EncryptionSpec {
+    fn other_test_encryption(alg: EncryptionAlgorithm) -> Encryption {
         match alg {
-            EncryptionAlgorithm::Aegis256 => EncryptionSpec::aegis256(OTHER_TEST_KEY),
-            EncryptionAlgorithm::Aes256Gcm => EncryptionSpec::aes256_gcm(OTHER_TEST_KEY),
+            EncryptionAlgorithm::Aegis256 => Encryption::aegis256(OTHER_TEST_KEY),
+            EncryptionAlgorithm::Aes256Gcm => Encryption::aes256_gcm(OTHER_TEST_KEY),
         }
     }
 
@@ -465,7 +472,7 @@ mod tests {
     }
 
     fn make_encrypted_stored_record(
-        encryption: &EncryptionSpec,
+        encryption: &Encryption,
         headers: Vec<Header>,
         body: Bytes,
         aad: &[u8],
@@ -473,13 +480,13 @@ mod tests {
         let metered_size = make_plaintext_envelope(headers.clone(), body.clone()).metered_size();
         let plaintext = make_envelope(headers, body);
         let encrypted = match encryption {
-            EncryptionSpec::Plain => {
+            Encryption::Plain => {
                 unreachable!("plain mode should not produce an encrypted record")
             }
-            EncryptionSpec::Aegis256(key) => {
+            Encryption::Aegis256(key) => {
                 encrypt_payload(&plaintext, EncryptionAlgorithm::Aegis256, key.secret(), aad)
             }
-            EncryptionSpec::Aes256Gcm(key) => encrypt_payload(
+            Encryption::Aes256Gcm(key) => encrypt_payload(
                 &plaintext,
                 EncryptionAlgorithm::Aes256Gcm,
                 key.secret(),
@@ -685,11 +692,9 @@ mod tests {
     }
 
     #[test]
-    fn decrypt_stored_record_preserves_plaintext() {
-        let record = StoredRecord::Plaintext(Record::Envelope(
-            EnvelopeRecord::try_from_parts(vec![], Bytes::from_static(b"legacy-plaintext"))
-                .unwrap(),
-        ));
+    fn decrypt_stored_record_preserves_plaintext_command_records() {
+        let token: crate::record::FencingToken = "fence-test".parse().unwrap();
+        let record = StoredRecord::Plaintext(Record::Command(CommandRecord::Fence(token.clone())));
 
         let decrypted = decrypt_stored_record(
             record,
@@ -698,10 +703,10 @@ mod tests {
         )
         .unwrap();
 
-        let Record::Envelope(record) = decrypted.into_inner() else {
-            panic!("expected envelope record");
+        let Record::Command(record) = decrypted.into_inner() else {
+            panic!("expected command record");
         };
-        assert_eq!(record.body().as_ref(), b"legacy-plaintext");
+        assert_eq!(record, CommandRecord::Fence(token));
     }
 
     #[test]
@@ -743,7 +748,7 @@ mod tests {
             &aad,
         );
 
-        let result = decrypt_stored_record(record, &EncryptionSpec::Plain, &aad);
+        let result = decrypt_stored_record(record, &Encryption::Plain, &aad);
 
         assert!(matches!(
             result,

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -496,7 +496,7 @@ mod tests {
         let plaintext = make_envelope(headers, body);
         let encrypted = match encryption {
             EncryptionSpec::Plain => {
-                panic!("plain mode should not produce an encrypted record")
+                panic!("plain encryption should not produce an encrypted record")
             }
             EncryptionSpec::Aegis256(key) => encrypt_payload(
                 &plaintext,

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -202,17 +202,27 @@ pub fn encrypt_record(
     aad: &[u8],
 ) -> Metered<StoredRecord> {
     let metered_size = record.metered_size();
-    let record = match record.into_inner() {
-        record @ Record::Command(_) => StoredRecord::Plaintext(record),
-        record @ Record::Envelope(_) if encryption.is_plain() => StoredRecord::Plaintext(record),
-        Record::Envelope(envelope) => {
-            let algorithm = encryption
-                .algorithm()
-                .expect("non-plain encryption should carry an algorithm");
-            let key = encryption
-                .key_for_algorithm(algorithm)
-                .expect("non-plain encryption should carry a matching key");
-            let encrypted = encrypt_payload(&envelope, algorithm, key, aad);
+    let record = match (record.into_inner(), encryption) {
+        (record @ Record::Command(_), _) => StoredRecord::Plaintext(record),
+        (record @ Record::Envelope(_), EncryptionSpec::Plaintext) => {
+            StoredRecord::Plaintext(record)
+        }
+        (Record::Envelope(envelope), EncryptionSpec::Aegis256(key)) => {
+            let encrypted = encrypt_payload(
+                &envelope,
+                EncryptionAlgorithm::Aegis256,
+                key_bytes_32(key),
+                aad,
+            );
+            StoredRecord::encrypted(encrypted, metered_size)
+        }
+        (Record::Envelope(envelope), EncryptionSpec::Aes256Gcm(key)) => {
+            let encrypted = encrypt_payload(
+                &envelope,
+                EncryptionAlgorithm::Aes256Gcm,
+                key_bytes_32(key),
+                aad,
+            );
             StoredRecord::encrypted(encrypted, metered_size)
         }
     };
@@ -282,16 +292,17 @@ pub fn decrypt_stored_record(
 ) -> Result<Metered<Record>, RecordDecryptionError> {
     match record {
         StoredRecord::Plaintext(record @ Record::Command(_)) => Ok(record.metered()),
-        StoredRecord::Plaintext(record @ Record::Envelope(_)) => {
-            if encryption.is_plain() {
-                Ok(record.metered())
-            } else {
-                Err(RecordDecryptionError::AlgorithmMismatch {
-                    expected: encryption.algorithm(),
-                    actual: None,
-                })
-            }
-        }
+        StoredRecord::Plaintext(record @ Record::Envelope(_)) => match encryption {
+            EncryptionSpec::Plaintext => Ok(record.metered()),
+            EncryptionSpec::Aegis256(_) => Err(RecordDecryptionError::AlgorithmMismatch {
+                expected: Some(EncryptionAlgorithm::Aegis256),
+                actual: None,
+            }),
+            EncryptionSpec::Aes256Gcm(_) => Err(RecordDecryptionError::AlgorithmMismatch {
+                expected: Some(EncryptionAlgorithm::Aes256Gcm),
+                actual: None,
+            }),
+        },
         StoredRecord::Encrypted {
             metered_size,
             record: encrypted,
@@ -316,18 +327,11 @@ fn decrypt_payload(
     aad: &[u8],
 ) -> Result<Bytes, RecordDecryptionError> {
     let format = record.format;
-    let expected = encryption.algorithm();
     let (mut encoded, payload_start, payload_end) = decryption_layout(record, format)?;
     let plaintext_len = payload_end - payload_start;
 
-    match format {
-        EncryptedRecordFormat::Aegis256V1 => {
-            let Some(key) = encryption.key_for_algorithm(EncryptionAlgorithm::Aegis256) else {
-                return Err(RecordDecryptionError::AlgorithmMismatch {
-                    expected,
-                    actual: Some(EncryptionAlgorithm::Aegis256),
-                });
-            };
+    match (format, encryption) {
+        (EncryptedRecordFormat::Aegis256V1, EncryptionSpec::Aegis256(key)) => {
             {
                 let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
                 let nonce: &[u8; 32] = prefix
@@ -341,20 +345,26 @@ fn decrypt_payload(
                     .try_into()
                     .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
 
-                Aegis256::<16>::new(key, nonce)
+                Aegis256::<16>::new(key_bytes_32(key), nonce)
                     .decrypt_in_place(ciphertext, tag, aad)
                     .map_err(|_| RecordDecryptionError::AuthenticationFailed)?;
             }
             Ok(decryption_finish(encoded, payload_start, plaintext_len))
         }
-        EncryptedRecordFormat::Aes256GcmV1 => {
-            let Some(key) = encryption.key_for_algorithm(EncryptionAlgorithm::Aes256Gcm) else {
-                return Err(RecordDecryptionError::AlgorithmMismatch {
-                    expected,
-                    actual: Some(EncryptionAlgorithm::Aes256Gcm),
-                });
-            };
-            let cipher = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key));
+        (EncryptedRecordFormat::Aegis256V1, EncryptionSpec::Plaintext) => {
+            Err(RecordDecryptionError::AlgorithmMismatch {
+                expected: None,
+                actual: Some(EncryptionAlgorithm::Aegis256),
+            })
+        }
+        (EncryptedRecordFormat::Aegis256V1, EncryptionSpec::Aes256Gcm(_)) => {
+            Err(RecordDecryptionError::AlgorithmMismatch {
+                expected: Some(EncryptionAlgorithm::Aes256Gcm),
+                actual: Some(EncryptionAlgorithm::Aegis256),
+            })
+        }
+        (EncryptedRecordFormat::Aes256GcmV1, EncryptionSpec::Aes256Gcm(key)) => {
+            let cipher = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key_bytes_32(key)));
             {
                 let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
                 let nonce: &[u8; 12] = prefix
@@ -375,7 +385,25 @@ fn decrypt_payload(
             }
             Ok(decryption_finish(encoded, payload_start, plaintext_len))
         }
+        (EncryptedRecordFormat::Aes256GcmV1, EncryptionSpec::Plaintext) => {
+            Err(RecordDecryptionError::AlgorithmMismatch {
+                expected: None,
+                actual: Some(EncryptionAlgorithm::Aes256Gcm),
+            })
+        }
+        (EncryptedRecordFormat::Aes256GcmV1, EncryptionSpec::Aegis256(_)) => {
+            Err(RecordDecryptionError::AlgorithmMismatch {
+                expected: Some(EncryptionAlgorithm::Aegis256),
+                actual: Some(EncryptionAlgorithm::Aes256Gcm),
+            })
+        }
     }
+}
+
+fn key_bytes_32(key: &crate::encryption::EncryptionKey) -> &[u8; 32] {
+    key.bytes()
+        .try_into()
+        .expect("encryption key should be 32 bytes after validation")
 }
 
 fn decryption_layout(
@@ -476,13 +504,23 @@ mod tests {
     ) -> StoredRecord {
         let metered_size = make_plaintext_envelope(headers.clone(), body.clone()).metered_size();
         let plaintext = make_envelope(headers, body);
-        let algorithm = encryption
-            .algorithm()
-            .expect("plain mode should not produce an encrypted record");
-        let key = encryption
-            .key_for_algorithm(algorithm)
-            .expect("encrypted test record should carry a matching key");
-        let encrypted = encrypt_payload(&plaintext, algorithm, key, aad);
+        let encrypted = match encryption {
+            EncryptionSpec::Plaintext => {
+                panic!("plain mode should not produce an encrypted record")
+            }
+            EncryptionSpec::Aegis256(key) => encrypt_payload(
+                &plaintext,
+                EncryptionAlgorithm::Aegis256,
+                key_bytes_32(key),
+                aad,
+            ),
+            EncryptionSpec::Aes256Gcm(key) => encrypt_payload(
+                &plaintext,
+                EncryptionAlgorithm::Aes256Gcm,
+                key_bytes_32(key),
+                aad,
+            ),
+        };
         StoredRecord::encrypted(encrypted, metered_size)
     }
 
@@ -738,7 +776,7 @@ mod tests {
             &aad,
         );
 
-        let result = decrypt_stored_record(record, &EncryptionSpec::plain(), &aad);
+        let result = decrypt_stored_record(record, &EncryptionSpec::Plaintext, &aad);
 
         assert!(matches!(
             result,

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -230,7 +230,7 @@ pub fn encrypt_record(
 fn encrypt_payload(
     plaintext: &(impl Encodable + ?Sized),
     alg: EncryptionAlgorithm,
-    key: &[u8],
+    key: &[u8; 32],
     aad: &[u8],
 ) -> EncryptedRecord {
     let format = EncryptedRecordFormat::current_for_algorithm(alg);
@@ -246,7 +246,6 @@ fn encrypt_payload(
 
     match format {
         EncryptedRecordFormat::Aegis256V1 => {
-            let key: &[u8; 32] = key.try_into().expect("AEGIS-256 key must be 32 bytes");
             let nonce: &[u8; 32] = nonce.try_into().expect("AEGIS-256 nonce must be 32 bytes");
             let tag = Aegis256::<16>::new(key, nonce).encrypt_in_place(payload, aad);
             encoded.put_slice(tag.as_ref());
@@ -330,10 +329,6 @@ fn decrypt_payload(
     match (format, encryption) {
         (EncryptedRecordFormat::Aegis256V1, EncryptionSpec::Aegis256(key)) => {
             let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
-            let key: &[u8; 32] = key
-                .expose_secret()
-                .try_into()
-                .expect("AEGIS-256 key must be 32 bytes");
             let nonce: &[u8; 32] = prefix
                 .get(FORMAT_ID_LEN..)
                 .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?
@@ -344,7 +339,7 @@ fn decrypt_payload(
                 .as_ref()
                 .try_into()
                 .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
-            Aegis256::<16>::new(key, nonce)
+            Aegis256::<16>::new(key.expose_secret(), nonce)
                 .decrypt_in_place(ciphertext, tag, aad)
                 .map_err(|_| RecordDecryptionError::AuthenticationFailed)?;
             Ok(decryption_finish(encoded, payload_start, plaintext_len))

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -36,7 +36,7 @@ use rand::random;
 use super::{Encodable, Metered, MeteredSize, Record, RecordDecodeError, StoredRecord};
 use crate::{
     deep_size::DeepSize,
-    encryption::{Encryption, EncryptionAlgorithm},
+    encryption::{EncryptionAlgorithm, EncryptionSpec},
     record::MeteredExt as _,
 };
 
@@ -198,21 +198,21 @@ impl Encodable for EncryptedRecord {
 
 pub fn encrypt_record(
     record: Metered<Record>,
-    encryption: &Encryption,
+    encryption: &EncryptionSpec,
     aad: &[u8],
 ) -> Metered<StoredRecord> {
     let metered_size = record.metered_size();
-    let record = match (record.into_inner(), encryption) {
-        (record @ Record::Command(_), _) => StoredRecord::Plaintext(record),
-        (record @ Record::Envelope(_), Encryption::Plain) => StoredRecord::Plaintext(record),
-        (Record::Envelope(envelope), Encryption::Aegis256(key)) => {
-            let encrypted =
-                encrypt_payload(&envelope, EncryptionAlgorithm::Aegis256, key.secret(), aad);
-            StoredRecord::encrypted(encrypted, metered_size)
-        }
-        (Record::Envelope(envelope), Encryption::Aes256Gcm(key)) => {
-            let encrypted =
-                encrypt_payload(&envelope, EncryptionAlgorithm::Aes256Gcm, key.secret(), aad);
+    let record = match record.into_inner() {
+        record @ Record::Command(_) => StoredRecord::Plaintext(record),
+        record @ Record::Envelope(_) if encryption.is_plain() => StoredRecord::Plaintext(record),
+        Record::Envelope(envelope) => {
+            let algorithm = encryption
+                .algorithm()
+                .expect("non-plain encryption should carry an algorithm");
+            let key = encryption
+                .secret_key()
+                .expect("non-plain encryption should carry a secret key");
+            let encrypted = encrypt_payload(&envelope, algorithm, key, aad);
             StoredRecord::encrypted(encrypted, metered_size)
         }
     };
@@ -277,18 +277,21 @@ impl TryFrom<Bytes> for EncryptedRecord {
 
 pub fn decrypt_stored_record(
     record: StoredRecord,
-    encryption: &Encryption,
+    encryption: &EncryptionSpec,
     aad: &[u8],
 ) -> Result<Metered<Record>, RecordDecryptionError> {
     match record {
         StoredRecord::Plaintext(record @ Record::Command(_)) => Ok(record.metered()),
-        StoredRecord::Plaintext(record @ Record::Envelope(_)) => match encryption {
-            Encryption::Plain => Ok(record.metered()),
-            _ => Err(RecordDecryptionError::AlgorithmMismatch {
-                expected: encryption.algorithm(),
-                actual: None,
-            }),
-        },
+        StoredRecord::Plaintext(record @ Record::Envelope(_)) => {
+            if encryption.is_plain() {
+                Ok(record.metered())
+            } else {
+                Err(RecordDecryptionError::AlgorithmMismatch {
+                    expected: encryption.algorithm(),
+                    actual: None,
+                })
+            }
+        }
         StoredRecord::Encrypted {
             metered_size,
             record: encrypted,
@@ -309,7 +312,7 @@ pub fn decrypt_stored_record(
 
 fn decrypt_payload(
     record: EncryptedRecord,
-    encryption: &Encryption,
+    encryption: &EncryptionSpec,
     aad: &[u8],
 ) -> Result<Bytes, RecordDecryptionError> {
     let format = record.format;
@@ -319,14 +322,12 @@ fn decrypt_payload(
 
     match format {
         EncryptedRecordFormat::Aegis256V1 => {
-            let key = match encryption {
-                Encryption::Aegis256(key) => key,
-                _ => {
-                    return Err(RecordDecryptionError::AlgorithmMismatch {
-                        expected,
-                        actual: Some(EncryptionAlgorithm::Aegis256),
-                    });
-                }
+            let Some(key) = encryption.secret_key_for_algorithm(EncryptionAlgorithm::Aegis256)
+            else {
+                return Err(RecordDecryptionError::AlgorithmMismatch {
+                    expected,
+                    actual: Some(EncryptionAlgorithm::Aegis256),
+                });
             };
             {
                 let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
@@ -341,23 +342,21 @@ fn decrypt_payload(
                     .try_into()
                     .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
 
-                Aegis256::<16>::new(key.secret(), nonce)
+                Aegis256::<16>::new(key, nonce)
                     .decrypt_in_place(ciphertext, tag, aad)
                     .map_err(|_| RecordDecryptionError::AuthenticationFailed)?;
             }
             Ok(decryption_finish(encoded, payload_start, plaintext_len))
         }
         EncryptedRecordFormat::Aes256GcmV1 => {
-            let key = match encryption {
-                Encryption::Aes256Gcm(key) => key,
-                _ => {
-                    return Err(RecordDecryptionError::AlgorithmMismatch {
-                        expected,
-                        actual: Some(EncryptionAlgorithm::Aes256Gcm),
-                    });
-                }
+            let Some(key) = encryption.secret_key_for_algorithm(EncryptionAlgorithm::Aes256Gcm)
+            else {
+                return Err(RecordDecryptionError::AlgorithmMismatch {
+                    expected,
+                    actual: Some(EncryptionAlgorithm::Aes256Gcm),
+                });
             };
-            let cipher = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key.secret()));
+            let cipher = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key));
             {
                 let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
                 let nonce: &[u8; 12] = prefix
@@ -414,17 +413,17 @@ mod tests {
     const TEST_KEY: [u8; 32] = [0x42; 32];
     const OTHER_TEST_KEY: [u8; 32] = [0x99; 32];
 
-    fn test_encryption(alg: EncryptionAlgorithm) -> Encryption {
+    fn test_encryption(alg: EncryptionAlgorithm) -> EncryptionSpec {
         match alg {
-            EncryptionAlgorithm::Aegis256 => Encryption::aegis256(TEST_KEY),
-            EncryptionAlgorithm::Aes256Gcm => Encryption::aes256_gcm(TEST_KEY),
+            EncryptionAlgorithm::Aegis256 => EncryptionSpec::aegis256(TEST_KEY),
+            EncryptionAlgorithm::Aes256Gcm => EncryptionSpec::aes256_gcm(TEST_KEY),
         }
     }
 
-    fn other_test_encryption(alg: EncryptionAlgorithm) -> Encryption {
+    fn other_test_encryption(alg: EncryptionAlgorithm) -> EncryptionSpec {
         match alg {
-            EncryptionAlgorithm::Aegis256 => Encryption::aegis256(OTHER_TEST_KEY),
-            EncryptionAlgorithm::Aes256Gcm => Encryption::aes256_gcm(OTHER_TEST_KEY),
+            EncryptionAlgorithm::Aegis256 => EncryptionSpec::aegis256(OTHER_TEST_KEY),
+            EncryptionAlgorithm::Aes256Gcm => EncryptionSpec::aes256_gcm(OTHER_TEST_KEY),
         }
     }
 
@@ -472,27 +471,20 @@ mod tests {
     }
 
     fn make_encrypted_stored_record(
-        encryption: &Encryption,
+        encryption: &EncryptionSpec,
         headers: Vec<Header>,
         body: Bytes,
         aad: &[u8],
     ) -> StoredRecord {
         let metered_size = make_plaintext_envelope(headers.clone(), body.clone()).metered_size();
         let plaintext = make_envelope(headers, body);
-        let encrypted = match encryption {
-            Encryption::Plain => {
-                unreachable!("plain mode should not produce an encrypted record")
-            }
-            Encryption::Aegis256(key) => {
-                encrypt_payload(&plaintext, EncryptionAlgorithm::Aegis256, key.secret(), aad)
-            }
-            Encryption::Aes256Gcm(key) => encrypt_payload(
-                &plaintext,
-                EncryptionAlgorithm::Aes256Gcm,
-                key.secret(),
-                aad,
-            ),
-        };
+        let algorithm = encryption
+            .algorithm()
+            .expect("plain mode should not produce an encrypted record");
+        let key = encryption
+            .secret_key()
+            .expect("encrypted test record should carry a secret key");
+        let encrypted = encrypt_payload(&plaintext, algorithm, key, aad);
         StoredRecord::encrypted(encrypted, metered_size)
     }
 
@@ -748,7 +740,7 @@ mod tests {
             &aad,
         );
 
-        let result = decrypt_stored_record(record, &Encryption::Plain, &aad);
+        let result = decrypt_stored_record(record, &EncryptionSpec::plain(), &aad);
 
         assert!(matches!(
             result,

--- a/common/src/record/mod.rs
+++ b/common/src/record/mod.rs
@@ -241,10 +241,10 @@ impl StoredRecord {
         }
     }
 
-    pub fn encryption_mode(&self) -> crate::encryption::EncryptionMode {
+    pub fn encryption_algorithm(&self) -> Option<crate::encryption::EncryptionAlgorithm> {
         match self {
-            Self::Plaintext(_) => crate::encryption::EncryptionMode::Plain,
-            Self::Encrypted { record, .. } => record.algorithm().into(),
+            Self::Plaintext(_) => None,
+            Self::Encrypted { record, .. } => Some(record.algorithm()),
         }
     }
 }

--- a/common/src/types/config.rs
+++ b/common/src/types/config.rs
@@ -341,7 +341,7 @@ impl From<StreamConfig> for OptionalStreamConfig {
 #[derive(Debug, Clone, Default)]
 pub struct BasinConfig {
     pub default_stream_config: OptionalStreamConfig,
-    pub stream_encryption_algorithm: Option<EncryptionAlgorithm>,
+    pub stream_cipher: Option<EncryptionAlgorithm>,
     pub create_stream_on_append: bool,
     pub create_stream_on_read: bool,
 }
@@ -350,7 +350,7 @@ impl BasinConfig {
     pub fn reconfigure(mut self, reconfiguration: BasinReconfiguration) -> Self {
         let BasinReconfiguration {
             default_stream_config,
-            stream_encryption_algorithm,
+            stream_cipher,
             create_stream_on_append,
             create_stream_on_read,
         } = reconfiguration;
@@ -361,8 +361,8 @@ impl BasinConfig {
                 .unwrap_or_default();
         }
 
-        if let Maybe::Specified(stream_encryption_algorithm) = stream_encryption_algorithm {
-            self.stream_encryption_algorithm = stream_encryption_algorithm;
+        if let Maybe::Specified(stream_cipher) = stream_cipher {
+            self.stream_cipher = stream_cipher;
         }
 
         if let Maybe::Specified(create_stream_on_append) = create_stream_on_append {
@@ -381,14 +381,14 @@ impl From<BasinConfig> for BasinReconfiguration {
     fn from(value: BasinConfig) -> Self {
         let BasinConfig {
             default_stream_config,
-            stream_encryption_algorithm,
+            stream_cipher,
             create_stream_on_append,
             create_stream_on_read,
         } = value;
 
         Self {
             default_stream_config: Some(default_stream_config.into()).into(),
-            stream_encryption_algorithm: stream_encryption_algorithm.into(),
+            stream_cipher: stream_cipher.into(),
             create_stream_on_append: create_stream_on_append.into(),
             create_stream_on_read: create_stream_on_read.into(),
         }
@@ -398,7 +398,7 @@ impl From<BasinConfig> for BasinReconfiguration {
 #[derive(Debug, Clone, Default)]
 pub struct BasinReconfiguration {
     pub default_stream_config: Maybe<Option<StreamReconfiguration>>,
-    pub stream_encryption_algorithm: Maybe<Option<EncryptionAlgorithm>>,
+    pub stream_cipher: Maybe<Option<EncryptionAlgorithm>>,
     pub create_stream_on_append: Maybe<bool>,
     pub create_stream_on_read: Maybe<bool>,
 }

--- a/common/src/types/config.rs
+++ b/common/src/types/config.rs
@@ -1,20 +1,16 @@
 //! Stream and basin configuration types.
 //!
-//! Each config area (stream, timestamping, delete-on-empty, basin-level stream encryption) has
-//! three type tiers:
+//! Stream configuration uses three representations:
 //!
-//! - Resolved (`StreamConfig`, `TimestampingConfig`, `DeleteOnEmptyConfig`): All fields are
-//!   concrete values. Produced by merging optional configs with defaults using `merge()`.
+//! - Resolved (`StreamConfig`, `TimestampingConfig`, `DeleteOnEmptyConfig`): concrete values,
+//!   produced by merging optional configs with defaults using `merge()`.
 //!
 //! - Optional (`OptionalStreamConfig`, `OptionalTimestampingConfig`,
-//!   `OptionalDeleteOnEmptyConfig`): The internal representation, stored in metadata. Fields are
-//!   `Option<T>` where `None` means "not set at this layer, fall back to defaults."
+//!   `OptionalDeleteOnEmptyConfig`): stored metadata, where `None` means "not set at this layer;
+//!   fall back to defaults."
 //!
 //! - Reconfiguration (`StreamReconfiguration`, `TimestampingReconfiguration`,
-//!   `DeleteOnEmptyReconfiguration`, `BasinReconfiguration`): Partial updates with PATCH semantics.
-//!   Most fields are `Maybe<Option<T>>` with three states: `Unspecified` (don't change),
-//!   `Specified(None)` (clear to default), `Specified(Some(v))` (set to value). Applied using
-//!   `reconfigure()`.
+//!   `DeleteOnEmptyReconfiguration`): PATCH-style updates applied with `reconfigure()`.
 //!
 //! Reconfiguration of nested fields (e.g. `timestamping`, `delete_on_empty`,
 //! `default_stream_config`) is applied recursively: `Specified(Some(inner_reconfig))`
@@ -24,9 +20,8 @@
 //! `merge()` resolves optional configs into resolved configs with precedence:
 //! stream-level → basin-level → system default (via `Option::or` chaining).
 //!
-//! The `From<Optional*> for *Reconfiguration` conversions treat every field as
-//! `Specified`. These conversions represent "set the config to exactly this state",
-//! not "update only the fields that are set."
+//! Basin config also carries basin-level knobs like `stream_cipher`,
+//! `create_stream_on_append`, and `create_stream_on_read`.
 
 use std::time::Duration;
 

--- a/common/src/types/config.rs
+++ b/common/src/types/config.rs
@@ -1,6 +1,7 @@
 //! Stream and basin configuration types.
 //!
-//! Each config area (stream, timestamping, delete-on-empty) has three type tiers:
+//! Each config area (stream, timestamping, delete-on-empty, basin-level stream encryption) has
+//! three type tiers:
 //!
 //! - Resolved (`StreamConfig`, `TimestampingConfig`, `DeleteOnEmptyConfig`): All fields are
 //!   concrete values. Produced by merging optional configs with defaults using `merge()`.
@@ -10,10 +11,10 @@
 //!   `Option<T>` where `None` means "not set at this layer, fall back to defaults."
 //!
 //! - Reconfiguration (`StreamReconfiguration`, `TimestampingReconfiguration`,
-//!   `DeleteOnEmptyReconfiguration`): Partial updates with PATCH semantics. Most fields are
-//!   `Maybe<Option<T>>` with three states: `Unspecified` (don't change), `Specified(None)` (clear
-//!   to default), `Specified(Some(v))` (set to value). Collection-valued fields may instead use an
-//!   empty collection to mean "clear to default". Applied using `reconfigure()`.
+//!   `DeleteOnEmptyReconfiguration`, `BasinReconfiguration`): Partial updates with PATCH semantics.
+//!   Most fields are `Maybe<Option<T>>` with three states: `Unspecified` (don't change),
+//!   `Specified(None)` (clear to default), `Specified(Some(v))` (set to value). Applied using
+//!   `reconfigure()`.
 //!
 //! Reconfiguration of nested fields (e.g. `timestamping`, `delete_on_empty`,
 //! `default_stream_config`) is applied recursively: `Specified(Some(inner_reconfig))`
@@ -30,9 +31,8 @@
 use std::time::Duration;
 
 use enum_ordinalize::Ordinalize;
-use enumset::EnumSet;
 
-use crate::{encryption::EncryptionMode, maybe::Maybe};
+use crate::{encryption::EncryptionAlgorithm, maybe::Maybe};
 
 #[derive(
     Debug,
@@ -101,29 +101,12 @@ pub struct DeleteOnEmptyConfig {
     pub min_age: Duration,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EncryptionConfig {
-    pub allowed_modes: EnumSet<EncryptionMode>,
-}
-
-pub const DEFAULT_ALLOWED_ENCRYPTION_MODES: EnumSet<EncryptionMode> =
-    enumset::enum_set!(EncryptionMode::Plain);
-
-impl Default for EncryptionConfig {
-    fn default() -> Self {
-        Self {
-            allowed_modes: DEFAULT_ALLOWED_ENCRYPTION_MODES,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct StreamConfig {
     pub storage_class: StorageClass,
     pub retention_policy: RetentionPolicy,
     pub timestamping: TimestampingConfig,
     pub delete_on_empty: DeleteOnEmptyConfig,
-    pub encryption: EncryptionConfig,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -138,17 +121,11 @@ pub struct DeleteOnEmptyReconfiguration {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct EncryptionReconfiguration {
-    pub allowed_modes: Maybe<EnumSet<EncryptionMode>>,
-}
-
-#[derive(Debug, Clone, Default)]
 pub struct StreamReconfiguration {
     pub storage_class: Maybe<Option<StorageClass>>,
     pub retention_policy: Maybe<Option<RetentionPolicy>>,
     pub timestamping: Maybe<Option<TimestampingReconfiguration>>,
     pub delete_on_empty: Maybe<Option<DeleteOnEmptyReconfiguration>>,
-    pub encryption: Maybe<Option<EncryptionReconfiguration>>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -249,61 +226,11 @@ impl From<OptionalDeleteOnEmptyConfig> for DeleteOnEmptyReconfiguration {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct OptionalEncryptionConfig {
-    pub allowed_modes: EnumSet<EncryptionMode>,
-}
-
-impl OptionalEncryptionConfig {
-    pub fn reconfigure(mut self, reconfiguration: EncryptionReconfiguration) -> Self {
-        if let Maybe::Specified(allowed_modes) = reconfiguration.allowed_modes {
-            self.allowed_modes = allowed_modes;
-        }
-        self
-    }
-
-    pub fn merge(self, basin_defaults: Self) -> EncryptionConfig {
-        let allowed_modes = if !self.allowed_modes.is_empty() {
-            self.allowed_modes
-        } else if !basin_defaults.allowed_modes.is_empty() {
-            basin_defaults.allowed_modes
-        } else {
-            DEFAULT_ALLOWED_ENCRYPTION_MODES
-        };
-        EncryptionConfig { allowed_modes }
-    }
-}
-
-impl From<OptionalEncryptionConfig> for EncryptionConfig {
-    fn from(value: OptionalEncryptionConfig) -> Self {
-        Self {
-            allowed_modes: value.allowed_modes,
-        }
-    }
-}
-
-impl From<EncryptionConfig> for OptionalEncryptionConfig {
-    fn from(value: EncryptionConfig) -> Self {
-        Self {
-            allowed_modes: value.allowed_modes,
-        }
-    }
-}
-
-impl From<OptionalEncryptionConfig> for EncryptionReconfiguration {
-    fn from(value: OptionalEncryptionConfig) -> Self {
-        Self {
-            allowed_modes: Maybe::Specified(value.allowed_modes),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Default)]
 pub struct OptionalStreamConfig {
     pub storage_class: Option<StorageClass>,
     pub retention_policy: Option<RetentionPolicy>,
     pub timestamping: OptionalTimestampingConfig,
     pub delete_on_empty: OptionalDeleteOnEmptyConfig,
-    pub encryption: OptionalEncryptionConfig,
 }
 
 impl OptionalStreamConfig {
@@ -313,7 +240,6 @@ impl OptionalStreamConfig {
             retention_policy,
             timestamping,
             delete_on_empty,
-            encryption,
         } = reconfiguration;
         if let Maybe::Specified(storage_class) = storage_class {
             self.storage_class = storage_class;
@@ -329,11 +255,6 @@ impl OptionalStreamConfig {
         if let Maybe::Specified(delete_on_empty_reconfig) = delete_on_empty {
             self.delete_on_empty = delete_on_empty_reconfig
                 .map(|reconfig| self.delete_on_empty.reconfigure(reconfig))
-                .unwrap_or_default();
-        }
-        if let Maybe::Specified(encryption) = encryption {
-            self.encryption = encryption
-                .map(|enc| self.encryption.reconfigure(enc))
                 .unwrap_or_default();
         }
         self
@@ -354,14 +275,11 @@ impl OptionalStreamConfig {
 
         let delete_on_empty = self.delete_on_empty.merge(basin_defaults.delete_on_empty);
 
-        let encryption = self.encryption.merge(basin_defaults.encryption);
-
         StreamConfig {
             storage_class,
             retention_policy,
             timestamping,
             delete_on_empty,
-            encryption,
         }
     }
 }
@@ -373,7 +291,6 @@ impl From<OptionalStreamConfig> for StreamReconfiguration {
             retention_policy,
             timestamping,
             delete_on_empty,
-            encryption,
         } = value;
 
         Self {
@@ -381,7 +298,6 @@ impl From<OptionalStreamConfig> for StreamReconfiguration {
             retention_policy: retention_policy.into(),
             timestamping: Some(timestamping.into()).into(),
             delete_on_empty: Some(delete_on_empty.into()).into(),
-            encryption: Some(encryption.into()).into(),
         }
     }
 }
@@ -393,7 +309,6 @@ impl From<OptionalStreamConfig> for StreamConfig {
             retention_policy,
             timestamping,
             delete_on_empty,
-            encryption,
         } = value;
 
         Self {
@@ -401,7 +316,6 @@ impl From<OptionalStreamConfig> for StreamConfig {
             retention_policy: retention_policy.unwrap_or_default(),
             timestamping: timestamping.into(),
             delete_on_empty: delete_on_empty.into(),
-            encryption: encryption.into(),
         }
     }
 }
@@ -413,7 +327,6 @@ impl From<StreamConfig> for OptionalStreamConfig {
             retention_policy,
             timestamping,
             delete_on_empty,
-            encryption,
         } = value;
 
         Self {
@@ -421,7 +334,6 @@ impl From<StreamConfig> for OptionalStreamConfig {
             retention_policy: Some(retention_policy),
             timestamping: timestamping.into(),
             delete_on_empty: delete_on_empty.into(),
-            encryption: encryption.into(),
         }
     }
 }
@@ -429,6 +341,7 @@ impl From<StreamConfig> for OptionalStreamConfig {
 #[derive(Debug, Clone, Default)]
 pub struct BasinConfig {
     pub default_stream_config: OptionalStreamConfig,
+    pub stream_encryption_algorithm: Option<EncryptionAlgorithm>,
     pub create_stream_on_append: bool,
     pub create_stream_on_read: bool,
 }
@@ -437,6 +350,7 @@ impl BasinConfig {
     pub fn reconfigure(mut self, reconfiguration: BasinReconfiguration) -> Self {
         let BasinReconfiguration {
             default_stream_config,
+            stream_encryption_algorithm,
             create_stream_on_append,
             create_stream_on_read,
         } = reconfiguration;
@@ -445,6 +359,10 @@ impl BasinConfig {
             self.default_stream_config = default_stream_config
                 .map(|reconfig| self.default_stream_config.reconfigure(reconfig))
                 .unwrap_or_default();
+        }
+
+        if let Maybe::Specified(stream_encryption_algorithm) = stream_encryption_algorithm {
+            self.stream_encryption_algorithm = stream_encryption_algorithm;
         }
 
         if let Maybe::Specified(create_stream_on_append) = create_stream_on_append {
@@ -463,12 +381,14 @@ impl From<BasinConfig> for BasinReconfiguration {
     fn from(value: BasinConfig) -> Self {
         let BasinConfig {
             default_stream_config,
+            stream_encryption_algorithm,
             create_stream_on_append,
             create_stream_on_read,
         } = value;
 
         Self {
             default_stream_config: Some(default_stream_config.into()).into(),
+            stream_encryption_algorithm: stream_encryption_algorithm.into(),
             create_stream_on_append: create_stream_on_append.into(),
             create_stream_on_read: create_stream_on_read.into(),
         }
@@ -478,6 +398,7 @@ impl From<BasinConfig> for BasinReconfiguration {
 #[derive(Debug, Clone, Default)]
 pub struct BasinReconfiguration {
     pub default_stream_config: Maybe<Option<StreamReconfiguration>>,
+    pub stream_encryption_algorithm: Maybe<Option<EncryptionAlgorithm>>,
     pub create_stream_on_append: Maybe<bool>,
     pub create_stream_on_read: Maybe<bool>,
 }

--- a/common/src/types/stream.rs
+++ b/common/src/types/stream.rs
@@ -169,7 +169,7 @@ pub struct StreamInfo {
     pub name: StreamName,
     pub created_at: OffsetDateTime,
     pub deleted_at: Option<OffsetDateTime>,
-    pub encryption_algorithm: Option<EncryptionAlgorithm>,
+    pub cipher: Option<EncryptionAlgorithm>,
 }
 
 #[derive(Debug, Clone)]

--- a/common/src/types/stream.rs
+++ b/common/src/types/stream.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{
     caps,
-    encryption::EncryptionSpec,
+    encryption::{Encryption, EncryptionAlgorithm},
     read_extent::{ReadLimit, ReadUntil},
     record::{
         FencingToken, Metered, MeteredExt, MeteredSize, Record, RecordDecryptionError, SeqNum,
@@ -169,6 +169,7 @@ pub struct StreamInfo {
     pub name: StreamName,
     pub created_at: OffsetDateTime,
     pub deleted_at: Option<OffsetDateTime>,
+    pub encryption_algorithm: Option<EncryptionAlgorithm>,
 }
 
 #[derive(Debug, Clone)]
@@ -326,7 +327,7 @@ pub struct AppendInput<T = Record> {
 }
 
 impl AppendInput<Record> {
-    pub fn encrypt(self, encryption: &EncryptionSpec, aad: &[u8]) -> AppendInput<StoredRecord> {
+    pub fn encrypt(self, encryption: &Encryption, aad: &[u8]) -> AppendInput<StoredRecord> {
         let AppendInput {
             records,
             match_seq_num,
@@ -446,7 +447,7 @@ impl<T> std::fmt::Debug for ReadBatch<T> {
 impl ReadBatch<StoredRecord> {
     pub fn decrypt(
         self,
-        encryption: &EncryptionSpec,
+        encryption: &Encryption,
         aad: &[u8],
     ) -> Result<ReadBatch, RecordDecryptionError> {
         let records: Result<Metered<Vec<Sequenced<Record>>>, RecordDecryptionError> = self
@@ -478,7 +479,7 @@ pub enum ReadSessionOutput<T = Record> {
 impl ReadSessionOutput<StoredRecord> {
     pub fn decrypt(
         self,
-        encryption: &EncryptionSpec,
+        encryption: &Encryption,
         aad: &[u8],
     ) -> Result<ReadSessionOutput, RecordDecryptionError> {
         match self {
@@ -585,7 +586,7 @@ mod test {
     #[case::encrypt(true)]
     #[case::into(false)]
     fn append_input_to_stored_preserves_metadata(#[case] encrypt: bool) {
-        let encryption = EncryptionSpec::aegis256([0x42; 32]);
+        let encryption = Encryption::aegis256([0x42; 32]);
         let mapped = if encrypt {
             sample_append_input().encrypt(&encryption, TEST_AAD)
         } else {
@@ -612,7 +613,12 @@ mod test {
             encrypt
         );
 
-        let decrypted = decrypt_stored_record(stored_record, &encryption, TEST_AAD).unwrap();
+        let decryption = if encrypt {
+            &encryption
+        } else {
+            &Encryption::Plain
+        };
+        let decrypted = decrypt_stored_record(stored_record, decryption, TEST_AAD).unwrap();
         let Record::Envelope(record) = decrypted.into_inner() else {
             panic!("expected envelope record");
         };
@@ -649,7 +655,7 @@ mod test {
         };
 
         let mapped = batch
-            .decrypt(&crate::encryption::EncryptionSpec::Plain, &[])
+            .decrypt(&crate::encryption::Encryption::Plain, &[])
             .unwrap();
         let records = mapped.records.into_inner();
 

--- a/common/src/types/stream.rs
+++ b/common/src/types/stream.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{
     caps,
-    encryption::{Encryption, EncryptionAlgorithm},
+    encryption::{EncryptionAlgorithm, EncryptionSpec},
     read_extent::{ReadLimit, ReadUntil},
     record::{
         FencingToken, Metered, MeteredExt, MeteredSize, Record, RecordDecryptionError, SeqNum,
@@ -327,7 +327,7 @@ pub struct AppendInput<T = Record> {
 }
 
 impl AppendInput<Record> {
-    pub fn encrypt(self, encryption: &Encryption, aad: &[u8]) -> AppendInput<StoredRecord> {
+    pub fn encrypt(self, encryption: &EncryptionSpec, aad: &[u8]) -> AppendInput<StoredRecord> {
         let AppendInput {
             records,
             match_seq_num,
@@ -447,7 +447,7 @@ impl<T> std::fmt::Debug for ReadBatch<T> {
 impl ReadBatch<StoredRecord> {
     pub fn decrypt(
         self,
-        encryption: &Encryption,
+        encryption: &EncryptionSpec,
         aad: &[u8],
     ) -> Result<ReadBatch, RecordDecryptionError> {
         let records: Result<Metered<Vec<Sequenced<Record>>>, RecordDecryptionError> = self
@@ -479,7 +479,7 @@ pub enum ReadSessionOutput<T = Record> {
 impl ReadSessionOutput<StoredRecord> {
     pub fn decrypt(
         self,
-        encryption: &Encryption,
+        encryption: &EncryptionSpec,
         aad: &[u8],
     ) -> Result<ReadSessionOutput, RecordDecryptionError> {
         match self {
@@ -586,7 +586,7 @@ mod test {
     #[case::encrypt(true)]
     #[case::into(false)]
     fn append_input_to_stored_preserves_metadata(#[case] encrypt: bool) {
-        let encryption = Encryption::aegis256([0x42; 32]);
+        let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let mapped = if encrypt {
             sample_append_input().encrypt(&encryption, TEST_AAD)
         } else {
@@ -616,7 +616,7 @@ mod test {
         let decryption = if encrypt {
             &encryption
         } else {
-            &Encryption::Plain
+            &EncryptionSpec::plain()
         };
         let decrypted = decrypt_stored_record(stored_record, decryption, TEST_AAD).unwrap();
         let Record::Envelope(record) = decrypted.into_inner() else {
@@ -655,7 +655,7 @@ mod test {
         };
 
         let mapped = batch
-            .decrypt(&crate::encryption::Encryption::Plain, &[])
+            .decrypt(&crate::encryption::EncryptionSpec::plain(), &[])
             .unwrap();
         let records = mapped.records.into_inner();
 

--- a/common/src/types/stream.rs
+++ b/common/src/types/stream.rs
@@ -616,7 +616,7 @@ mod test {
         let decryption = if encrypt {
             &encryption
         } else {
-            &EncryptionSpec::plain()
+            &EncryptionSpec::Plaintext
         };
         let decrypted = decrypt_stored_record(stored_record, decryption, TEST_AAD).unwrap();
         let Record::Envelope(record) = decrypted.into_inner() else {
@@ -655,7 +655,7 @@ mod test {
         };
 
         let mapped = batch
-            .decrypt(&crate::encryption::EncryptionSpec::plain(), &[])
+            .decrypt(&crate::encryption::EncryptionSpec::Plaintext, &[])
             .unwrap();
         let records = mapped.records.into_inner();
 

--- a/common/src/types/stream.rs
+++ b/common/src/types/stream.rs
@@ -616,7 +616,7 @@ mod test {
         let decryption = if encrypt {
             &encryption
         } else {
-            &EncryptionSpec::Plaintext
+            &EncryptionSpec::Plain
         };
         let decrypted = decrypt_stored_record(stored_record, decryption, TEST_AAD).unwrap();
         let Record::Envelope(record) = decrypted.into_inner() else {
@@ -655,7 +655,7 @@ mod test {
         };
 
         let mapped = batch
-            .decrypt(&crate::encryption::EncryptionSpec::Plaintext, &[])
+            .decrypt(&crate::encryption::EncryptionSpec::Plain, &[])
             .unwrap();
         let records = mapped.records.into_inner();
 

--- a/docs/adr/csek.md
+++ b/docs/adr/csek.md
@@ -2,13 +2,13 @@
 
 Encryption algorithms supported: `aegis-256`, `aes-256-gcm`.
 
-At the basin level, users configure the encryption algorithm (or none, the default) to be used for streams created in that basin.
+At the basin level, users configure the encryption algorithm (or none, the default) to apply to newly created streams in that basin.
 
-New streams materialize this algorithm into their metadata when created. It is immutable for the lifetime of a stream and cannot be reconfigured.
+New streams record this algorithm in their metadata when created. It is immutable for the lifetime of a stream and cannot be reconfigured.
 
 Data plane `append` and `read` operations look for the `s2-encryption-key` header, where it must be provided as a base64 string if encryption is enabled.
 
-Data plane operations treat the `s2-encryption-key` header as opaque base64-encoded key material. If we need wrapped or structured key material in future, that may be introduced as an format discriminator.
+Data plane operations treat the `s2-encryption-key` header as opaque base64-encoded key material. If we need wrapped or structured key material in future, that may be introduced as a format discriminator.
 
 The encryption key should stay consistent for a given stream, but this is not enforced by the service.
 - If no key is provided when required, the `append` or `read` operation will fail.

--- a/docs/adr/csek.md
+++ b/docs/adr/csek.md
@@ -1,12 +1,14 @@
 # Customer-supplied Encryption Key
 
-Encryption algorithms supported: `aegis-256`, `aes-256-gcm`. Both require a 32-byte symmetric key.
+Encryption algorithms supported: `aegis-256`, `aes-256-gcm`.
 
 At the basin level, users configure the encryption algorithm (or none, the default) to be used for streams created in that basin.
 
 New streams materialize this algorithm into their metadata when created. It is immutable for the lifetime of a stream and cannot be reconfigured.
 
 Data plane `append` and `read` operations look for the `s2-encryption-key` header, where it must be provided as a base64 string if encryption is enabled.
+
+Data plane operations treat the `s2-encryption-key` header as opaque base64-encoded key material. If we need wrapped or structured key material in future, that may be introduced as an format discriminator.
 
 The encryption key should stay consistent for a given stream, but this is not enforced by the service.
 - If no key is provided when required, the `append` or `read` operation will fail.

--- a/docs/adr/csek.md
+++ b/docs/adr/csek.md
@@ -1,0 +1,16 @@
+# Customer-supplied Encryption Key
+
+Encryption algorithms supported: `aegis-256`, `aes-256-gcm`. Both require a 32-byte symmetric key.
+
+At the basin level, users configure the encryption algorithm (or none, the default) to be used for streams created in that basin.
+
+New streams materialize this algorithm into their metadata when created. It is immutable for the lifetime of a stream and cannot be reconfigured.
+
+Data plane `append` and `read` operations look for the `s2-encryption-key` header, where it must be provided as a base64 string if encryption is enabled.
+
+The encryption key should stay consistent for a given stream, but this is not enforced by the service.
+- If no key is provided when required, the `append` or `read` operation will fail.
+- The same key used to encrypt when appending must be used when reading records.
+- Appends will succeed even if a different key is provided than previously used.
+
+Encryption algorithm is one of the pieces of stream-level metadata returned when listing streams.

--- a/lite/src/backend/append.rs
+++ b/lite/src/backend/append.rs
@@ -6,6 +6,7 @@ use std::{
 
 use futures::{Stream, StreamExt as _, future::OptionFuture, stream::FuturesOrdered};
 use s2_common::{
+    encryption::{EncryptionKey, EncryptionSpec},
     record::{SeqNum, StreamPosition},
     types::{
         basin::BasinName,
@@ -14,10 +15,46 @@ use s2_common::{
 };
 use tokio::sync::oneshot;
 
-use super::{Backend, StreamHandle};
-use crate::backend::error::{AppendError, AppendErrorInternal, StorageError};
+use super::{Backend, StreamHandle, core::StreamLookup};
+use crate::backend::error::{AppendError, AppendErrorInternal, ResolveAppendError, StorageError};
 
 impl Backend {
+    async fn resolve_append_handle(
+        &self,
+        basin: &BasinName,
+        stream: &StreamName,
+    ) -> Result<StreamHandle, AppendError> {
+        match self.lookup_stream::<AppendError>(basin, stream).await? {
+            StreamLookup::Found(handle) => Ok(handle),
+            StreamLookup::Missing {
+                basin_config,
+                not_found,
+            } => {
+                if !basin_config.create_stream_on_append {
+                    return Err(not_found.into());
+                }
+                self.create_stream_if_missing::<AppendError>(basin, stream)
+                    .await?;
+                let client = self.streamer_client(basin, stream).await?;
+                Ok(StreamHandle {
+                    backend: self.clone(),
+                    client,
+                })
+            }
+        }
+    }
+
+    pub(crate) async fn resolve_append_target(
+        &self,
+        basin: &BasinName,
+        stream: &StreamName,
+        encryption_key: Option<EncryptionKey>,
+    ) -> Result<(StreamHandle, EncryptionSpec), ResolveAppendError> {
+        let handle = self.resolve_append_handle(basin, stream).await?;
+        let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
+        Ok((handle, encryption))
+    }
+
     pub async fn append<I>(
         &self,
         basin: BasinName,
@@ -27,11 +64,7 @@ impl Backend {
     where
         I: Into<StoredAppendInput>,
     {
-        let handle = self
-            .stream_handle_with_auto_create::<AppendError>(&basin, &stream, |config| {
-                config.create_stream_on_append
-            })
-            .await?;
+        let handle = self.resolve_append_handle(&basin, &stream).await?;
         handle.append(input).await
     }
 
@@ -45,11 +78,7 @@ impl Backend {
         I: Into<StoredAppendInput>,
         S: Stream<Item = I>,
     {
-        let handle = self
-            .stream_handle_with_auto_create::<AppendError>(&basin, &stream, |config| {
-                config.create_stream_on_append
-            })
-            .await?;
+        let handle = self.resolve_append_handle(&basin, &stream).await?;
         Ok(handle.append_session(inputs))
     }
 }

--- a/lite/src/backend/append.rs
+++ b/lite/src/backend/append.rs
@@ -6,7 +6,6 @@ use std::{
 
 use futures::{Stream, StreamExt as _, future::OptionFuture, stream::FuturesOrdered};
 use s2_common::{
-    encryption::{EncryptionKey, EncryptionSpec},
     record::{SeqNum, StreamPosition},
     types::{
         basin::BasinName,
@@ -16,10 +15,10 @@ use s2_common::{
 use tokio::sync::oneshot;
 
 use super::{Backend, StreamHandle, core::StreamLookup};
-use crate::backend::error::{AppendError, AppendErrorInternal, ResolveAppendError, StorageError};
+use crate::backend::error::{AppendError, AppendErrorInternal, StorageError};
 
 impl Backend {
-    async fn resolve_append_handle(
+    pub(crate) async fn resolve_append_handle(
         &self,
         basin: &BasinName,
         stream: &StreamName,
@@ -42,17 +41,6 @@ impl Backend {
                 })
             }
         }
-    }
-
-    pub(crate) async fn resolve_append_target(
-        &self,
-        basin: &BasinName,
-        stream: &StreamName,
-        encryption_key: Option<EncryptionKey>,
-    ) -> Result<(StreamHandle, EncryptionSpec), ResolveAppendError> {
-        let handle = self.resolve_append_handle(basin, stream).await?;
-        let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
-        Ok((handle, encryption))
     }
 
     pub async fn append<I>(

--- a/lite/src/backend/append.rs
+++ b/lite/src/backend/append.rs
@@ -37,8 +37,7 @@ impl Backend {
 
 impl StreamHandle {
     pub async fn append(self, input: AppendInput) -> Result<AppendAck, AppendError> {
-        let stream_id = self.stream_id();
-        let input = input.encrypt(&self.encryption, stream_id.as_bytes());
+        let input = input.encrypt(&self.encryption, self.client.stream_id().as_bytes());
         let ack = self.client.append_permit(input).await?.submit().await?;
         Ok(ack)
     }
@@ -47,7 +46,7 @@ impl StreamHandle {
     where
         S: Stream<Item = AppendInput>,
     {
-        let stream_id = self.stream_id();
+        let stream_id = self.client.stream_id();
         let StreamHandle {
             client, encryption, ..
         } = self;

--- a/lite/src/backend/append.rs
+++ b/lite/src/backend/append.rs
@@ -14,7 +14,7 @@ use s2_common::{
 };
 use tokio::sync::oneshot;
 
-use super::Backend;
+use super::{Backend, StreamHandle};
 use crate::backend::error::{AppendError, AppendErrorInternal, StorageError};
 
 impl Backend {
@@ -27,13 +27,12 @@ impl Backend {
     where
         I: Into<StoredAppendInput>,
     {
-        let client = self
-            .streamer_client_with_auto_create::<AppendError>(&basin, &stream, |config| {
+        let handle = self
+            .stream_handle_with_auto_create::<AppendError>(&basin, &stream, |config| {
                 config.create_stream_on_append
             })
             .await?;
-        let ack = client.append_permit(input.into()).await?.submit().await?;
-        Ok(ack)
+        handle.append(input).await
     }
 
     pub async fn append_session<I, S>(
@@ -46,13 +45,40 @@ impl Backend {
         I: Into<StoredAppendInput>,
         S: Stream<Item = I>,
     {
-        let client = self
-            .streamer_client_with_auto_create::<AppendError>(&basin, &stream, |config| {
+        let handle = self
+            .stream_handle_with_auto_create::<AppendError>(&basin, &stream, |config| {
                 config.create_stream_on_append
             })
             .await?;
+        Ok(handle.append_session(inputs))
+    }
+}
+
+impl StreamHandle {
+    pub(crate) async fn append<I>(self, input: I) -> Result<AppendAck, AppendError>
+    where
+        I: Into<StoredAppendInput>,
+    {
+        let ack = self
+            .client
+            .append_permit(input.into())
+            .await?
+            .submit()
+            .await?;
+        Ok(ack)
+    }
+
+    pub(crate) fn append_session<I, S>(
+        self,
+        inputs: S,
+    ) -> impl Stream<Item = Result<AppendAck, AppendError>>
+    where
+        I: Into<StoredAppendInput>,
+        S: Stream<Item = I>,
+    {
+        let client = self.client;
         let session = SessionHandle::new();
-        Ok(async_stream::stream! {
+        async_stream::stream! {
             tokio::pin!(inputs);
             let mut permit_opt = None;
             let mut append_futs = FuturesOrdered::new();
@@ -87,7 +113,7 @@ impl Backend {
                     }
                 }
             }
-        })
+        }
     }
 }
 

--- a/lite/src/backend/append.rs
+++ b/lite/src/backend/append.rs
@@ -14,33 +14,19 @@ use s2_common::{
 };
 use tokio::sync::oneshot;
 
-use super::{Backend, StreamHandle, core::StreamLookup};
+use super::{Backend, StreamHandle};
 use crate::backend::error::{AppendError, AppendErrorInternal, StorageError};
 
 impl Backend {
-    pub(crate) async fn resolve_append_handle(
+    pub async fn resolve_append_handle(
         &self,
         basin: &BasinName,
         stream: &StreamName,
     ) -> Result<StreamHandle, AppendError> {
-        match self.lookup_stream::<AppendError>(basin, stream).await? {
-            StreamLookup::Found(handle) => Ok(handle),
-            StreamLookup::Missing {
-                basin_config,
-                not_found,
-            } => {
-                if !basin_config.create_stream_on_append {
-                    return Err(not_found.into());
-                }
-                self.create_stream_if_missing::<AppendError>(basin, stream)
-                    .await?;
-                let client = self.streamer_client(basin, stream).await?;
-                Ok(StreamHandle {
-                    backend: self.clone(),
-                    client,
-                })
-            }
-        }
+        self.stream_handle_with_auto_create::<AppendError>(basin, stream, |config| {
+            config.create_stream_on_append
+        })
+        .await
     }
 
     pub async fn append<I>(
@@ -72,7 +58,7 @@ impl Backend {
 }
 
 impl StreamHandle {
-    pub(crate) async fn append<I>(self, input: I) -> Result<AppendAck, AppendError>
+    pub async fn append<I>(self, input: I) -> Result<AppendAck, AppendError>
     where
         I: Into<StoredAppendInput>,
     {
@@ -85,7 +71,7 @@ impl StreamHandle {
         Ok(ack)
     }
 
-    pub(crate) fn append_session<I, S>(
+    pub fn append_session<I, S>(
         self,
         inputs: S,
     ) -> impl Stream<Item = Result<AppendAck, AppendError>>

--- a/lite/src/backend/append.rs
+++ b/lite/src/backend/append.rs
@@ -6,10 +6,11 @@ use std::{
 
 use futures::{Stream, StreamExt as _, future::OptionFuture, stream::FuturesOrdered};
 use s2_common::{
+    encryption::{EncryptionKey, EncryptionSpec},
     record::{SeqNum, StreamPosition},
     types::{
         basin::BasinName,
-        stream::{AppendAck, StoredAppendInput, StreamName},
+        stream::{AppendAck, AppendInput, StreamName},
     },
 };
 use tokio::sync::oneshot;
@@ -22,64 +23,34 @@ impl Backend {
         &self,
         basin: &BasinName,
         stream: &StreamName,
+        encryption_key: Option<EncryptionKey>,
     ) -> Result<StreamHandle, AppendError> {
-        self.stream_handle_with_auto_create::<AppendError>(basin, stream, |config| {
-            config.create_stream_on_append
-        })
+        self.stream_handle_with_auto_create::<AppendError>(
+            basin,
+            stream,
+            |config| config.create_stream_on_append,
+            |cipher| Ok(EncryptionSpec::resolve(cipher, encryption_key)?),
+        )
         .await
-    }
-
-    pub async fn append<I>(
-        &self,
-        basin: BasinName,
-        stream: StreamName,
-        input: I,
-    ) -> Result<AppendAck, AppendError>
-    where
-        I: Into<StoredAppendInput>,
-    {
-        let handle = self.open_for_append(&basin, &stream).await?;
-        handle.append(input).await
-    }
-
-    pub async fn append_session<I, S>(
-        self,
-        basin: BasinName,
-        stream: StreamName,
-        inputs: S,
-    ) -> Result<impl Stream<Item = Result<AppendAck, AppendError>>, AppendError>
-    where
-        I: Into<StoredAppendInput>,
-        S: Stream<Item = I>,
-    {
-        let handle = self.open_for_append(&basin, &stream).await?;
-        Ok(handle.append_session(inputs))
     }
 }
 
 impl StreamHandle {
-    pub async fn append<I>(self, input: I) -> Result<AppendAck, AppendError>
-    where
-        I: Into<StoredAppendInput>,
-    {
-        let ack = self
-            .client
-            .append_permit(input.into())
-            .await?
-            .submit()
-            .await?;
+    pub async fn append(self, input: AppendInput) -> Result<AppendAck, AppendError> {
+        let stream_id = self.stream_id();
+        let input = input.encrypt(&self.encryption, stream_id.as_bytes());
+        let ack = self.client.append_permit(input).await?.submit().await?;
         Ok(ack)
     }
 
-    pub fn append_session<I, S>(
-        self,
-        inputs: S,
-    ) -> impl Stream<Item = Result<AppendAck, AppendError>>
+    pub fn append_session<S>(self, inputs: S) -> impl Stream<Item = Result<AppendAck, AppendError>>
     where
-        I: Into<StoredAppendInput>,
-        S: Stream<Item = I>,
+        S: Stream<Item = AppendInput>,
     {
-        let client = self.client;
+        let stream_id = self.stream_id();
+        let StreamHandle {
+            client, encryption, ..
+        } = self;
         let session = SessionHandle::new();
         async_stream::stream! {
             tokio::pin!(inputs);
@@ -88,7 +59,9 @@ impl StreamHandle {
             loop {
                 tokio::select! {
                     Some(input) = inputs.next(), if permit_opt.is_none() => {
-                        permit_opt = Some(Box::pin(client.append_permit(input.into())));
+                        permit_opt = Some(Box::pin(client.append_permit(
+                            input.encrypt(&encryption, stream_id.as_bytes()),
+                        )));
                     }
                     Some(res) = OptionFuture::from(permit_opt.as_mut()) => {
                         permit_opt = None;

--- a/lite/src/backend/append.rs
+++ b/lite/src/backend/append.rs
@@ -18,7 +18,7 @@ use super::{Backend, StreamHandle};
 use crate::backend::error::{AppendError, AppendErrorInternal, StorageError};
 
 impl Backend {
-    pub async fn resolve_append_handle(
+    pub async fn open_for_append(
         &self,
         basin: &BasinName,
         stream: &StreamName,
@@ -38,7 +38,7 @@ impl Backend {
     where
         I: Into<StoredAppendInput>,
     {
-        let handle = self.resolve_append_handle(&basin, &stream).await?;
+        let handle = self.open_for_append(&basin, &stream).await?;
         handle.append(input).await
     }
 
@@ -52,7 +52,7 @@ impl Backend {
         I: Into<StoredAppendInput>,
         S: Stream<Item = I>,
     {
-        let handle = self.resolve_append_handle(&basin, &stream).await?;
+        let handle = self.open_for_append(&basin, &stream).await?;
         Ok(handle.append_session(inputs))
     }
 }

--- a/lite/src/backend/bgtasks/basin_deletion.rs
+++ b/lite/src/backend/bgtasks/basin_deletion.rs
@@ -165,6 +165,7 @@ mod tests {
     fn stream_meta(deleted_at: Option<OffsetDateTime>) -> kv::stream_meta::StreamMeta {
         kv::stream_meta::StreamMeta {
             config: Default::default(),
+            encryption_algorithm: None,
             created_at: OffsetDateTime::now_utc(),
             deleted_at,
             creation_idempotency_key: None,

--- a/lite/src/backend/bgtasks/basin_deletion.rs
+++ b/lite/src/backend/bgtasks/basin_deletion.rs
@@ -165,7 +165,7 @@ mod tests {
     fn stream_meta(deleted_at: Option<OffsetDateTime>) -> kv::stream_meta::StreamMeta {
         kv::stream_meta::StreamMeta {
             config: Default::default(),
-            encryption_algorithm: None,
+            cipher: None,
             created_at: OffsetDateTime::now_utc(),
             deleted_at,
             creation_idempotency_key: None,

--- a/lite/src/backend/bgtasks/stream_doe.rs
+++ b/lite/src/backend/bgtasks/stream_doe.rs
@@ -253,7 +253,7 @@ mod tests {
     ) -> kv::stream_meta::StreamMeta {
         kv::stream_meta::StreamMeta {
             config,
-            encryption_algorithm: None,
+            cipher: None,
             created_at,
             deleted_at: None,
             creation_idempotency_key: None,

--- a/lite/src/backend/bgtasks/stream_doe.rs
+++ b/lite/src/backend/bgtasks/stream_doe.rs
@@ -253,6 +253,7 @@ mod tests {
     ) -> kv::stream_meta::StreamMeta {
         kv::stream_meta::StreamMeta {
             config,
+            encryption_algorithm: None,
             created_at,
             deleted_at: None,
             creation_idempotency_key: None,

--- a/lite/src/backend/bgtasks/stream_trim.rs
+++ b/lite/src/backend/bgtasks/stream_trim.rs
@@ -289,7 +289,7 @@ mod tests {
 
         let meta = kv::stream_meta::StreamMeta {
             config: OptionalStreamConfig::default(),
-            encryption_algorithm: None,
+            cipher: None,
             created_at: OffsetDateTime::now_utc(),
             deleted_at: None,
             creation_idempotency_key: None,

--- a/lite/src/backend/bgtasks/stream_trim.rs
+++ b/lite/src/backend/bgtasks/stream_trim.rs
@@ -289,6 +289,7 @@ mod tests {
 
         let meta = kv::stream_meta::StreamMeta {
             config: OptionalStreamConfig::default(),
+            encryption_algorithm: None,
             created_at: OffsetDateTime::now_utc(),
             deleted_at: None,
             creation_idempotency_key: None,

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -297,44 +297,41 @@ impl Backend {
                 backend: self.clone(),
                 client,
             }),
-            Err(StreamerError::StreamNotFound(not_found)) => {
-                let basin_config = match self.get_basin_config(basin.clone()).await {
-                    Ok(basin_config) => basin_config,
-                    Err(GetBasinConfigError::Storage(e)) => return Err(e.into()),
-                    Err(GetBasinConfigError::BasinNotFound(e)) => return Err(e.into()),
+            Err(StreamerError::StreamNotFound(e)) => {
+                let config = match self.get_basin_config(basin.clone()).await {
+                    Ok(config) => config,
+                    Err(GetBasinConfigError::Storage(e)) => Err(e)?,
+                    Err(GetBasinConfigError::BasinNotFound(e)) => Err(e)?,
                 };
-                if !should_auto_create(&basin_config) {
-                    return Err(not_found.into());
+                if should_auto_create(&config) {
+                    if let Err(e) = self
+                        .create_stream(
+                            basin.clone(),
+                            stream.clone(),
+                            OptionalStreamConfig::default(),
+                            CreateMode::CreateOnly(None),
+                        )
+                        .await
+                    {
+                        match e {
+                            CreateStreamError::Storage(e) => Err(e)?,
+                            CreateStreamError::TransactionConflict(e) => Err(e)?,
+                            CreateStreamError::BasinDeletionPending(e) => Err(e)?,
+                            CreateStreamError::StreamDeletionPending(e) => Err(e)?,
+                            CreateStreamError::BasinNotFound(e) => Err(e)?,
+                            CreateStreamError::StreamAlreadyExists(_) => {}
+                            CreateStreamError::Validation(_) => {
+                                unreachable!("auto-create uses default config")
+                            }
+                        }
+                    }
+                    Ok(StreamHandle {
+                        backend: self.clone(),
+                        client: self.streamer_client(basin, stream).await?,
+                    })
+                } else {
+                    Err(e.into())
                 }
-                match self
-                    .create_stream(
-                        basin.clone(),
-                        stream.clone(),
-                        OptionalStreamConfig::default(),
-                        CreateMode::CreateOnly(None),
-                    )
-                    .await
-                {
-                    Ok(_) | Err(CreateStreamError::StreamAlreadyExists(_)) => {}
-                    Err(CreateStreamError::Storage(err)) => return Err(err.into()),
-                    Err(CreateStreamError::TransactionConflict(err)) => {
-                        return Err(err.into());
-                    }
-                    Err(CreateStreamError::BasinDeletionPending(err)) => {
-                        return Err(err.into());
-                    }
-                    Err(CreateStreamError::StreamDeletionPending(err)) => {
-                        return Err(err.into());
-                    }
-                    Err(CreateStreamError::BasinNotFound(err)) => return Err(err.into()),
-                    Err(CreateStreamError::Validation(_)) => {
-                        unreachable!("auto-create uses default config")
-                    }
-                }
-                Ok(StreamHandle {
-                    backend: self.clone(),
-                    client: self.streamer_client(basin, stream).await?,
-                })
             }
             Err(e) => Err(e.into()),
         }

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -142,7 +142,7 @@ impl Backend {
             db: self.db.clone(),
             stream_id,
             config: meta.config,
-            encryption_algorithm: meta.encryption_algorithm,
+            cipher: meta.cipher,
             tail_pos,
             fencing_token,
             trim_point: ..trim_point.map_or(SeqNum::MIN, |tp| tp.end.get()),
@@ -331,7 +331,7 @@ impl Backend {
         }
     }
 
-    pub(crate) async fn stream_encryption_algorithm_with_auto_create<E>(
+    pub(crate) async fn stream_cipher_with_auto_create<E>(
         &self,
         basin: &BasinName,
         stream: &StreamName,
@@ -349,7 +349,7 @@ impl Backend {
         let client = self
             .streamer_client_with_auto_create::<E>(basin, stream, should_auto_create)
             .await?;
-        Ok(client.encryption_algorithm())
+        Ok(client.cipher())
     }
 }
 
@@ -388,7 +388,7 @@ mod tests {
 
         let meta = kv::stream_meta::StreamMeta {
             config: OptionalStreamConfig::default(),
-            encryption_algorithm: None,
+            cipher: None,
             created_at: OffsetDateTime::now_utc(),
             deleted_at: None,
             creation_idempotency_key: None,

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -70,6 +70,14 @@ pub struct Backend {
     bgtask_trigger_tx: broadcast::Sender<BgtaskTrigger>,
 }
 
+pub(super) enum StreamLookup {
+    Found(StreamHandle),
+    Missing {
+        basin_config: BasinConfig,
+        not_found: StreamNotFoundError,
+    },
+}
+
 impl Backend {
     pub fn new(db: slatedb::Db, append_inflight_bytes: ByteSize) -> Self {
         let (bgtask_trigger_tx, _) = broadcast::channel(16);
@@ -86,6 +94,13 @@ impl Backend {
             append_inflight_bytes_sema: append_inflight_bytes,
             durability_notifier,
             bgtask_trigger_tx,
+        }
+    }
+
+    fn new_stream_handle(&self, client: StreamerClient) -> StreamHandle {
+        StreamHandle {
+            backend: self.clone(),
+            client,
         }
     }
 
@@ -277,81 +292,61 @@ impl Backend {
         }
     }
 
-    pub(super) async fn streamer_client_with_auto_create<E>(
+    pub(super) async fn lookup_stream<E>(
         &self,
         basin: &BasinName,
         stream: &StreamName,
-        should_auto_create: impl FnOnce(&BasinConfig) -> bool,
-    ) -> Result<StreamerClient, E>
+    ) -> Result<StreamLookup, E>
     where
-        E: From<StreamerError>
-            + From<StorageError>
-            + From<BasinNotFoundError>
-            + From<TransactionConflictError>
-            + From<BasinDeletionPendingError>
-            + From<StreamDeletionPendingError>
-            + From<StreamNotFoundError>,
+        E: From<StreamerError> + From<StorageError> + From<BasinNotFoundError>,
     {
         match self.streamer_client(basin, stream).await {
-            Ok(client) => Ok(client),
-            Err(StreamerError::StreamNotFound(e)) => {
-                let config = match self.get_basin_config(basin.clone()).await {
-                    Ok(config) => config,
-                    Err(GetBasinConfigError::Storage(e)) => Err(e)?,
-                    Err(GetBasinConfigError::BasinNotFound(e)) => Err(e)?,
-                };
-                if should_auto_create(&config) {
-                    if let Err(e) = self
-                        .create_stream(
-                            basin.clone(),
-                            stream.clone(),
-                            OptionalStreamConfig::default(),
-                            CreateMode::CreateOnly(None),
-                        )
-                        .await
-                    {
-                        match e {
-                            CreateStreamError::Storage(e) => Err(e)?,
-                            CreateStreamError::TransactionConflict(e) => Err(e)?,
-                            CreateStreamError::BasinDeletionPending(e) => Err(e)?,
-                            CreateStreamError::StreamDeletionPending(e) => Err(e)?,
-                            CreateStreamError::BasinNotFound(e) => Err(e)?,
-                            CreateStreamError::StreamAlreadyExists(_) => {}
-                            CreateStreamError::Validation(_) => {
-                                unreachable!("auto-create uses default config")
-                            }
-                        }
-                    }
-                    Ok(self.streamer_client(basin, stream).await?)
-                } else {
-                    Err(e.into())
+            Ok(client) => Ok(StreamLookup::Found(self.new_stream_handle(client))),
+            Err(StreamerError::StreamNotFound(not_found)) => {
+                match self.get_basin_config(basin.clone()).await {
+                    Ok(basin_config) => Ok(StreamLookup::Missing {
+                        basin_config,
+                        not_found,
+                    }),
+                    Err(GetBasinConfigError::Storage(e)) => Err(e.into()),
+                    Err(GetBasinConfigError::BasinNotFound(e)) => Err(e.into()),
                 }
             }
             Err(e) => Err(e.into()),
         }
     }
 
-    pub(crate) async fn stream_handle_with_auto_create<E>(
+    pub(super) async fn create_stream_if_missing<E>(
         &self,
         basin: &BasinName,
         stream: &StreamName,
-        should_auto_create: impl FnOnce(&BasinConfig) -> bool,
-    ) -> Result<StreamHandle, E>
+    ) -> Result<(), E>
     where
-        E: From<StreamerError>
-            + From<StorageError>
-            + From<BasinNotFoundError>
+        E: From<StorageError>
             + From<TransactionConflictError>
             + From<BasinDeletionPendingError>
             + From<StreamDeletionPendingError>
-            + From<StreamNotFoundError>,
+            + From<BasinNotFoundError>,
     {
-        self.streamer_client_with_auto_create::<E>(basin, stream, should_auto_create)
+        match self
+            .create_stream(
+                basin.clone(),
+                stream.clone(),
+                OptionalStreamConfig::default(),
+                CreateMode::CreateOnly(None),
+            )
             .await
-            .map(|client| StreamHandle {
-                backend: self.clone(),
-                client,
-            })
+        {
+            Ok(_) | Err(CreateStreamError::StreamAlreadyExists(_)) => Ok(()),
+            Err(CreateStreamError::Storage(err)) => Err(err.into()),
+            Err(CreateStreamError::TransactionConflict(err)) => Err(err.into()),
+            Err(CreateStreamError::BasinDeletionPending(err)) => Err(err.into()),
+            Err(CreateStreamError::StreamDeletionPending(err)) => Err(err.into()),
+            Err(CreateStreamError::BasinNotFound(err)) => Err(err.into()),
+            Err(CreateStreamError::Validation(_)) => {
+                unreachable!("auto-create uses default config")
+            }
+        }
     }
 }
 
@@ -362,7 +357,10 @@ mod tests {
     use bytes::Bytes;
     use s2_common::{
         record::{Metered, Record, StoredRecord, StreamPosition},
-        types::{config::BasinConfig, resources::CreateMode},
+        types::{
+            config::{BasinConfig, OptionalStreamConfig},
+            resources::CreateMode,
+        },
     };
     use slatedb::{WriteBatch, config::WriteOptions, object_store};
     use time::OffsetDateTime;

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -284,39 +284,6 @@ impl Backend {
         }
     }
 
-    pub(super) async fn create_stream_if_missing<E>(
-        &self,
-        basin: &BasinName,
-        stream: &StreamName,
-    ) -> Result<(), E>
-    where
-        E: From<StorageError>
-            + From<TransactionConflictError>
-            + From<BasinDeletionPendingError>
-            + From<StreamDeletionPendingError>
-            + From<BasinNotFoundError>,
-    {
-        match self
-            .create_stream(
-                basin.clone(),
-                stream.clone(),
-                OptionalStreamConfig::default(),
-                CreateMode::CreateOnly(None),
-            )
-            .await
-        {
-            Ok(_) | Err(CreateStreamError::StreamAlreadyExists(_)) => Ok(()),
-            Err(CreateStreamError::Storage(err)) => Err(err.into()),
-            Err(CreateStreamError::TransactionConflict(err)) => Err(err.into()),
-            Err(CreateStreamError::BasinDeletionPending(err)) => Err(err.into()),
-            Err(CreateStreamError::StreamDeletionPending(err)) => Err(err.into()),
-            Err(CreateStreamError::BasinNotFound(err)) => Err(err.into()),
-            Err(CreateStreamError::Validation(_)) => {
-                unreachable!("auto-create uses default config")
-            }
-        }
-    }
-
     pub(super) async fn stream_handle_with_auto_create<E>(
         &self,
         basin: &BasinName,
@@ -343,7 +310,31 @@ impl Backend {
                 if !should_auto_create(&basin_config) {
                     return Err(not_found.into());
                 }
-                self.create_stream_if_missing::<E>(basin, stream).await?;
+                match self
+                    .create_stream(
+                        basin.clone(),
+                        stream.clone(),
+                        OptionalStreamConfig::default(),
+                        CreateMode::CreateOnly(None),
+                    )
+                    .await
+                {
+                    Ok(_) | Err(CreateStreamError::StreamAlreadyExists(_)) => {}
+                    Err(CreateStreamError::Storage(err)) => return Err(err.into()),
+                    Err(CreateStreamError::TransactionConflict(err)) => {
+                        return Err(err.into());
+                    }
+                    Err(CreateStreamError::BasinDeletionPending(err)) => {
+                        return Err(err.into());
+                    }
+                    Err(CreateStreamError::StreamDeletionPending(err)) => {
+                        return Err(err.into());
+                    }
+                    Err(CreateStreamError::BasinNotFound(err)) => return Err(err.into()),
+                    Err(CreateStreamError::Validation(_)) => {
+                        unreachable!("auto-create uses default config")
+                    }
+                }
                 Ok(self.new_stream_handle(self.streamer_client(basin, stream).await?))
             }
             Err(e) => Err(e.into()),

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -89,13 +89,6 @@ impl Backend {
         }
     }
 
-    fn new_stream_handle(&self, client: StreamerClient) -> StreamHandle {
-        StreamHandle {
-            backend: self.clone(),
-            client,
-        }
-    }
-
     pub(super) fn bgtask_trigger(&self, trigger: BgtaskTrigger) {
         let _ = self.bgtask_trigger_tx.send(trigger);
     }
@@ -300,7 +293,10 @@ impl Backend {
             + From<StreamNotFoundError>,
     {
         match self.streamer_client(basin, stream).await {
-            Ok(client) => Ok(self.new_stream_handle(client)),
+            Ok(client) => Ok(StreamHandle {
+                backend: self.clone(),
+                client,
+            }),
             Err(StreamerError::StreamNotFound(not_found)) => {
                 let basin_config = match self.get_basin_config(basin.clone()).await {
                     Ok(basin_config) => basin_config,
@@ -335,7 +331,10 @@ impl Backend {
                         unreachable!("auto-create uses default config")
                     }
                 }
-                Ok(self.new_stream_handle(self.streamer_client(basin, stream).await?))
+                Ok(StreamHandle {
+                    backend: self.clone(),
+                    client: self.streamer_client(basin, stream).await?,
+                })
             }
             Err(e) => Err(e.into()),
         }

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -70,14 +70,6 @@ pub struct Backend {
     bgtask_trigger_tx: broadcast::Sender<BgtaskTrigger>,
 }
 
-pub(super) enum StreamLookup {
-    Found(StreamHandle),
-    Missing {
-        basin_config: BasinConfig,
-        not_found: StreamNotFoundError,
-    },
-}
-
 impl Backend {
     pub fn new(db: slatedb::Db, append_inflight_bytes: ByteSize) -> Self {
         let (bgtask_trigger_tx, _) = broadcast::channel(16);
@@ -292,30 +284,6 @@ impl Backend {
         }
     }
 
-    pub(super) async fn lookup_stream<E>(
-        &self,
-        basin: &BasinName,
-        stream: &StreamName,
-    ) -> Result<StreamLookup, E>
-    where
-        E: From<StreamerError> + From<StorageError> + From<BasinNotFoundError>,
-    {
-        match self.streamer_client(basin, stream).await {
-            Ok(client) => Ok(StreamLookup::Found(self.new_stream_handle(client))),
-            Err(StreamerError::StreamNotFound(not_found)) => {
-                match self.get_basin_config(basin.clone()).await {
-                    Ok(basin_config) => Ok(StreamLookup::Missing {
-                        basin_config,
-                        not_found,
-                    }),
-                    Err(GetBasinConfigError::Storage(e)) => Err(e.into()),
-                    Err(GetBasinConfigError::BasinNotFound(e)) => Err(e.into()),
-                }
-            }
-            Err(e) => Err(e.into()),
-        }
-    }
-
     pub(super) async fn create_stream_if_missing<E>(
         &self,
         basin: &BasinName,
@@ -364,18 +332,21 @@ impl Backend {
             + From<StreamDeletionPendingError>
             + From<StreamNotFoundError>,
     {
-        match self.lookup_stream::<E>(basin, stream).await? {
-            StreamLookup::Found(handle) => Ok(handle),
-            StreamLookup::Missing {
-                basin_config,
-                not_found,
-            } => {
+        match self.streamer_client(basin, stream).await {
+            Ok(client) => Ok(self.new_stream_handle(client)),
+            Err(StreamerError::StreamNotFound(not_found)) => {
+                let basin_config = match self.get_basin_config(basin.clone()).await {
+                    Ok(basin_config) => basin_config,
+                    Err(GetBasinConfigError::Storage(e)) => return Err(e.into()),
+                    Err(GetBasinConfigError::BasinNotFound(e)) => return Err(e.into()),
+                };
                 if !should_auto_create(&basin_config) {
                     return Err(not_found.into());
                 }
                 self.create_stream_if_missing::<E>(basin, stream).await?;
                 Ok(self.new_stream_handle(self.streamer_client(basin, stream).await?))
             }
+            Err(e) => Err(e.into()),
         }
     }
 }

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -11,6 +11,7 @@ use futures::{
     future::{BoxFuture, Shared},
 };
 use s2_common::{
+    encryption::{EncryptionAlgorithm, EncryptionSpec},
     record::{NonZeroSeqNum, SeqNum, StreamPosition},
     types::{
         basin::BasinName,
@@ -282,6 +283,7 @@ impl Backend {
         basin: &BasinName,
         stream: &StreamName,
         should_auto_create: impl FnOnce(&BasinConfig) -> bool,
+        resolve_encryption: impl FnOnce(Option<EncryptionAlgorithm>) -> Result<EncryptionSpec, E>,
     ) -> Result<StreamHandle, E>
     where
         E: From<StreamerError>
@@ -294,7 +296,8 @@ impl Backend {
     {
         match self.streamer_client(basin, stream).await {
             Ok(client) => Ok(StreamHandle {
-                backend: self.clone(),
+                db: self.db.clone(),
+                encryption: resolve_encryption(client.cipher())?,
                 client,
             }),
             Err(StreamerError::StreamNotFound(e)) => {
@@ -304,6 +307,7 @@ impl Backend {
                     Err(GetBasinConfigError::BasinNotFound(e)) => Err(e)?,
                 };
                 if should_auto_create(&config) {
+                    let encryption = resolve_encryption(config.stream_cipher)?;
                     if let Err(e) = self
                         .create_stream(
                             basin.clone(),
@@ -325,9 +329,11 @@ impl Backend {
                             }
                         }
                     }
+                    let client = self.streamer_client(basin, stream).await?;
                     Ok(StreamHandle {
-                        backend: self.clone(),
-                        client: self.streamer_client(basin, stream).await?,
+                        db: self.db.clone(),
+                        encryption,
+                        client,
                     })
                 } else {
                     Err(e.into())

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -11,6 +11,7 @@ use futures::{
     future::{BoxFuture, Shared},
 };
 use s2_common::{
+    encryption::EncryptionAlgorithm,
     record::{NonZeroSeqNum, SeqNum, StreamPosition},
     types::{
         basin::BasinName,
@@ -141,6 +142,7 @@ impl Backend {
             db: self.db.clone(),
             stream_id,
             config: meta.config,
+            encryption_algorithm: meta.encryption_algorithm,
             tail_pos,
             fencing_token,
             trim_point: ..trim_point.map_or(SeqNum::MIN, |tp| tp.end.get()),
@@ -328,6 +330,27 @@ impl Backend {
             Err(e) => Err(e.into()),
         }
     }
+
+    pub(crate) async fn stream_encryption_algorithm_with_auto_create<E>(
+        &self,
+        basin: &BasinName,
+        stream: &StreamName,
+        should_auto_create: impl FnOnce(&BasinConfig) -> bool,
+    ) -> Result<Option<EncryptionAlgorithm>, E>
+    where
+        E: From<StreamerError>
+            + From<StorageError>
+            + From<BasinNotFoundError>
+            + From<TransactionConflictError>
+            + From<BasinDeletionPendingError>
+            + From<StreamDeletionPendingError>
+            + From<StreamNotFoundError>,
+    {
+        let client = self
+            .streamer_client_with_auto_create::<E>(basin, stream, should_auto_create)
+            .await?;
+        Ok(client.encryption_algorithm())
+    }
 }
 
 #[cfg(test)]
@@ -365,6 +388,7 @@ mod tests {
 
         let meta = kv::stream_meta::StreamMeta {
             config: OptionalStreamConfig::default(),
+            encryption_algorithm: None,
             created_at: OffsetDateTime::now_utc(),
             deleted_at: None,
             creation_idempotency_key: None,

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -11,7 +11,6 @@ use futures::{
     future::{BoxFuture, Shared},
 };
 use s2_common::{
-    encryption::EncryptionAlgorithm,
     record::{NonZeroSeqNum, SeqNum, StreamPosition},
     types::{
         basin::BasinName,
@@ -27,6 +26,7 @@ use slatedb::{
 use tokio::sync::{Semaphore, broadcast};
 
 use super::{
+    StreamHandle,
     durability_notifier::DurabilityNotifier,
     error::{
         BasinDeletionPendingError, BasinNotFoundError, CreateStreamError, GetBasinConfigError,
@@ -331,12 +331,12 @@ impl Backend {
         }
     }
 
-    pub(crate) async fn stream_cipher_with_auto_create<E>(
+    pub(crate) async fn stream_handle_with_auto_create<E>(
         &self,
         basin: &BasinName,
         stream: &StreamName,
         should_auto_create: impl FnOnce(&BasinConfig) -> bool,
-    ) -> Result<Option<EncryptionAlgorithm>, E>
+    ) -> Result<StreamHandle, E>
     where
         E: From<StreamerError>
             + From<StorageError>
@@ -346,10 +346,12 @@ impl Backend {
             + From<StreamDeletionPendingError>
             + From<StreamNotFoundError>,
     {
-        let client = self
-            .streamer_client_with_auto_create::<E>(basin, stream, should_auto_create)
-            .await?;
-        Ok(client.cipher())
+        self.streamer_client_with_auto_create::<E>(basin, stream, should_auto_create)
+            .await
+            .map(|client| StreamHandle {
+                backend: self.clone(),
+                client,
+            })
     }
 }
 

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -348,6 +348,36 @@ impl Backend {
             }
         }
     }
+
+    pub(super) async fn stream_handle_with_auto_create<E>(
+        &self,
+        basin: &BasinName,
+        stream: &StreamName,
+        should_auto_create: impl FnOnce(&BasinConfig) -> bool,
+    ) -> Result<StreamHandle, E>
+    where
+        E: From<StreamerError>
+            + From<StorageError>
+            + From<BasinNotFoundError>
+            + From<TransactionConflictError>
+            + From<BasinDeletionPendingError>
+            + From<StreamDeletionPendingError>
+            + From<StreamNotFoundError>,
+    {
+        match self.lookup_stream::<E>(basin, stream).await? {
+            StreamLookup::Found(handle) => Ok(handle),
+            StreamLookup::Missing {
+                basin_config,
+                not_found,
+            } => {
+                if !should_auto_create(&basin_config) {
+                    return Err(not_found.into());
+                }
+                self.create_stream_if_missing::<E>(basin, stream).await?;
+                Ok(self.new_stream_handle(self.streamer_client(basin, stream).await?))
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -307,7 +307,6 @@ impl Backend {
                     Err(GetBasinConfigError::BasinNotFound(e)) => Err(e)?,
                 };
                 if should_auto_create(&config) {
-                    let encryption = resolve_encryption(config.stream_cipher)?;
                     if let Err(e) = self
                         .create_stream(
                             basin.clone(),
@@ -330,6 +329,7 @@ impl Backend {
                         }
                     }
                     let client = self.streamer_client(basin, stream).await?;
+                    let encryption = resolve_encryption(client.cipher())?;
                     Ok(StreamHandle {
                         db: self.db.clone(),
                         encryption,

--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -89,7 +89,7 @@ pub struct EncryptionAlgorithmMismatchError {
 pub struct TransactionConflictError;
 
 #[derive(Debug, Clone, thiserror::Error)]
-pub(crate) enum StreamerError {
+pub enum StreamerError {
     #[error(transparent)]
     Storage(#[from] StorageError),
     #[error(transparent)]

--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -1,7 +1,7 @@
 use std::{ops::RangeTo, sync::Arc};
 
 use s2_common::{
-    encryption::EncryptionMode,
+    encryption::EncryptionAlgorithm,
     record::{FencingToken, SeqNum, StreamPosition},
     types::{basin::BasinName, stream::StreamName},
 };
@@ -78,10 +78,10 @@ pub struct RequestDroppedError;
 pub struct AppendTimestampRequiredError;
 
 #[derive(Debug, Clone, thiserror::Error)]
-#[error("record encryption mode mismatch")]
-pub struct EncryptionModeMismatchError {
-    pub expected: EncryptionMode,
-    pub actual: EncryptionMode,
+#[error("record encryption algorithm mismatch")]
+pub struct EncryptionAlgorithmMismatchError {
+    pub expected: Option<EncryptionAlgorithm>,
+    pub actual: Option<EncryptionAlgorithm>,
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -111,7 +111,7 @@ pub(super) enum AppendErrorInternal {
     #[error(transparent)]
     TimestampMissing(#[from] AppendTimestampRequiredError),
     #[error(transparent)]
-    EncryptionModeMismatch(#[from] EncryptionModeMismatchError),
+    EncryptionAlgorithmMismatch(#[from] EncryptionAlgorithmMismatchError),
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -165,7 +165,7 @@ pub enum AppendError {
     #[error(transparent)]
     TimestampMissing(#[from] AppendTimestampRequiredError),
     #[error(transparent)]
-    EncryptionModeMismatch(#[from] EncryptionModeMismatchError),
+    EncryptionAlgorithmMismatch(#[from] EncryptionAlgorithmMismatchError),
 }
 
 impl From<AppendErrorInternal> for AppendError {
@@ -178,8 +178,8 @@ impl From<AppendErrorInternal> for AppendError {
             AppendErrorInternal::RequestDroppedError(e) => AppendError::RequestDroppedError(e),
             AppendErrorInternal::ConditionFailed(e) => AppendError::ConditionFailed(e),
             AppendErrorInternal::TimestampMissing(e) => AppendError::TimestampMissing(e),
-            AppendErrorInternal::EncryptionModeMismatch(e) => {
-                AppendError::EncryptionModeMismatch(e)
+            AppendErrorInternal::EncryptionAlgorithmMismatch(e) => {
+                AppendError::EncryptionAlgorithmMismatch(e)
             }
         }
     }

--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -1,8 +1,8 @@
 use std::{ops::RangeTo, sync::Arc};
 
 use s2_common::{
-    encryption::EncryptionAlgorithm,
-    record::{FencingToken, SeqNum, StreamPosition},
+    encryption::{EncryptionAlgorithm, EncryptionSpecResolutionError},
+    record::{FencingToken, RecordDecryptionError, SeqNum, StreamPosition},
     types::{basin::BasinName, stream::StreamName},
 };
 
@@ -147,6 +147,8 @@ pub enum AppendError {
     #[error(transparent)]
     Storage(#[from] StorageError),
     #[error(transparent)]
+    EncryptionSpecResolution(#[from] EncryptionSpecResolutionError),
+    #[error(transparent)]
     TransactionConflict(#[from] TransactionConflictError),
     #[error(transparent)]
     StreamerMissingInActionError(#[from] StreamerMissingInActionError),
@@ -226,6 +228,10 @@ impl From<StreamerError> for AppendError {
 pub enum ReadError {
     #[error(transparent)]
     Storage(#[from] StorageError),
+    #[error(transparent)]
+    EncryptionSpecResolution(#[from] EncryptionSpecResolutionError),
+    #[error(transparent)]
+    RecordDecryption(#[from] RecordDecryptionError),
     #[error(transparent)]
     TransactionConflict(#[from] TransactionConflictError),
     #[error(transparent)]

--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -1,7 +1,7 @@
 use std::{ops::RangeTo, sync::Arc};
 
 use s2_common::{
-    encryption::{EncryptionAlgorithm, EncryptionSpecResolutionError},
+    encryption::EncryptionAlgorithm,
     record::{FencingToken, SeqNum, StreamPosition},
     types::{basin::BasinName, stream::StreamName},
 };
@@ -186,14 +186,6 @@ impl From<AppendErrorInternal> for AppendError {
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
-pub enum ResolveAppendError {
-    #[error(transparent)]
-    Append(#[from] AppendError),
-    #[error(transparent)]
-    EncryptionSpecResolution(#[from] EncryptionSpecResolutionError),
-}
-
-#[derive(Debug, Clone, thiserror::Error)]
 pub enum AppendConditionFailedError {
     #[error("fencing token mismatch: expected `{expected}`, actual `{actual}`")]
     FencingTokenMismatch {
@@ -270,14 +262,6 @@ impl From<slatedb::Error> for ReadError {
     fn from(e: slatedb::Error) -> Self {
         Self::Storage(e.into())
     }
-}
-
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum ResolveReadError {
-    #[error(transparent)]
-    Read(#[from] ReadError),
-    #[error(transparent)]
-    EncryptionSpecResolution(#[from] EncryptionSpecResolutionError),
 }
 
 #[derive(Debug, Clone, thiserror::Error)]

--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -1,6 +1,7 @@
 use std::{ops::RangeTo, sync::Arc};
 
 use s2_common::{
+    encryption::EncryptionMode,
     record::{FencingToken, SeqNum, StreamPosition},
     types::{basin::BasinName, stream::StreamName},
 };
@@ -77,15 +78,18 @@ pub struct RequestDroppedError;
 pub struct AppendTimestampRequiredError;
 
 #[derive(Debug, Clone, thiserror::Error)]
-#[error("encryption mode '{0}' is not allowed on this stream")]
-pub struct EncryptionModeNotAllowedError(pub s2_common::encryption::EncryptionMode);
+#[error("record encryption mode mismatch")]
+pub struct EncryptionModeMismatchError {
+    pub expected: EncryptionMode,
+    pub actual: EncryptionMode,
+}
 
 #[derive(Debug, Clone, thiserror::Error)]
 #[error("transaction conflict occurred – this is usually retriable")]
 pub struct TransactionConflictError;
 
 #[derive(Debug, Clone, thiserror::Error)]
-pub(super) enum StreamerError {
+pub(crate) enum StreamerError {
     #[error(transparent)]
     Storage(#[from] StorageError),
     #[error(transparent)]
@@ -107,7 +111,7 @@ pub(super) enum AppendErrorInternal {
     #[error(transparent)]
     TimestampMissing(#[from] AppendTimestampRequiredError),
     #[error(transparent)]
-    EncryptionModeNotAllowed(#[from] EncryptionModeNotAllowedError),
+    EncryptionModeMismatch(#[from] EncryptionModeMismatchError),
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -161,7 +165,7 @@ pub enum AppendError {
     #[error(transparent)]
     TimestampMissing(#[from] AppendTimestampRequiredError),
     #[error(transparent)]
-    EncryptionModeNotAllowed(#[from] EncryptionModeNotAllowedError),
+    EncryptionModeMismatch(#[from] EncryptionModeMismatchError),
 }
 
 impl From<AppendErrorInternal> for AppendError {
@@ -174,8 +178,8 @@ impl From<AppendErrorInternal> for AppendError {
             AppendErrorInternal::RequestDroppedError(e) => AppendError::RequestDroppedError(e),
             AppendErrorInternal::ConditionFailed(e) => AppendError::ConditionFailed(e),
             AppendErrorInternal::TimestampMissing(e) => AppendError::TimestampMissing(e),
-            AppendErrorInternal::EncryptionModeNotAllowed(e) => {
-                AppendError::EncryptionModeNotAllowed(e)
+            AppendErrorInternal::EncryptionModeMismatch(e) => {
+                AppendError::EncryptionModeMismatch(e)
             }
         }
     }

--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -1,7 +1,7 @@
 use std::{ops::RangeTo, sync::Arc};
 
 use s2_common::{
-    encryption::EncryptionAlgorithm,
+    encryption::{EncryptionAlgorithm, EncryptionSpecResolutionError},
     record::{FencingToken, SeqNum, StreamPosition},
     types::{basin::BasinName, stream::StreamName},
 };
@@ -186,6 +186,14 @@ impl From<AppendErrorInternal> for AppendError {
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
+pub enum ResolveAppendError {
+    #[error(transparent)]
+    Append(#[from] AppendError),
+    #[error(transparent)]
+    EncryptionSpecResolution(#[from] EncryptionSpecResolutionError),
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum AppendConditionFailedError {
     #[error("fencing token mismatch: expected `{expected}`, actual `{actual}`")]
     FencingTokenMismatch {
@@ -262,6 +270,14 @@ impl From<slatedb::Error> for ReadError {
     fn from(e: slatedb::Error) -> Self {
         Self::Storage(e.into())
     }
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum ResolveReadError {
+    #[error(transparent)]
+    Read(#[from] ReadError),
+    #[error(transparent)]
+    EncryptionSpecResolution(#[from] EncryptionSpecResolutionError),
 }
 
 #[derive(Debug, Clone, thiserror::Error)]

--- a/lite/src/backend/kv/stream_meta.rs
+++ b/lite/src/backend/kv/stream_meta.rs
@@ -204,6 +204,7 @@ mod tests {
             stream_meta.config.storage_class,
             decoded.config.storage_class
         );
+        assert_eq!(stream_meta.cipher, decoded.cipher);
         assert_eq!(stream_meta.created_at, decoded.created_at);
         assert_eq!(stream_meta.deleted_at, decoded.deleted_at);
     }

--- a/lite/src/backend/kv/stream_meta.rs
+++ b/lite/src/backend/kv/stream_meta.rs
@@ -5,6 +5,7 @@ use enum_ordinalize::Ordinalize;
 use s2_common::{
     bash::Bash,
     caps::{MIN_BASIN_NAME_LEN, MIN_STREAM_NAME_LEN},
+    encryption::EncryptionAlgorithm,
     types::{
         basin::BasinName,
         config::OptionalStreamConfig,
@@ -24,6 +25,7 @@ const FIELD_SEPARATOR: u8 = b'\0';
 #[derive(Debug, Clone)]
 pub struct StreamMeta {
     pub config: OptionalStreamConfig,
+    pub encryption_algorithm: Option<EncryptionAlgorithm>,
     pub created_at: OffsetDateTime,
     pub deleted_at: Option<OffsetDateTime>,
     pub creation_idempotency_key: Option<Bash>,
@@ -32,6 +34,7 @@ pub struct StreamMeta {
 #[derive(Debug, Serialize, Deserialize)]
 struct StreamMetaSerde {
     config: Option<s2_api::v1::config::StreamConfig>,
+    encryption_algorithm: Option<EncryptionAlgorithm>,
     #[serde(with = "time::serde::rfc3339")]
     created_at: OffsetDateTime,
     #[serde(with = "time::serde::rfc3339::option")]
@@ -43,6 +46,7 @@ impl From<StreamMeta> for StreamMetaSerde {
     fn from(meta: StreamMeta) -> Self {
         Self {
             config: s2_api::v1::config::StreamConfig::to_opt(meta.config),
+            encryption_algorithm: meta.encryption_algorithm,
             created_at: meta.created_at,
             deleted_at: meta.deleted_at,
             creation_idempotency_key: meta.creation_idempotency_key,
@@ -61,6 +65,7 @@ impl TryFrom<StreamMetaSerde> for StreamMeta {
 
         Ok(Self {
             config,
+            encryption_algorithm: serde.encryption_algorithm,
             created_at: serde.created_at,
             deleted_at: serde.deleted_at,
             creation_idempotency_key: serde.creation_idempotency_key,
@@ -153,6 +158,7 @@ mod tests {
     use proptest::prelude::*;
     use s2_common::{
         bash::Bash,
+        encryption::EncryptionAlgorithm,
         types::{
             basin::BasinName,
             config::{OptionalStreamConfig, StorageClass},
@@ -181,6 +187,7 @@ mod tests {
         );
         let stream_meta = super::StreamMeta {
             config: config.clone(),
+            encryption_algorithm: Some(EncryptionAlgorithm::Aegis256),
             created_at,
             deleted_at,
             creation_idempotency_key: Some(Bash::length_prefixed(&[
@@ -205,6 +212,7 @@ mod tests {
     fn stream_meta_deser_defaults_config_missing() {
         let serde_value = super::StreamMetaSerde {
             config: None,
+            encryption_algorithm: Some(EncryptionAlgorithm::Aes256Gcm),
             created_at: OffsetDateTime::from_unix_timestamp(2_345_678).unwrap(),
             deleted_at: None,
             creation_idempotency_key: Some(Bash::length_prefixed(&[
@@ -236,6 +244,10 @@ mod tests {
         );
         assert_eq!(decoded.created_at, serde_value.created_at);
         assert_eq!(decoded.deleted_at, serde_value.deleted_at);
+        assert_eq!(
+            decoded.encryption_algorithm,
+            serde_value.encryption_algorithm
+        );
     }
 
     fn stream_name_prefix_strategy() -> impl Strategy<Value = StreamNamePrefix> {

--- a/lite/src/backend/kv/stream_meta.rs
+++ b/lite/src/backend/kv/stream_meta.rs
@@ -25,7 +25,7 @@ const FIELD_SEPARATOR: u8 = b'\0';
 #[derive(Debug, Clone)]
 pub struct StreamMeta {
     pub config: OptionalStreamConfig,
-    pub encryption_algorithm: Option<EncryptionAlgorithm>,
+    pub cipher: Option<EncryptionAlgorithm>,
     pub created_at: OffsetDateTime,
     pub deleted_at: Option<OffsetDateTime>,
     pub creation_idempotency_key: Option<Bash>,
@@ -34,7 +34,7 @@ pub struct StreamMeta {
 #[derive(Debug, Serialize, Deserialize)]
 struct StreamMetaSerde {
     config: Option<s2_api::v1::config::StreamConfig>,
-    encryption_algorithm: Option<EncryptionAlgorithm>,
+    cipher: Option<EncryptionAlgorithm>,
     #[serde(with = "time::serde::rfc3339")]
     created_at: OffsetDateTime,
     #[serde(with = "time::serde::rfc3339::option")]
@@ -46,7 +46,7 @@ impl From<StreamMeta> for StreamMetaSerde {
     fn from(meta: StreamMeta) -> Self {
         Self {
             config: s2_api::v1::config::StreamConfig::to_opt(meta.config),
-            encryption_algorithm: meta.encryption_algorithm,
+            cipher: meta.cipher,
             created_at: meta.created_at,
             deleted_at: meta.deleted_at,
             creation_idempotency_key: meta.creation_idempotency_key,
@@ -65,7 +65,7 @@ impl TryFrom<StreamMetaSerde> for StreamMeta {
 
         Ok(Self {
             config,
-            encryption_algorithm: serde.encryption_algorithm,
+            cipher: serde.cipher,
             created_at: serde.created_at,
             deleted_at: serde.deleted_at,
             creation_idempotency_key: serde.creation_idempotency_key,
@@ -187,7 +187,7 @@ mod tests {
         );
         let stream_meta = super::StreamMeta {
             config: config.clone(),
-            encryption_algorithm: Some(EncryptionAlgorithm::Aegis256),
+            cipher: Some(EncryptionAlgorithm::Aegis256),
             created_at,
             deleted_at,
             creation_idempotency_key: Some(Bash::length_prefixed(&[
@@ -212,7 +212,7 @@ mod tests {
     fn stream_meta_deser_defaults_config_missing() {
         let serde_value = super::StreamMetaSerde {
             config: None,
-            encryption_algorithm: Some(EncryptionAlgorithm::Aes256Gcm),
+            cipher: Some(EncryptionAlgorithm::Aes256Gcm),
             created_at: OffsetDateTime::from_unix_timestamp(2_345_678).unwrap(),
             deleted_at: None,
             creation_idempotency_key: Some(Bash::length_prefixed(&[
@@ -244,10 +244,7 @@ mod tests {
         );
         assert_eq!(decoded.created_at, serde_value.created_at);
         assert_eq!(decoded.deleted_at, serde_value.deleted_at);
-        assert_eq!(
-            decoded.encryption_algorithm,
-            serde_value.encryption_algorithm
-        );
+        assert_eq!(decoded.cipher, serde_value.cipher);
     }
 
     fn stream_name_prefix_strategy() -> impl Strategy<Value = StreamNamePrefix> {

--- a/lite/src/backend/mod.rs
+++ b/lite/src/backend/mod.rs
@@ -1,3 +1,5 @@
+use s2_common::encryption::EncryptionAlgorithm;
+
 pub mod error;
 
 mod basins;
@@ -15,6 +17,22 @@ mod kv;
 pub use core::Backend;
 
 pub use crate::stream_id::StreamId;
+
+#[derive(Clone)]
+pub(crate) struct StreamHandle {
+    backend: Backend,
+    client: streamer::StreamerClient,
+}
+
+impl StreamHandle {
+    pub(crate) fn cipher(&self) -> Option<EncryptionAlgorithm> {
+        self.client.cipher()
+    }
+
+    pub(crate) fn stream_id(&self) -> StreamId {
+        self.client.stream_id()
+    }
+}
 
 pub const FOLLOWER_MAX_LAG: usize = 25;
 

--- a/lite/src/backend/mod.rs
+++ b/lite/src/backend/mod.rs
@@ -1,4 +1,4 @@
-use s2_common::encryption::EncryptionAlgorithm;
+use s2_common::encryption::EncryptionSpec;
 
 pub mod error;
 
@@ -20,15 +20,12 @@ pub use crate::stream_id::StreamId;
 
 #[derive(Clone)]
 pub struct StreamHandle {
-    backend: Backend,
+    db: slatedb::Db,
     client: streamer::StreamerClient,
+    encryption: EncryptionSpec,
 }
 
 impl StreamHandle {
-    pub fn cipher(&self) -> Option<EncryptionAlgorithm> {
-        self.client.cipher()
-    }
-
     pub fn stream_id(&self) -> StreamId {
         self.client.stream_id()
     }

--- a/lite/src/backend/mod.rs
+++ b/lite/src/backend/mod.rs
@@ -19,17 +19,17 @@ pub use core::Backend;
 pub use crate::stream_id::StreamId;
 
 #[derive(Clone)]
-pub(crate) struct StreamHandle {
+pub struct StreamHandle {
     backend: Backend,
     client: streamer::StreamerClient,
 }
 
 impl StreamHandle {
-    pub(crate) fn cipher(&self) -> Option<EncryptionAlgorithm> {
+    pub fn cipher(&self) -> Option<EncryptionAlgorithm> {
         self.client.cipher()
     }
 
-    pub(crate) fn stream_id(&self) -> StreamId {
+    pub fn stream_id(&self) -> StreamId {
         self.client.stream_id()
     }
 }

--- a/lite/src/backend/mod.rs
+++ b/lite/src/backend/mod.rs
@@ -25,12 +25,6 @@ pub struct StreamHandle {
     encryption: EncryptionSpec,
 }
 
-impl StreamHandle {
-    pub fn stream_id(&self) -> StreamId {
-        self.client.stream_id()
-    }
-}
-
 pub const FOLLOWER_MAX_LAG: usize = 25;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/lite/src/backend/read.rs
+++ b/lite/src/backend/read.rs
@@ -1,14 +1,16 @@
 use std::time::Duration;
 
-use futures::Stream;
+use futures::{Stream, StreamExt as _};
 use s2_common::{
     caps,
+    encryption::{EncryptionKey, EncryptionSpec},
     read_extent::{EvaluatedReadLimit, ReadLimit, ReadUntil},
     record::{Metered, MeteredSize as _, SeqNum, StoredSequencedRecord, StreamPosition, Timestamp},
     types::{
         basin::BasinName,
         stream::{
-            ReadEnd, ReadPosition, ReadStart, StoredReadBatch, StoredReadSessionOutput, StreamName,
+            ReadEnd, ReadPosition, ReadSessionOutput, ReadStart, StoredReadBatch,
+            StoredReadSessionOutput, StreamName,
         },
     },
 };
@@ -22,9 +24,7 @@ use super::{Backend, StreamHandle};
 use crate::{
     backend::{
         error::{
-            BasinDeletionPendingError, BasinNotFoundError, CheckTailError, ReadError, StorageError,
-            StreamDeletionPendingError, StreamNotFoundError, StreamerError,
-            StreamerMissingInActionError, TransactionConflictError, UnwrittenError,
+            CheckTailError, ReadError, StorageError, StreamerMissingInActionError, UnwrittenError,
         },
         kv,
     },
@@ -32,90 +32,33 @@ use crate::{
 };
 
 impl Backend {
-    pub async fn open_for_read<E>(
+    pub async fn open_for_check_tail(
         &self,
         basin: &BasinName,
         stream: &StreamName,
-    ) -> Result<StreamHandle, E>
-    where
-        E: From<StreamerError>
-            + From<StorageError>
-            + From<BasinNotFoundError>
-            + From<TransactionConflictError>
-            + From<BasinDeletionPendingError>
-            + From<StreamDeletionPendingError>
-            + From<StreamNotFoundError>,
-    {
-        self.stream_handle_with_auto_create::<E>(basin, stream, |config| {
-            config.create_stream_on_read
-        })
+    ) -> Result<StreamHandle, CheckTailError> {
+        self.stream_handle_with_auto_create::<CheckTailError>(
+            basin,
+            stream,
+            |config| config.create_stream_on_read,
+            |_| Ok(EncryptionSpec::Plain),
+        )
         .await
     }
 
-    async fn read_start_seq_num(
+    pub async fn open_for_read(
         &self,
-        stream_id: StreamId,
-        start: ReadStart,
-        end: ReadEnd,
-        tail: StreamPosition,
-    ) -> Result<SeqNum, ReadError> {
-        let mut read_pos = match start.from {
-            s2_common::types::stream::ReadFrom::SeqNum(seq_num) => ReadPosition::SeqNum(seq_num),
-            s2_common::types::stream::ReadFrom::Timestamp(timestamp) => {
-                ReadPosition::Timestamp(timestamp)
-            }
-            s2_common::types::stream::ReadFrom::TailOffset(tail_offset) => {
-                ReadPosition::SeqNum(tail.seq_num.saturating_sub(tail_offset))
-            }
-        };
-        if match read_pos {
-            ReadPosition::SeqNum(start_seq_num) => start_seq_num > tail.seq_num,
-            ReadPosition::Timestamp(start_timestamp) => start_timestamp > tail.timestamp,
-        } {
-            if start.clamp {
-                read_pos = ReadPosition::SeqNum(tail.seq_num);
-            } else {
-                return Err(UnwrittenError(tail).into());
-            }
-        }
-        if let ReadPosition::SeqNum(start_seq_num) = read_pos
-            && start_seq_num == tail.seq_num
-            && !end.may_follow()
-        {
-            return Err(UnwrittenError(tail).into());
-        }
-        Ok(match read_pos {
-            ReadPosition::SeqNum(start_seq_num) => start_seq_num,
-            ReadPosition::Timestamp(start_timestamp) => {
-                self.resolve_timestamp(stream_id, start_timestamp)
-                    .await?
-                    .unwrap_or(tail)
-                    .seq_num
-            }
-        })
-    }
-
-    pub async fn check_tail(
-        &self,
-        basin: BasinName,
-        stream: StreamName,
-    ) -> Result<StreamPosition, CheckTailError> {
-        let handle = self
-            .open_for_read::<CheckTailError>(&basin, &stream)
-            .await?;
-        handle.check_tail().await
-    }
-
-    pub async fn read(
-        &self,
-        basin: BasinName,
-        stream: StreamName,
-        start: ReadStart,
-        end: ReadEnd,
-    ) -> Result<impl Stream<Item = Result<StoredReadSessionOutput, ReadError>> + 'static, ReadError>
-    {
-        let handle = self.open_for_read::<ReadError>(&basin, &stream).await?;
-        handle.read(start, end).await
+        basin: &BasinName,
+        stream: &StreamName,
+        encryption_key: Option<EncryptionKey>,
+    ) -> Result<StreamHandle, ReadError> {
+        self.stream_handle_with_auto_create::<ReadError>(
+            basin,
+            stream,
+            |config| config.create_stream_on_read,
+            |cipher| Ok(EncryptionSpec::resolve(cipher, encryption_key)?),
+        )
+        .await
     }
 }
 
@@ -129,210 +72,268 @@ impl StreamHandle {
         self,
         start: ReadStart,
         end: ReadEnd,
-    ) -> Result<impl Stream<Item = Result<StoredReadSessionOutput, ReadError>> + 'static, ReadError>
-    {
+    ) -> Result<impl Stream<Item = Result<ReadSessionOutput, ReadError>> + 'static, ReadError> {
         let stream_id = self.client.stream_id();
-        let tail = self.client.check_tail().await?;
-        let mut state = ReadSessionState {
-            start_seq_num: self
-                .backend
-                .read_start_seq_num(stream_id, start, end, tail)
-                .await?,
-            limit: EvaluatedReadLimit::Remaining(end.limit),
-            until: end.until,
-            wait: end.wait,
-            wait_deadline: None,
-            tail,
-        };
-        let db = self.backend.db.clone();
-        let session = async_stream::try_stream! {
-            'session: while let EvaluatedReadLimit::Remaining(limit) = state.limit {
-                if state.start_seq_num < state.tail.seq_num {
-                    let start_key = kv::stream_record_data::ser_key(
-                        stream_id,
-                        StreamPosition {
-                            seq_num: state.start_seq_num,
-                            timestamp: 0,
-                        },
-                    );
-                    let end_key = kv::stream_record_data::ser_key(
-                        stream_id,
-                        StreamPosition {
-                            seq_num: state.tail.seq_num,
-                            timestamp: 0,
-                        },
-                    );
-                    static SCAN_OPTS: ScanOptions = ScanOptions {
-                        durability_filter: DurabilityLevel::Remote,
-                        dirty: false,
-                        read_ahead_bytes: 1024 * 1024,
-                        cache_blocks: true,
-                        max_fetch_tasks: 8,
-                        order: IterationOrder::Ascending,
-                    };
-                    let mut it = db
-                        .scan_with_options(start_key..end_key, &SCAN_OPTS)
-                        .await?;
-
-                    let mut records = Metered::with_capacity(
-                        limit.count()
-                            .unwrap_or(usize::MAX)
-                            .min(caps::RECORD_BATCH_MAX.count),
-                    );
-
-                    while let EvaluatedReadLimit::Remaining(limit) = state.limit {
-                        let Some(kv) = it.next().await? else {
-                            break;
-                        };
-                        let (deser_stream_id, pos) = kv::stream_record_data::deser_key(kv.key)?;
-                        assert_eq!(deser_stream_id, stream_id);
-
-                        let record = kv::stream_record_data::deser_value(kv.value)?.sequenced(pos);
-
-                        if end.until.deny(pos.timestamp)
-                            || limit.deny(records.len() + 1, records.metered_size() + record.metered_size()) {
-                            if records.is_empty() {
-                                break 'session;
-                            } else {
-                                break;
-                            }
-                        }
-
-                        if records.len() == caps::RECORD_BATCH_MAX.count
-                            || records.metered_size() + record.metered_size() > caps::RECORD_BATCH_MAX.bytes
-                        {
-                            let new_records_buf = Metered::with_capacity(
-                                limit.count()
-                                    .map_or(usize::MAX, |n| n.saturating_sub(records.len()))
-                                    .min(caps::RECORD_BATCH_MAX.count),
-                            );
-                            yield state.on_batch(StoredReadBatch {
-                                records: std::mem::replace(&mut records, new_records_buf),
-                                tail: None,
-                            });
-                        }
-
-                        records.push(record);
-                    }
-
-                    if !records.is_empty() {
-                        yield state.on_batch(StoredReadBatch {
-                            records,
-                            tail: None,
-                        });
-                    } else {
-                        state.start_seq_num = state.tail.seq_num;
-                    }
-                } else {
-                    assert_eq!(state.start_seq_num, state.tail.seq_num);
-                    if !end.may_follow() {
-                        break;
-                    }
-                    match self.client.follow(state.start_seq_num).await? {
-                        Ok(mut follow_rx) => {
-                            // Only a delivered batch should reset the absolute wait budget.
-                            state.arm_wait_deadline_if_unset();
-                            if state.wait_deadline_expired() {
-                                break;
-                            }
-                            yield StoredReadSessionOutput::Heartbeat(state.tail);
-                            while let EvaluatedReadLimit::Remaining(limit) = state.limit {
-                                tokio::select! {
-                                    biased;
-                                    msg = follow_rx.recv() => {
-                                        match msg {
-                                            Ok(mut records) => {
-                                                let count = records.len();
-                                                let tail = super::streamer::next_pos(&records);
-                                                let allowed_count = count_allowed_records(limit, end.until, &records);
-                                                if allowed_count > 0 {
-                                                    yield state.on_batch(StoredReadBatch {
-                                                        records: records.drain(..allowed_count).collect(),
-                                                        tail: Some(tail),
-                                                    });
-                                                }
-                                                if allowed_count < count {
-                                                    break 'session;
-                                                }
-                                                Ok(())
-                                            }
-                                            Err(broadcast::error::RecvError::Lagged(_)) => {
-                                                // Catch up using DB
-                                                continue 'session;
-                                            }
-                                            Err(broadcast::error::RecvError::Closed) => {
-                                                Err(StreamerMissingInActionError)
-                                            }
-                                        }
-                                    }
-                                    _ = new_heartbeat_sleep() => {
-                                        yield StoredReadSessionOutput::Heartbeat(state.tail);
-                                        Ok(())
-                                    }
-                                    _ = wait_sleep_until(state.wait_deadline) => {
-                                        break 'session;
-                                    }
-                                }?;
-                            }
-                        }
-                        Err(tail) => {
-                            assert!(state.tail.seq_num < tail.seq_num, "tail cannot regress");
-                            state.tail = tail;
-                        }
-                    }
+        let session = read_session(self.db, self.client, start, end).await?;
+        Ok(async_stream::stream! {
+            tokio::pin!(session);
+            while let Some(output) = session.next().await {
+                let output = match output {
+                    Ok(output) => output
+                        .decrypt(&self.encryption, stream_id.as_bytes())
+                        .map_err(ReadError::from),
+                    Err(err) => Err(err),
+                };
+                let should_stop = output.is_err();
+                yield output;
+                if should_stop {
+                    break;
                 }
             }
-        };
-        Ok(session)
+        })
     }
 }
 
-impl Backend {
-    pub(super) async fn resolve_timestamp(
-        &self,
-        stream_id: StreamId,
-        timestamp: Timestamp,
-    ) -> Result<Option<StreamPosition>, StorageError> {
-        let start_key = kv::stream_record_timestamp::ser_key(
-            stream_id,
-            StreamPosition {
-                seq_num: SeqNum::MIN,
-                timestamp,
-            },
-        );
-        let end_key = kv::stream_record_timestamp::ser_key(
-            stream_id,
-            StreamPosition {
-                seq_num: SeqNum::MAX,
-                timestamp: Timestamp::MAX,
-            },
-        );
-        static SCAN_OPTS: ScanOptions = ScanOptions {
-            durability_filter: DurabilityLevel::Remote,
-            dirty: false,
-            read_ahead_bytes: 1,
-            cache_blocks: false,
-            max_fetch_tasks: 1,
-            order: IterationOrder::Ascending,
-        };
-        let mut it = self
-            .db
-            .scan_with_options(start_key..end_key, &SCAN_OPTS)
-            .await?;
-        Ok(match it.next().await? {
-            Some(kv) => {
-                let (deser_stream_id, pos) = kv::stream_record_timestamp::deser_key(kv.key)?;
-                assert_eq!(deser_stream_id, stream_id);
-                assert!(pos.timestamp >= timestamp);
-                kv::stream_record_timestamp::deser_value(kv.value)?;
-                Some(StreamPosition {
-                    seq_num: pos.seq_num,
-                    timestamp: pos.timestamp,
-                })
+async fn read_session(
+    db: slatedb::Db,
+    client: super::streamer::StreamerClient,
+    start: ReadStart,
+    end: ReadEnd,
+) -> Result<impl Stream<Item = Result<StoredReadSessionOutput, ReadError>> + 'static, ReadError> {
+    let stream_id = client.stream_id();
+    let tail = client.check_tail().await?;
+    let mut state = ReadSessionState {
+        start_seq_num: read_start_seq_num(&db, stream_id, start, end, tail).await?,
+        limit: EvaluatedReadLimit::Remaining(end.limit),
+        until: end.until,
+        wait: end.wait,
+        wait_deadline: None,
+        tail,
+    };
+    let session = async_stream::try_stream! {
+        'session: while let EvaluatedReadLimit::Remaining(limit) = state.limit {
+            if state.start_seq_num < state.tail.seq_num {
+                let start_key = kv::stream_record_data::ser_key(
+                    stream_id,
+                    StreamPosition {
+                        seq_num: state.start_seq_num,
+                        timestamp: 0,
+                    },
+                );
+                let end_key = kv::stream_record_data::ser_key(
+                    stream_id,
+                    StreamPosition {
+                        seq_num: state.tail.seq_num,
+                        timestamp: 0,
+                    },
+                );
+                static SCAN_OPTS: ScanOptions = ScanOptions {
+                    durability_filter: DurabilityLevel::Remote,
+                    dirty: false,
+                    read_ahead_bytes: 1024 * 1024,
+                    cache_blocks: true,
+                    max_fetch_tasks: 8,
+                    order: IterationOrder::Ascending,
+                };
+                let mut it = db.scan_with_options(start_key..end_key, &SCAN_OPTS).await?;
+
+                let mut records = Metered::with_capacity(
+                    limit.count()
+                        .unwrap_or(usize::MAX)
+                        .min(caps::RECORD_BATCH_MAX.count),
+                );
+
+                while let EvaluatedReadLimit::Remaining(limit) = state.limit {
+                    let Some(kv) = it.next().await? else {
+                        break;
+                    };
+                    let (deser_stream_id, pos) = kv::stream_record_data::deser_key(kv.key)?;
+                    assert_eq!(deser_stream_id, stream_id);
+
+                    let record = kv::stream_record_data::deser_value(kv.value)?.sequenced(pos);
+
+                    if end.until.deny(pos.timestamp)
+                        || limit.deny(records.len() + 1, records.metered_size() + record.metered_size())
+                    {
+                        if records.is_empty() {
+                            break 'session;
+                        } else {
+                            break;
+                        }
+                    }
+
+                    if records.len() == caps::RECORD_BATCH_MAX.count
+                        || records.metered_size() + record.metered_size() > caps::RECORD_BATCH_MAX.bytes
+                    {
+                        let new_records_buf = Metered::with_capacity(
+                            limit.count()
+                                .map_or(usize::MAX, |n| n.saturating_sub(records.len()))
+                                .min(caps::RECORD_BATCH_MAX.count),
+                        );
+                        yield state.on_batch(StoredReadBatch {
+                            records: std::mem::replace(&mut records, new_records_buf),
+                            tail: None,
+                        });
+                    }
+
+                    records.push(record);
+                }
+
+                if !records.is_empty() {
+                    yield state.on_batch(StoredReadBatch {
+                        records,
+                        tail: None,
+                    });
+                } else {
+                    state.start_seq_num = state.tail.seq_num;
+                }
+            } else {
+                assert_eq!(state.start_seq_num, state.tail.seq_num);
+                if !end.may_follow() {
+                    break;
+                }
+                match client.follow(state.start_seq_num).await? {
+                    Ok(mut follow_rx) => {
+                        // Only a delivered batch should reset the absolute wait budget.
+                        state.arm_wait_deadline_if_unset();
+                        if state.wait_deadline_expired() {
+                            break;
+                        }
+                        yield StoredReadSessionOutput::Heartbeat(state.tail);
+                        while let EvaluatedReadLimit::Remaining(limit) = state.limit {
+                            tokio::select! {
+                                biased;
+                                msg = follow_rx.recv() => {
+                                    match msg {
+                                        Ok(mut records) => {
+                                            let count = records.len();
+                                            let tail = super::streamer::next_pos(&records);
+                                            let allowed_count = count_allowed_records(limit, end.until, &records);
+                                            if allowed_count > 0 {
+                                                yield state.on_batch(StoredReadBatch {
+                                                    records: records.drain(..allowed_count).collect(),
+                                                    tail: Some(tail),
+                                                });
+                                            }
+                                            if allowed_count < count {
+                                                break 'session;
+                                            }
+                                            Ok(())
+                                        }
+                                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                                            // Catch up using DB
+                                            continue 'session;
+                                        }
+                                        Err(broadcast::error::RecvError::Closed) => {
+                                            Err(StreamerMissingInActionError)
+                                        }
+                                    }
+                                }
+                                _ = new_heartbeat_sleep() => {
+                                    yield StoredReadSessionOutput::Heartbeat(state.tail);
+                                    Ok(())
+                                }
+                                _ = wait_sleep_until(state.wait_deadline) => {
+                                    break 'session;
+                                }
+                            }?;
+                        }
+                    }
+                    Err(tail) => {
+                        assert!(state.tail.seq_num < tail.seq_num, "tail cannot regress");
+                        state.tail = tail;
+                    }
+                }
             }
-            None => None,
-        })
+        }
+    };
+    Ok(session)
+}
+
+async fn read_start_seq_num(
+    db: &slatedb::Db,
+    stream_id: StreamId,
+    start: ReadStart,
+    end: ReadEnd,
+    tail: StreamPosition,
+) -> Result<SeqNum, ReadError> {
+    let mut read_pos = match start.from {
+        s2_common::types::stream::ReadFrom::SeqNum(seq_num) => ReadPosition::SeqNum(seq_num),
+        s2_common::types::stream::ReadFrom::Timestamp(timestamp) => {
+            ReadPosition::Timestamp(timestamp)
+        }
+        s2_common::types::stream::ReadFrom::TailOffset(tail_offset) => {
+            ReadPosition::SeqNum(tail.seq_num.saturating_sub(tail_offset))
+        }
+    };
+    if match read_pos {
+        ReadPosition::SeqNum(start_seq_num) => start_seq_num > tail.seq_num,
+        ReadPosition::Timestamp(start_timestamp) => start_timestamp > tail.timestamp,
+    } {
+        if start.clamp {
+            read_pos = ReadPosition::SeqNum(tail.seq_num);
+        } else {
+            return Err(UnwrittenError(tail).into());
+        }
     }
+    if let ReadPosition::SeqNum(start_seq_num) = read_pos
+        && start_seq_num == tail.seq_num
+        && !end.may_follow()
+    {
+        return Err(UnwrittenError(tail).into());
+    }
+    Ok(match read_pos {
+        ReadPosition::SeqNum(start_seq_num) => start_seq_num,
+        ReadPosition::Timestamp(start_timestamp) => {
+            resolve_timestamp(db, stream_id, start_timestamp)
+                .await?
+                .unwrap_or(tail)
+                .seq_num
+        }
+    })
+}
+
+async fn resolve_timestamp(
+    db: &slatedb::Db,
+    stream_id: StreamId,
+    timestamp: Timestamp,
+) -> Result<Option<StreamPosition>, StorageError> {
+    let start_key = kv::stream_record_timestamp::ser_key(
+        stream_id,
+        StreamPosition {
+            seq_num: SeqNum::MIN,
+            timestamp,
+        },
+    );
+    let end_key = kv::stream_record_timestamp::ser_key(
+        stream_id,
+        StreamPosition {
+            seq_num: SeqNum::MAX,
+            timestamp: Timestamp::MAX,
+        },
+    );
+    static SCAN_OPTS: ScanOptions = ScanOptions {
+        durability_filter: DurabilityLevel::Remote,
+        dirty: false,
+        read_ahead_bytes: 1,
+        cache_blocks: false,
+        max_fetch_tasks: 1,
+        order: IterationOrder::Ascending,
+    };
+    let mut it = db.scan_with_options(start_key..end_key, &SCAN_OPTS).await?;
+    Ok(match it.next().await? {
+        Some(kv) => {
+            let (deser_stream_id, pos) = kv::stream_record_timestamp::deser_key(kv.key)?;
+            assert_eq!(deser_stream_id, stream_id);
+            assert!(pos.timestamp >= timestamp);
+            kv::stream_record_timestamp::deser_value(kv.value)?;
+            Some(StreamPosition {
+                seq_num: pos.seq_num,
+                timestamp: pos.timestamp,
+            })
+        }
+        None => None,
+    })
 }
 
 struct ReadSessionState {
@@ -426,14 +427,14 @@ mod tests {
     use futures::StreamExt;
     use s2_common::{
         read_extent::{ReadLimit, ReadUntil},
-        record::{Metered, Record, StoredRecord},
+        record::{Metered, Record},
         types::{
             basin::BasinName,
             config::{BasinConfig, OptionalStreamConfig},
             resources::CreateMode,
             stream::{
-                ReadEnd, ReadFrom, ReadStart, StoredAppendInput, StoredAppendRecord,
-                StoredAppendRecordBatch, StoredAppendRecordParts, StoredReadSessionOutput,
+                AppendInput, AppendRecord, AppendRecordBatch, AppendRecordParts, ReadEnd, ReadFrom,
+                ReadSessionOutput, ReadStart,
             },
         },
     };
@@ -446,15 +447,15 @@ mod tests {
         stream_id::StreamId,
     };
 
-    fn stored_append_input(record: Record) -> StoredAppendInput {
-        let record: StoredAppendRecord = StoredAppendRecordParts {
+    fn append_input(record: Record) -> AppendInput {
+        let record: AppendRecord = AppendRecordParts {
             timestamp: None,
-            record: Metered::from(StoredRecord::from(record)),
+            record: Metered::from(record),
         }
         .try_into()
         .unwrap();
-        let records: StoredAppendRecordBatch = vec![record].try_into().unwrap();
-        StoredAppendInput {
+        let records: AppendRecordBatch = vec![record].try_into().unwrap();
+        AppendInput {
             records,
             match_seq_num: None,
             fencing_token: None,
@@ -462,8 +463,8 @@ mod tests {
     }
 
     fn map_test_output(
-        output: Option<Result<StoredReadSessionOutput, ReadError>>,
-    ) -> Option<StoredReadSessionOutput> {
+        output: Option<Result<ReadSessionOutput, ReadError>>,
+    ) -> Option<ReadSessionOutput> {
         match output {
             Some(Ok(output)) => Some(output),
             Some(Err(e)) => panic!("Read error: {e:?}"),
@@ -474,9 +475,9 @@ mod tests {
     async fn poll_next_after_advance<S>(
         session: &mut std::pin::Pin<Box<S>>,
         advance_by: Duration,
-    ) -> Poll<Option<StoredReadSessionOutput>>
+    ) -> Poll<Option<ReadSessionOutput>>
     where
-        S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+        S: futures::Stream<Item = Result<ReadSessionOutput, ReadError>>,
     {
         let mut pinned_session = session.as_mut();
         let next = pinned_session.next();
@@ -535,7 +536,7 @@ mod tests {
             .unwrap();
 
         // Should find record in stream_a
-        let result = backend.resolve_timestamp(stream_a, 500).await.unwrap();
+        let result = resolve_timestamp(&backend.db, stream_a, 500).await.unwrap();
         assert_eq!(
             result,
             Some(StreamPosition {
@@ -545,7 +546,9 @@ mod tests {
         );
 
         // Should return None, not find stream_b's record
-        let result = backend.resolve_timestamp(stream_a, 1500).await.unwrap();
+        let result = resolve_timestamp(&backend.db, stream_a, 1500)
+            .await
+            .unwrap();
         assert_eq!(result, None);
     }
 
@@ -575,10 +578,12 @@ mod tests {
             .await
             .unwrap();
 
-        let input =
-            stored_append_input(Record::try_from_parts(vec![], bytes::Bytes::from("x")).unwrap());
+        let input = append_input(Record::try_from_parts(vec![], bytes::Bytes::from("x")).unwrap());
         let ack = backend
-            .append(basin.clone(), stream.clone(), input)
+            .open_for_append(&basin, &stream, None)
+            .await
+            .unwrap()
+            .append(input)
             .await
             .unwrap();
         assert!(ack.end.seq_num > 0);
@@ -604,7 +609,13 @@ mod tests {
             until: ReadUntil::Unbounded,
             wait: None,
         };
-        let session = backend.read(basin, stream, start, end).await.unwrap();
+        let session = backend
+            .open_for_read(&basin, &stream, None)
+            .await
+            .unwrap()
+            .read(start, end)
+            .await
+            .unwrap();
         let records: Vec<_> = tokio::time::timeout(
             Duration::from_secs(2),
             futures::StreamExt::collect::<Vec<_>>(session),
@@ -651,7 +662,13 @@ mod tests {
             wait: Some(wait),
         };
 
-        let session = backend.read(basin, stream, start, end).await.unwrap();
+        let session = backend
+            .open_for_read(&basin, &stream, None)
+            .await
+            .unwrap()
+            .read(start, end)
+            .await
+            .unwrap();
         let mut session = Box::pin(session);
         let probe_step = Duration::from_millis(1);
         let first = session
@@ -660,7 +677,7 @@ mod tests {
             .await
             .expect("session should enter follow mode")
             .expect("session should not error");
-        assert!(matches!(first, StoredReadSessionOutput::Heartbeat(_)));
+        assert!(matches!(first, ReadSessionOutput::Heartbeat(_)));
 
         let started = Instant::now();
         let second = match poll_next_after_advance(&mut session, wait).await {
@@ -668,12 +685,12 @@ mod tests {
             Poll::Ready(None) => panic!("session closed before emitting a follow heartbeat"),
             Poll::Pending => panic!("expected a follow heartbeat before the wait budget expired"),
         };
-        assert!(matches!(second, StoredReadSessionOutput::Heartbeat(_)));
+        assert!(matches!(second, ReadSessionOutput::Heartbeat(_)));
 
         tokio::task::yield_now().await;
         let closed_at = loop {
             match futures::poll!(session.as_mut().next()) {
-                Poll::Ready(Some(Ok(StoredReadSessionOutput::Heartbeat(_)))) => {}
+                Poll::Ready(Some(Ok(ReadSessionOutput::Heartbeat(_)))) => {}
                 Poll::Ready(Some(Ok(output))) => {
                     panic!("unexpected output after wait deadline: {output:?}");
                 }
@@ -713,11 +730,13 @@ mod tests {
             .await
             .unwrap();
 
-        let initial_input = stored_append_input(
-            Record::try_from_parts(vec![], bytes::Bytes::from("initial")).unwrap(),
-        );
+        let initial_input =
+            append_input(Record::try_from_parts(vec![], bytes::Bytes::from("initial")).unwrap());
         backend
-            .append(basin.clone(), stream.clone(), initial_input)
+            .open_for_append(&basin, &stream, None)
+            .await
+            .unwrap()
+            .append(initial_input)
             .await
             .unwrap();
 
@@ -734,7 +753,10 @@ mod tests {
         };
 
         let session = backend
-            .read(basin.clone(), stream.clone(), start, end)
+            .open_for_read(&basin, &stream, None)
+            .await
+            .unwrap()
+            .read(start, end)
             .await
             .unwrap();
         let mut session = Box::pin(session);
@@ -745,15 +767,14 @@ mod tests {
             .await
             .expect("session should yield the initial batch")
             .expect("session should not error");
-        let StoredReadSessionOutput::Batch(batch) = first else {
+        let ReadSessionOutput::Batch(batch) = first else {
             panic!("expected initial batch");
         };
         let initial_record = batch
             .records
             .first()
             .expect("batch should contain one record");
-        let StoredRecord::Plaintext(Record::Envelope(initial_envelope)) = initial_record.inner()
-        else {
+        let Record::Envelope(initial_envelope) = initial_record.inner() else {
             panic!("expected plaintext envelope record");
         };
         assert_eq!(initial_envelope.body().as_ref(), b"initial");
@@ -764,15 +785,20 @@ mod tests {
             .await
             .expect("session should enter follow mode")
             .expect("session should not error");
-        assert!(matches!(second, StoredReadSessionOutput::Heartbeat(_)));
+        assert!(matches!(second, ReadSessionOutput::Heartbeat(_)));
 
         tokio::time::advance(Duration::from_millis(20)).await;
         tokio::task::yield_now().await;
 
-        let follow_input = stored_append_input(
-            Record::try_from_parts(vec![], bytes::Bytes::from("follow-1")).unwrap(),
-        );
-        backend.append(basin, stream, follow_input).await.unwrap();
+        let follow_input =
+            append_input(Record::try_from_parts(vec![], bytes::Bytes::from("follow-1")).unwrap());
+        backend
+            .open_for_append(&basin, &stream, None)
+            .await
+            .unwrap()
+            .append(follow_input)
+            .await
+            .unwrap();
 
         let follow = session
             .as_mut()
@@ -781,15 +807,14 @@ mod tests {
             .expect("session should deliver the live batch")
             .expect("session should not error");
         let reset_at = Instant::now();
-        let StoredReadSessionOutput::Batch(batch) = follow else {
+        let ReadSessionOutput::Batch(batch) = follow else {
             panic!("expected live batch after append");
         };
         let follow_record = batch
             .records
             .first()
             .expect("batch should contain one record");
-        let StoredRecord::Plaintext(Record::Envelope(follow_envelope)) = follow_record.inner()
-        else {
+        let Record::Envelope(follow_envelope) = follow_record.inner() else {
             panic!("expected plaintext envelope record");
         };
         assert_eq!(follow_envelope.body().as_ref(), b"follow-1");
@@ -799,7 +824,7 @@ mod tests {
 
         loop {
             match futures::poll!(session.as_mut().next()) {
-                Poll::Ready(Some(Ok(StoredReadSessionOutput::Heartbeat(_)))) => {}
+                Poll::Ready(Some(Ok(ReadSessionOutput::Heartbeat(_)))) => {}
                 Poll::Ready(Some(Ok(output))) => {
                     panic!("unexpected output before the reset wait deadline: {output:?}");
                 }
@@ -816,7 +841,7 @@ mod tests {
 
         let closed_at = loop {
             match futures::poll!(session.as_mut().next()) {
-                Poll::Ready(Some(Ok(StoredReadSessionOutput::Heartbeat(_)))) => {}
+                Poll::Ready(Some(Ok(ReadSessionOutput::Heartbeat(_)))) => {}
                 Poll::Ready(Some(Ok(output))) => {
                     panic!("unexpected output after the reset wait deadline: {output:?}");
                 }
@@ -869,7 +894,10 @@ mod tests {
             wait: Some(wait),
         };
         let session = backend
-            .read(basin.clone(), stream.clone(), start, end)
+            .open_for_read(&basin, &stream, None)
+            .await
+            .unwrap()
+            .read(start, end)
             .await
             .unwrap();
         let mut session = Box::pin(session);
@@ -880,18 +908,21 @@ mod tests {
             .await
             .expect("session should enter follow mode")
             .expect("session should not error");
-        assert!(matches!(first, StoredReadSessionOutput::Heartbeat(_)));
+        assert!(matches!(first, ReadSessionOutput::Heartbeat(_)));
 
         let stream_id = StreamId::new(&basin, &stream);
         let mut delete_batch = WriteBatch::new();
         let lagged_appends = FOLLOWER_MAX_LAG + 25;
 
         for i in 0..lagged_appends {
-            let input = stored_append_input(
+            let input = append_input(
                 Record::try_from_parts(vec![], bytes::Bytes::from(format!("lagged-{i}"))).unwrap(),
             );
             let ack = backend
-                .append(basin.clone(), stream.clone(), input)
+                .open_for_append(&basin, &stream, None)
+                .await
+                .unwrap()
+                .append(input)
                 .await
                 .unwrap();
             delete_batch.delete(kv::stream_record_data::ser_key(stream_id, ack.start));
@@ -942,11 +973,13 @@ mod tests {
             .await
             .unwrap();
 
-        let initial_input = stored_append_input(
-            Record::try_from_parts(vec![], bytes::Bytes::from("initial")).unwrap(),
-        );
+        let initial_input =
+            append_input(Record::try_from_parts(vec![], bytes::Bytes::from("initial")).unwrap());
         backend
-            .append(basin.clone(), stream.clone(), initial_input)
+            .open_for_append(&basin, &stream, None)
+            .await
+            .unwrap()
+            .append(initial_input)
             .await
             .unwrap();
 
@@ -960,7 +993,10 @@ mod tests {
             wait: None,
         };
         let session = backend
-            .read(basin.clone(), stream.clone(), start, end)
+            .open_for_read(&basin, &stream, None)
+            .await
+            .unwrap()
+            .read(start, end)
             .await
             .unwrap();
         let mut session = Box::pin(session);
@@ -971,7 +1007,7 @@ mod tests {
             .await
             .expect("session should yield initial batch")
             .expect("session should not error");
-        assert!(matches!(first, StoredReadSessionOutput::Batch(_)));
+        assert!(matches!(first, ReadSessionOutput::Batch(_)));
 
         let second = session
             .as_mut()
@@ -979,15 +1015,20 @@ mod tests {
             .await
             .expect("session should enter follow mode")
             .expect("session should not error");
-        assert!(matches!(second, StoredReadSessionOutput::Heartbeat(_)));
+        assert!(matches!(second, ReadSessionOutput::Heartbeat(_)));
 
         tokio::time::advance(DORMANT_TIMEOUT + Duration::from_secs(1)).await;
         tokio::task::yield_now().await;
 
-        let follow_input = stored_append_input(
-            Record::try_from_parts(vec![], bytes::Bytes::from("follow-1")).unwrap(),
-        );
-        backend.append(basin, stream, follow_input).await.unwrap();
+        let follow_input =
+            append_input(Record::try_from_parts(vec![], bytes::Bytes::from("follow-1")).unwrap());
+        backend
+            .open_for_append(&basin, &stream, None)
+            .await
+            .unwrap()
+            .append(follow_input)
+            .await
+            .unwrap();
 
         let next = session
             .as_mut()
@@ -995,12 +1036,12 @@ mod tests {
             .await
             .expect("session should stay open after dormancy")
             .expect("session should not error after dormancy");
-        let StoredReadSessionOutput::Batch(batch) = next else {
+        let ReadSessionOutput::Batch(batch) = next else {
             panic!("expected new batch after append");
         };
         assert_eq!(batch.records.len(), 1);
         let record = batch.records.first().expect("batch should have one record");
-        let StoredRecord::Plaintext(Record::Envelope(envelope)) = record.inner() else {
+        let Record::Envelope(envelope) = record.inner() else {
             panic!("expected envelope record");
         };
         assert_eq!(envelope.body().as_ref(), b"follow-1");

--- a/lite/src/backend/read.rs
+++ b/lite/src/backend/read.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use futures::Stream;
 use s2_common::{
     caps,
-    encryption::{EncryptionKey, EncryptionSpec},
     read_extent::{EvaluatedReadLimit, ReadLimit, ReadUntil},
     record::{Metered, MeteredSize as _, SeqNum, StoredSequencedRecord, StreamPosition, Timestamp},
     types::{
@@ -23,9 +22,9 @@ use super::{Backend, StreamHandle, core::StreamLookup};
 use crate::{
     backend::{
         error::{
-            BasinDeletionPendingError, BasinNotFoundError, CheckTailError, ReadError,
-            ResolveReadError, StorageError, StreamDeletionPendingError, StreamNotFoundError,
-            StreamerError, StreamerMissingInActionError, TransactionConflictError, UnwrittenError,
+            BasinDeletionPendingError, BasinNotFoundError, CheckTailError, ReadError, StorageError,
+            StreamDeletionPendingError, StreamNotFoundError, StreamerError,
+            StreamerMissingInActionError, TransactionConflictError, UnwrittenError,
         },
         kv,
     },
@@ -33,7 +32,7 @@ use crate::{
 };
 
 impl Backend {
-    async fn resolve_read_handle<E>(
+    pub(crate) async fn resolve_read_handle<E>(
         &self,
         basin: &BasinName,
         stream: &StreamName,
@@ -64,17 +63,6 @@ impl Backend {
                 })
             }
         }
-    }
-
-    pub(crate) async fn resolve_read_target(
-        &self,
-        basin: &BasinName,
-        stream: &StreamName,
-        encryption_key: Option<EncryptionKey>,
-    ) -> Result<(StreamHandle, EncryptionSpec), ResolveReadError> {
-        let handle = self.resolve_read_handle::<ReadError>(basin, stream).await?;
-        let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
-        Ok((handle, encryption))
     }
 
     async fn read_start_seq_num(

--- a/lite/src/backend/read.rs
+++ b/lite/src/backend/read.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use futures::Stream;
 use s2_common::{
     caps,
+    encryption::{EncryptionKey, EncryptionSpec},
     read_extent::{EvaluatedReadLimit, ReadLimit, ReadUntil},
     record::{Metered, MeteredSize as _, SeqNum, StoredSequencedRecord, StreamPosition, Timestamp},
     types::{
@@ -18,11 +19,13 @@ use slatedb::{
 };
 use tokio::{sync::broadcast, time::Instant};
 
-use super::{Backend, StreamHandle};
+use super::{Backend, StreamHandle, core::StreamLookup};
 use crate::{
     backend::{
         error::{
-            CheckTailError, ReadError, StorageError, StreamerMissingInActionError, UnwrittenError,
+            BasinDeletionPendingError, BasinNotFoundError, CheckTailError, ReadError,
+            ResolveReadError, StorageError, StreamDeletionPendingError, StreamNotFoundError,
+            StreamerError, StreamerMissingInActionError, TransactionConflictError, UnwrittenError,
         },
         kv,
     },
@@ -30,6 +33,50 @@ use crate::{
 };
 
 impl Backend {
+    async fn resolve_read_handle<E>(
+        &self,
+        basin: &BasinName,
+        stream: &StreamName,
+    ) -> Result<StreamHandle, E>
+    where
+        E: From<StreamerError>
+            + From<StorageError>
+            + From<BasinNotFoundError>
+            + From<TransactionConflictError>
+            + From<BasinDeletionPendingError>
+            + From<StreamDeletionPendingError>
+            + From<StreamNotFoundError>,
+    {
+        match self.lookup_stream::<E>(basin, stream).await? {
+            StreamLookup::Found(handle) => Ok(handle),
+            StreamLookup::Missing {
+                basin_config,
+                not_found,
+            } => {
+                if !basin_config.create_stream_on_read {
+                    return Err(not_found.into());
+                }
+                self.create_stream_if_missing::<E>(basin, stream).await?;
+                let client = self.streamer_client(basin, stream).await?;
+                Ok(StreamHandle {
+                    backend: self.clone(),
+                    client,
+                })
+            }
+        }
+    }
+
+    pub(crate) async fn resolve_read_target(
+        &self,
+        basin: &BasinName,
+        stream: &StreamName,
+        encryption_key: Option<EncryptionKey>,
+    ) -> Result<(StreamHandle, EncryptionSpec), ResolveReadError> {
+        let handle = self.resolve_read_handle::<ReadError>(basin, stream).await?;
+        let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
+        Ok((handle, encryption))
+    }
+
     async fn read_start_seq_num(
         &self,
         stream_id: StreamId,
@@ -79,9 +126,7 @@ impl Backend {
         stream: StreamName,
     ) -> Result<StreamPosition, CheckTailError> {
         let handle = self
-            .stream_handle_with_auto_create::<CheckTailError>(&basin, &stream, |config| {
-                config.create_stream_on_read
-            })
+            .resolve_read_handle::<CheckTailError>(&basin, &stream)
             .await?;
         handle.check_tail().await
     }
@@ -95,9 +140,7 @@ impl Backend {
     ) -> Result<impl Stream<Item = Result<StoredReadSessionOutput, ReadError>> + 'static, ReadError>
     {
         let handle = self
-            .stream_handle_with_auto_create::<ReadError>(&basin, &stream, |config| {
-                config.create_stream_on_read
-            })
+            .resolve_read_handle::<ReadError>(&basin, &stream)
             .await?;
         handle.read(start, end).await
     }

--- a/lite/src/backend/read.rs
+++ b/lite/src/backend/read.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 
 impl Backend {
-    pub async fn resolve_read_handle<E>(
+    pub async fn open_for_read<E>(
         &self,
         basin: &BasinName,
         stream: &StreamName,
@@ -101,7 +101,7 @@ impl Backend {
         stream: StreamName,
     ) -> Result<StreamPosition, CheckTailError> {
         let handle = self
-            .resolve_read_handle::<CheckTailError>(&basin, &stream)
+            .open_for_read::<CheckTailError>(&basin, &stream)
             .await?;
         handle.check_tail().await
     }
@@ -114,9 +114,7 @@ impl Backend {
         end: ReadEnd,
     ) -> Result<impl Stream<Item = Result<StoredReadSessionOutput, ReadError>> + 'static, ReadError>
     {
-        let handle = self
-            .resolve_read_handle::<ReadError>(&basin, &stream)
-            .await?;
+        let handle = self.open_for_read::<ReadError>(&basin, &stream).await?;
         handle.read(start, end).await
     }
 }

--- a/lite/src/backend/read.rs
+++ b/lite/src/backend/read.rs
@@ -131,12 +131,11 @@ impl StreamHandle {
         end: ReadEnd,
     ) -> Result<impl Stream<Item = Result<StoredReadSessionOutput, ReadError>> + 'static, ReadError>
     {
-        let backend = self.backend;
-        let client = self.client;
-        let stream_id = client.stream_id();
-        let tail = client.check_tail().await?;
+        let stream_id = self.client.stream_id();
+        let tail = self.client.check_tail().await?;
         let mut state = ReadSessionState {
-            start_seq_num: backend
+            start_seq_num: self
+                .backend
                 .read_start_seq_num(stream_id, start, end, tail)
                 .await?,
             limit: EvaluatedReadLimit::Remaining(end.limit),
@@ -145,7 +144,7 @@ impl StreamHandle {
             wait_deadline: None,
             tail,
         };
-        let db = backend.db.clone();
+        let db = self.backend.db.clone();
         let session = async_stream::try_stream! {
             'session: while let EvaluatedReadLimit::Remaining(limit) = state.limit {
                 if state.start_seq_num < state.tail.seq_num {
@@ -229,7 +228,7 @@ impl StreamHandle {
                     if !end.may_follow() {
                         break;
                     }
-                    match client.follow(state.start_seq_num).await? {
+                    match self.client.follow(state.start_seq_num).await? {
                         Ok(mut follow_rx) => {
                             // Only a delivered batch should reset the absolute wait budget.
                             state.arm_wait_deadline_if_unset();

--- a/lite/src/backend/read.rs
+++ b/lite/src/backend/read.rs
@@ -18,7 +18,7 @@ use slatedb::{
 };
 use tokio::{sync::broadcast, time::Instant};
 
-use super::{Backend, StreamHandle, core::StreamLookup};
+use super::{Backend, StreamHandle};
 use crate::{
     backend::{
         error::{
@@ -32,7 +32,7 @@ use crate::{
 };
 
 impl Backend {
-    pub(crate) async fn resolve_read_handle<E>(
+    pub async fn resolve_read_handle<E>(
         &self,
         basin: &BasinName,
         stream: &StreamName,
@@ -46,23 +46,10 @@ impl Backend {
             + From<StreamDeletionPendingError>
             + From<StreamNotFoundError>,
     {
-        match self.lookup_stream::<E>(basin, stream).await? {
-            StreamLookup::Found(handle) => Ok(handle),
-            StreamLookup::Missing {
-                basin_config,
-                not_found,
-            } => {
-                if !basin_config.create_stream_on_read {
-                    return Err(not_found.into());
-                }
-                self.create_stream_if_missing::<E>(basin, stream).await?;
-                let client = self.streamer_client(basin, stream).await?;
-                Ok(StreamHandle {
-                    backend: self.clone(),
-                    client,
-                })
-            }
-        }
+        self.stream_handle_with_auto_create::<E>(basin, stream, |config| {
+            config.create_stream_on_read
+        })
+        .await
     }
 
     async fn read_start_seq_num(
@@ -135,12 +122,12 @@ impl Backend {
 }
 
 impl StreamHandle {
-    pub(crate) async fn check_tail(self) -> Result<StreamPosition, CheckTailError> {
+    pub async fn check_tail(self) -> Result<StreamPosition, CheckTailError> {
         let tail = self.client.check_tail().await?;
         Ok(tail)
     }
 
-    pub(crate) async fn read(
+    pub async fn read(
         self,
         start: ReadStart,
         end: ReadEnd,

--- a/lite/src/backend/read.rs
+++ b/lite/src/backend/read.rs
@@ -18,7 +18,7 @@ use slatedb::{
 };
 use tokio::{sync::broadcast, time::Instant};
 
-use super::Backend;
+use super::{Backend, StreamHandle};
 use crate::{
     backend::{
         error::{
@@ -78,13 +78,12 @@ impl Backend {
         basin: BasinName,
         stream: StreamName,
     ) -> Result<StreamPosition, CheckTailError> {
-        let client = self
-            .streamer_client_with_auto_create::<CheckTailError>(&basin, &stream, |config| {
+        let handle = self
+            .stream_handle_with_auto_create::<CheckTailError>(&basin, &stream, |config| {
                 config.create_stream_on_read
             })
             .await?;
-        let tail = client.check_tail().await?;
-        Ok(tail)
+        handle.check_tail().await
     }
 
     pub async fn read(
@@ -95,22 +94,42 @@ impl Backend {
         end: ReadEnd,
     ) -> Result<impl Stream<Item = Result<StoredReadSessionOutput, ReadError>> + 'static, ReadError>
     {
-        let client = self
-            .streamer_client_with_auto_create::<ReadError>(&basin, &stream, |config| {
+        let handle = self
+            .stream_handle_with_auto_create::<ReadError>(&basin, &stream, |config| {
                 config.create_stream_on_read
             })
             .await?;
+        handle.read(start, end).await
+    }
+}
+
+impl StreamHandle {
+    pub(crate) async fn check_tail(self) -> Result<StreamPosition, CheckTailError> {
+        let tail = self.client.check_tail().await?;
+        Ok(tail)
+    }
+
+    pub(crate) async fn read(
+        self,
+        start: ReadStart,
+        end: ReadEnd,
+    ) -> Result<impl Stream<Item = Result<StoredReadSessionOutput, ReadError>> + 'static, ReadError>
+    {
+        let backend = self.backend;
+        let client = self.client;
         let stream_id = client.stream_id();
         let tail = client.check_tail().await?;
         let mut state = ReadSessionState {
-            start_seq_num: self.read_start_seq_num(stream_id, start, end, tail).await?,
+            start_seq_num: backend
+                .read_start_seq_num(stream_id, start, end, tail)
+                .await?,
             limit: EvaluatedReadLimit::Remaining(end.limit),
             until: end.until,
             wait: end.wait,
             wait_deadline: None,
             tail,
         };
-        let db = self.db.clone();
+        let db = backend.db.clone();
         let session = async_stream::try_stream! {
             'session: while let EvaluatedReadLimit::Remaining(limit) = state.limit {
                 if state.start_seq_num < state.tail.seq_num {
@@ -251,7 +270,9 @@ impl Backend {
         };
         Ok(session)
     }
+}
 
+impl Backend {
     pub(super) async fn resolve_timestamp(
         &self,
         stream_id: StreamId,

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -738,11 +738,10 @@ fn sequenced_records(
         match record.as_ref().into_inner() {
             StoredRecord::Plaintext(Record::Command(_)) => {}
             sr @ StoredRecord::Plaintext(_) | sr @ StoredRecord::Encrypted { .. } => {
-                let actual_algorithm = sr.encryption_algorithm();
-                if actual_algorithm != expected_encryption_algorithm {
+                if expected_encryption_algorithm != sr.encryption_algorithm() {
                     Err(EncryptionAlgorithmMismatchError {
                         expected: expected_encryption_algorithm,
-                        actual: actual_algorithm,
+                        actual: sr.encryption_algorithm(),
                     })?;
                 }
             }

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -835,7 +835,7 @@ mod tests {
 
     use bytes::Bytes;
     use s2_common::{
-        encryption::{Encryption, EncryptionAlgorithm},
+        encryption::{EncryptionAlgorithm, EncryptionSpec},
         record::{EnvelopeRecord, Metered, Record, StoredRecord},
         types::stream::{
             StoredAppendInput, StoredAppendRecord, StoredAppendRecordBatch, StoredAppendRecordParts,
@@ -866,7 +866,7 @@ mod tests {
         let envelope = EnvelopeRecord::try_from_parts(vec![], body).unwrap();
         let record = s2_common::record::encrypt_record(
             Metered::from(Record::Envelope(envelope)),
-            &Encryption::aegis256([0x42; 32]),
+            &EncryptionSpec::aegis256([0x42; 32]),
             b"test-streamer",
         );
         let parts = StoredAppendRecordParts { timestamp, record };

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -13,7 +13,7 @@ use futures::{
     future::{BoxFuture, OptionFuture},
 };
 use s2_common::{
-    encryption::{EncryptionAlgorithm, EncryptionMode},
+    encryption::EncryptionAlgorithm,
     record::{
         CommandRecord, FencingToken, Metered, MeteredSize, NonZeroSeqNum, Record, SeqNum,
         StoredRecord, StoredSequencedRecord, StreamPosition, Timestamp,
@@ -44,7 +44,7 @@ use crate::{
         durability_notifier::DurabilityNotifier,
         error::{
             AppendConditionFailedError, AppendErrorInternal, AppendTimestampRequiredError,
-            DeleteStreamError, EncryptionModeMismatchError, RequestDroppedError,
+            DeleteStreamError, EncryptionAlgorithmMismatchError, RequestDroppedError,
             StreamerMissingInActionError,
         },
         kv,
@@ -242,7 +242,7 @@ impl Streamer {
             first_seq_num,
             next_assignable_pos.timestamp,
             &self.config.timestamping,
-            expected_encryption_mode(self.encryption_algorithm),
+            self.encryption_algorithm,
         )
     }
 
@@ -639,7 +639,7 @@ impl StreamerClient {
                 }
                 AppendErrorInternal::ConditionFailed(_) => unreachable!("unconditional write"),
                 AppendErrorInternal::TimestampMissing(_) => unreachable!("Timestamp::MAX used"),
-                AppendErrorInternal::EncryptionModeMismatch(_) => {
+                AppendErrorInternal::EncryptionAlgorithmMismatch(_) => {
                     unreachable!("terminal append is plaintext command record")
                 }
             }),
@@ -723,7 +723,7 @@ fn sequenced_records(
     first_seq_num: SeqNum,
     prev_max_timestamp: Timestamp,
     config: &OptionalTimestampingConfig,
-    expected_encryption_mode: EncryptionMode,
+    expected_encryption_algorithm: Option<EncryptionAlgorithm>,
 ) -> Result<Vec<Metered<StoredSequencedRecord>>, AppendErrorInternal> {
     let mode = config.mode.unwrap_or_default();
     let uncapped = config.uncapped.unwrap_or_default();
@@ -738,11 +738,11 @@ fn sequenced_records(
         match record.as_ref().into_inner() {
             StoredRecord::Plaintext(Record::Command(_)) => {}
             sr @ StoredRecord::Plaintext(_) | sr @ StoredRecord::Encrypted { .. } => {
-                let actual_mode = sr.encryption_mode();
-                if actual_mode != expected_encryption_mode {
-                    Err(EncryptionModeMismatchError {
-                        expected: expected_encryption_mode,
-                        actual: actual_mode,
+                let actual_algorithm = sr.encryption_algorithm();
+                if actual_algorithm != expected_encryption_algorithm {
+                    Err(EncryptionAlgorithmMismatchError {
+                        expected: expected_encryption_algorithm,
+                        actual: actual_algorithm,
                     })?;
                 }
             }
@@ -767,10 +767,6 @@ fn sequenced_records(
         }));
     }
     Ok(sequenced_records)
-}
-
-fn expected_encryption_mode(algorithm: Option<EncryptionAlgorithm>) -> EncryptionMode {
-    algorithm.map(Into::into).unwrap_or(EncryptionMode::Plain)
 }
 
 async fn db_submit_append(
@@ -839,7 +835,7 @@ mod tests {
 
     use bytes::Bytes;
     use s2_common::{
-        encryption::{Encryption, EncryptionMode},
+        encryption::{Encryption, EncryptionAlgorithm},
         record::{EnvelopeRecord, Metered, Record, StoredRecord},
         types::stream::{
             StoredAppendInput, StoredAppendRecord, StoredAppendRecordBatch, StoredAppendRecordParts,
@@ -891,7 +887,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain).unwrap();
+        let result = sequenced_records(records, 100, 0, &config, None).unwrap();
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].position().seq_num, 100);
@@ -915,7 +911,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain).unwrap();
+        let result = sequenced_records(records, 100, 0, &config, None).unwrap();
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].position().seq_num, 100);
@@ -935,7 +931,7 @@ mod tests {
             .try_into()
             .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain);
+        let result = sequenced_records(records, 100, 0, &config, None);
 
         assert!(matches!(
             result,
@@ -957,7 +953,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain).unwrap();
+        let result = sequenced_records(records, 100, 0, &config, None).unwrap();
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].position().timestamp, 900);
@@ -979,7 +975,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain).unwrap();
+        let result = sequenced_records(records, 100, 0, &config, None).unwrap();
 
         assert_eq!(result.len(), 2);
         assert!(result[0].position().timestamp >= now);
@@ -1001,7 +997,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain).unwrap();
+        let result = sequenced_records(records, 100, 0, &config, None).unwrap();
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].position().timestamp, 1000);
@@ -1023,7 +1019,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, 100, 1000, &config, EncryptionMode::Plain).unwrap();
+        let result = sequenced_records(records, 100, 1000, &config, None).unwrap();
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].position().timestamp, 1000);
@@ -1044,7 +1040,7 @@ mod tests {
                 .try_into()
                 .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain).unwrap();
+        let result = sequenced_records(records, 100, 0, &config, None).unwrap();
 
         assert_eq!(result.len(), 1);
         assert!(result[0].position().timestamp <= now + 100);
@@ -1064,7 +1060,7 @@ mod tests {
                 .try_into()
                 .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain).unwrap();
+        let result = sequenced_records(records, 100, 0, &config, None).unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].position().timestamp, future);
@@ -1082,7 +1078,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, 42, 0, &config, EncryptionMode::Plain).unwrap();
+        let result = sequenced_records(records, 42, 0, &config, None).unwrap();
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].position().seq_num, 42);
@@ -1093,14 +1089,15 @@ mod tests {
     #[test]
     fn sequenced_records_skip_encryption_check_for_command_records() {
         let config = OptionalTimestampingConfig::default();
-        let expected_encryption_mode = EncryptionMode::Aegis256;
+        let expected_encryption_algorithm = Some(EncryptionAlgorithm::Aegis256);
 
         let records: StoredAppendRecordBatch =
             vec![test_command_record(CommandRecord::Trim(42), None)]
                 .try_into()
                 .unwrap();
 
-        let result = sequenced_records(records, 42, 0, &config, expected_encryption_mode).unwrap();
+        let result =
+            sequenced_records(records, 42, 0, &config, expected_encryption_algorithm).unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].position().seq_num, 42);
@@ -1109,21 +1106,21 @@ mod tests {
     #[test]
     fn sequenced_records_reject_disallowed_encrypted_envelope_records() {
         let config = OptionalTimestampingConfig::default();
-        let expected_encryption_mode = EncryptionMode::Aes256Gcm;
+        let expected_encryption_algorithm = Some(EncryptionAlgorithm::Aes256Gcm);
 
         let records: StoredAppendRecordBatch =
             vec![test_encrypted_record(vec![1, 2, 3].into(), None)]
                 .try_into()
                 .unwrap();
 
-        let result = sequenced_records(records, 42, 0, &config, expected_encryption_mode);
+        let result = sequenced_records(records, 42, 0, &config, expected_encryption_algorithm);
 
         assert!(matches!(
             result,
-            Err(AppendErrorInternal::EncryptionModeMismatch(
-                EncryptionModeMismatchError {
-                    expected: EncryptionMode::Aes256Gcm,
-                    actual: EncryptionMode::Aegis256,
+            Err(AppendErrorInternal::EncryptionAlgorithmMismatch(
+                EncryptionAlgorithmMismatchError {
+                    expected: Some(EncryptionAlgorithm::Aes256Gcm),
+                    actual: Some(EncryptionAlgorithm::Aegis256),
                 }
             ))
         ));

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -8,21 +8,19 @@ use std::{
     time::Duration,
 };
 
-use enumset::EnumSet;
 use futures::{
     FutureExt as _,
     future::{BoxFuture, OptionFuture},
 };
 use s2_common::{
-    encryption::EncryptionMode,
+    encryption::{EncryptionAlgorithm, EncryptionMode},
     record::{
         CommandRecord, FencingToken, Metered, MeteredSize, NonZeroSeqNum, Record, SeqNum,
         StoredRecord, StoredSequencedRecord, StreamPosition, Timestamp,
     },
     types::{
         config::{
-            DEFAULT_ALLOWED_ENCRYPTION_MODES, OptionalStreamConfig, OptionalTimestampingConfig,
-            RetentionPolicy, TimestampingMode,
+            OptionalStreamConfig, OptionalTimestampingConfig, RetentionPolicy, TimestampingMode,
         },
         stream::{
             AppendAck, StoredAppendInput, StoredAppendRecord, StoredAppendRecordBatch,
@@ -46,7 +44,7 @@ use crate::{
         durability_notifier::DurabilityNotifier,
         error::{
             AppendConditionFailedError, AppendErrorInternal, AppendTimestampRequiredError,
-            DeleteStreamError, EncryptionModeNotAllowedError, RequestDroppedError,
+            DeleteStreamError, EncryptionModeMismatchError, RequestDroppedError,
             StreamerMissingInActionError,
         },
         kv,
@@ -99,6 +97,7 @@ pub(super) struct Spawner {
     pub db: slatedb::Db,
     pub stream_id: StreamId,
     pub config: OptionalStreamConfig,
+    pub encryption_algorithm: Option<EncryptionAlgorithm>,
     pub tail_pos: StreamPosition,
     pub fencing_token: FencingToken,
     pub trim_point: RangeTo<SeqNum>,
@@ -113,6 +112,7 @@ impl Spawner {
             db,
             stream_id,
             config,
+            encryption_algorithm,
             tail_pos,
             fencing_token,
             trim_point,
@@ -127,6 +127,7 @@ impl Spawner {
             stream_id,
             msg_tx: msg_tx.clone(),
             config,
+            encryption_algorithm,
             fencing_token: CommandState {
                 state: fencing_token,
                 applied_point: ..tail_pos.seq_num,
@@ -157,6 +158,7 @@ impl Spawner {
         StreamerClient {
             id,
             stream_id,
+            encryption_algorithm,
             msg_tx,
             append_inflight_bytes: append_inflight_bytes_sema,
         }
@@ -186,6 +188,7 @@ struct Streamer {
     stream_id: StreamId,
     msg_tx: mpsc::UnboundedSender<Message>,
     config: OptionalStreamConfig,
+    encryption_algorithm: Option<EncryptionAlgorithm>,
     fencing_token: CommandState<FencingToken>,
     trim_point: CommandState<RangeTo<SeqNum>>,
     last_doe_deadline_at: Option<Instant>,
@@ -234,17 +237,12 @@ impl Streamer {
                 match_seq_num,
             })?;
         }
-        let allowed_encryption_modes = if self.config.encryption.allowed_modes.is_empty() {
-            DEFAULT_ALLOWED_ENCRYPTION_MODES
-        } else {
-            self.config.encryption.allowed_modes
-        };
         sequenced_records(
             records,
             first_seq_num,
             next_assignable_pos.timestamp,
             &self.config.timestamping,
-            allowed_encryption_modes,
+            expected_encryption_mode(self.encryption_algorithm),
         )
     }
 
@@ -539,6 +537,7 @@ impl Drop for FollowGuard {
 pub(super) struct StreamerClient {
     id: StreamerId,
     stream_id: StreamId,
+    encryption_algorithm: Option<EncryptionAlgorithm>,
     msg_tx: mpsc::UnboundedSender<Message>,
     append_inflight_bytes: Arc<Semaphore>,
 }
@@ -554,6 +553,10 @@ impl StreamerClient {
 
     pub fn stream_id(&self) -> StreamId {
         self.stream_id
+    }
+
+    pub fn encryption_algorithm(&self) -> Option<EncryptionAlgorithm> {
+        self.encryption_algorithm
     }
 
     pub async fn check_tail(&self) -> Result<StreamPosition, StreamerMissingInActionError> {
@@ -636,7 +639,7 @@ impl StreamerClient {
                 }
                 AppendErrorInternal::ConditionFailed(_) => unreachable!("unconditional write"),
                 AppendErrorInternal::TimestampMissing(_) => unreachable!("Timestamp::MAX used"),
-                AppendErrorInternal::EncryptionModeNotAllowed(_) => {
+                AppendErrorInternal::EncryptionModeMismatch(_) => {
                     unreachable!("terminal append is plaintext command record")
                 }
             }),
@@ -720,7 +723,7 @@ fn sequenced_records(
     first_seq_num: SeqNum,
     prev_max_timestamp: Timestamp,
     config: &OptionalTimestampingConfig,
-    allowed_encryption_modes: EnumSet<EncryptionMode>,
+    expected_encryption_mode: EncryptionMode,
 ) -> Result<Vec<Metered<StoredSequencedRecord>>, AppendErrorInternal> {
     let mode = config.mode.unwrap_or_default();
     let uncapped = config.uncapped.unwrap_or_default();
@@ -735,9 +738,12 @@ fn sequenced_records(
         match record.as_ref().into_inner() {
             StoredRecord::Plaintext(Record::Command(_)) => {}
             sr @ StoredRecord::Plaintext(_) | sr @ StoredRecord::Encrypted { .. } => {
-                let mode = sr.encryption_mode();
-                if !allowed_encryption_modes.contains(mode) {
-                    Err(EncryptionModeNotAllowedError(mode))?;
+                let actual_mode = sr.encryption_mode();
+                if actual_mode != expected_encryption_mode {
+                    Err(EncryptionModeMismatchError {
+                        expected: expected_encryption_mode,
+                        actual: actual_mode,
+                    })?;
                 }
             }
         }
@@ -761,6 +767,10 @@ fn sequenced_records(
         }));
     }
     Ok(sequenced_records)
+}
+
+fn expected_encryption_mode(algorithm: Option<EncryptionAlgorithm>) -> EncryptionMode {
+    algorithm.map(Into::into).unwrap_or(EncryptionMode::Plain)
 }
 
 async fn db_submit_append(
@@ -829,7 +839,7 @@ mod tests {
 
     use bytes::Bytes;
     use s2_common::{
-        encryption::{EncryptionMode, EncryptionSpec},
+        encryption::{Encryption, EncryptionMode},
         record::{EnvelopeRecord, Metered, Record, StoredRecord},
         types::stream::{
             StoredAppendInput, StoredAppendRecord, StoredAppendRecordBatch, StoredAppendRecordParts,
@@ -860,7 +870,7 @@ mod tests {
         let envelope = EnvelopeRecord::try_from_parts(vec![], body).unwrap();
         let record = s2_common::record::encrypt_record(
             Metered::from(Record::Envelope(envelope)),
-            &EncryptionSpec::aegis256([0x42; 32]),
+            &Encryption::aegis256([0x42; 32]),
             b"test-streamer",
         );
         let parts = StoredAppendRecordParts { timestamp, record };
@@ -881,8 +891,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result =
-            sequenced_records(records, 100, 0, &config, DEFAULT_ALLOWED_ENCRYPTION_MODES).unwrap();
+        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain).unwrap();
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].position().seq_num, 100);
@@ -906,8 +915,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result =
-            sequenced_records(records, 100, 0, &config, DEFAULT_ALLOWED_ENCRYPTION_MODES).unwrap();
+        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain).unwrap();
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].position().seq_num, 100);
@@ -927,7 +935,7 @@ mod tests {
             .try_into()
             .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, DEFAULT_ALLOWED_ENCRYPTION_MODES);
+        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain);
 
         assert!(matches!(
             result,
@@ -949,8 +957,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result =
-            sequenced_records(records, 100, 0, &config, DEFAULT_ALLOWED_ENCRYPTION_MODES).unwrap();
+        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain).unwrap();
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].position().timestamp, 900);
@@ -972,8 +979,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result =
-            sequenced_records(records, 100, 0, &config, DEFAULT_ALLOWED_ENCRYPTION_MODES).unwrap();
+        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain).unwrap();
 
         assert_eq!(result.len(), 2);
         assert!(result[0].position().timestamp >= now);
@@ -995,8 +1001,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result =
-            sequenced_records(records, 100, 0, &config, DEFAULT_ALLOWED_ENCRYPTION_MODES).unwrap();
+        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain).unwrap();
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].position().timestamp, 1000);
@@ -1018,14 +1023,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(
-            records,
-            100,
-            1000,
-            &config,
-            DEFAULT_ALLOWED_ENCRYPTION_MODES,
-        )
-        .unwrap();
+        let result = sequenced_records(records, 100, 1000, &config, EncryptionMode::Plain).unwrap();
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].position().timestamp, 1000);
@@ -1046,8 +1044,7 @@ mod tests {
                 .try_into()
                 .unwrap();
 
-        let result =
-            sequenced_records(records, 100, 0, &config, DEFAULT_ALLOWED_ENCRYPTION_MODES).unwrap();
+        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain).unwrap();
 
         assert_eq!(result.len(), 1);
         assert!(result[0].position().timestamp <= now + 100);
@@ -1067,8 +1064,7 @@ mod tests {
                 .try_into()
                 .unwrap();
 
-        let result =
-            sequenced_records(records, 100, 0, &config, DEFAULT_ALLOWED_ENCRYPTION_MODES).unwrap();
+        let result = sequenced_records(records, 100, 0, &config, EncryptionMode::Plain).unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].position().timestamp, future);
@@ -1086,8 +1082,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result =
-            sequenced_records(records, 42, 0, &config, DEFAULT_ALLOWED_ENCRYPTION_MODES).unwrap();
+        let result = sequenced_records(records, 42, 0, &config, EncryptionMode::Plain).unwrap();
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].position().seq_num, 42);
@@ -1098,14 +1093,14 @@ mod tests {
     #[test]
     fn sequenced_records_skip_encryption_check_for_command_records() {
         let config = OptionalTimestampingConfig::default();
-        let allowed_modes = [EncryptionMode::Aegis256].into();
+        let expected_encryption_mode = EncryptionMode::Aegis256;
 
         let records: StoredAppendRecordBatch =
             vec![test_command_record(CommandRecord::Trim(42), None)]
                 .try_into()
                 .unwrap();
 
-        let result = sequenced_records(records, 42, 0, &config, allowed_modes).unwrap();
+        let result = sequenced_records(records, 42, 0, &config, expected_encryption_mode).unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].position().seq_num, 42);
@@ -1114,19 +1109,22 @@ mod tests {
     #[test]
     fn sequenced_records_reject_disallowed_encrypted_envelope_records() {
         let config = OptionalTimestampingConfig::default();
-        let allowed_modes = [EncryptionMode::Aes256Gcm].into();
+        let expected_encryption_mode = EncryptionMode::Aes256Gcm;
 
         let records: StoredAppendRecordBatch =
             vec![test_encrypted_record(vec![1, 2, 3].into(), None)]
                 .try_into()
                 .unwrap();
 
-        let result = sequenced_records(records, 42, 0, &config, allowed_modes);
+        let result = sequenced_records(records, 42, 0, &config, expected_encryption_mode);
 
         assert!(matches!(
             result,
-            Err(AppendErrorInternal::EncryptionModeNotAllowed(
-                EncryptionModeNotAllowedError(EncryptionMode::Aegis256)
+            Err(AppendErrorInternal::EncryptionModeMismatch(
+                EncryptionModeMismatchError {
+                    expected: EncryptionMode::Aes256Gcm,
+                    actual: EncryptionMode::Aegis256,
+                }
             ))
         ));
     }
@@ -1166,6 +1164,7 @@ mod tests {
             stream_id: [3u8; StreamId::LEN].into(),
             msg_tx,
             config: OptionalStreamConfig::default(),
+            encryption_algorithm: None,
             fencing_token: CommandState {
                 state: FencingToken::default(),
                 applied_point: ..SeqNum::MIN,

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -97,7 +97,7 @@ pub(super) struct Spawner {
     pub db: slatedb::Db,
     pub stream_id: StreamId,
     pub config: OptionalStreamConfig,
-    pub encryption_algorithm: Option<EncryptionAlgorithm>,
+    pub cipher: Option<EncryptionAlgorithm>,
     pub tail_pos: StreamPosition,
     pub fencing_token: FencingToken,
     pub trim_point: RangeTo<SeqNum>,
@@ -112,7 +112,7 @@ impl Spawner {
             db,
             stream_id,
             config,
-            encryption_algorithm,
+            cipher,
             tail_pos,
             fencing_token,
             trim_point,
@@ -127,7 +127,7 @@ impl Spawner {
             stream_id,
             msg_tx: msg_tx.clone(),
             config,
-            encryption_algorithm,
+            cipher,
             fencing_token: CommandState {
                 state: fencing_token,
                 applied_point: ..tail_pos.seq_num,
@@ -158,7 +158,7 @@ impl Spawner {
         StreamerClient {
             id,
             stream_id,
-            encryption_algorithm,
+            cipher,
             msg_tx,
             append_inflight_bytes: append_inflight_bytes_sema,
         }
@@ -188,7 +188,7 @@ struct Streamer {
     stream_id: StreamId,
     msg_tx: mpsc::UnboundedSender<Message>,
     config: OptionalStreamConfig,
-    encryption_algorithm: Option<EncryptionAlgorithm>,
+    cipher: Option<EncryptionAlgorithm>,
     fencing_token: CommandState<FencingToken>,
     trim_point: CommandState<RangeTo<SeqNum>>,
     last_doe_deadline_at: Option<Instant>,
@@ -242,7 +242,7 @@ impl Streamer {
             first_seq_num,
             next_assignable_pos.timestamp,
             &self.config.timestamping,
-            self.encryption_algorithm,
+            self.cipher,
         )
     }
 
@@ -537,7 +537,7 @@ impl Drop for FollowGuard {
 pub(super) struct StreamerClient {
     id: StreamerId,
     stream_id: StreamId,
-    encryption_algorithm: Option<EncryptionAlgorithm>,
+    cipher: Option<EncryptionAlgorithm>,
     msg_tx: mpsc::UnboundedSender<Message>,
     append_inflight_bytes: Arc<Semaphore>,
 }
@@ -555,8 +555,8 @@ impl StreamerClient {
         self.stream_id
     }
 
-    pub fn encryption_algorithm(&self) -> Option<EncryptionAlgorithm> {
-        self.encryption_algorithm
+    pub fn cipher(&self) -> Option<EncryptionAlgorithm> {
+        self.cipher
     }
 
     pub async fn check_tail(&self) -> Result<StreamPosition, StreamerMissingInActionError> {
@@ -1161,7 +1161,7 @@ mod tests {
             stream_id: [3u8; StreamId::LEN].into(),
             msg_tx,
             config: OptionalStreamConfig::default(),
-            encryption_algorithm: None,
+            cipher: None,
             fencing_token: CommandState {
                 state: FencingToken::default(),
                 applied_point: ..SeqNum::MIN,

--- a/lite/src/backend/streams.rs
+++ b/lite/src/backend/streams.rs
@@ -1,11 +1,9 @@
 use s2_common::{
     bash::Bash,
-    encryption::EncryptionMode,
     record::StreamPosition,
     types::{
-        ValidationError,
         basin::BasinName,
-        config::{DEFAULT_ALLOWED_ENCRYPTION_MODES, OptionalStreamConfig, StreamReconfiguration},
+        config::{OptionalStreamConfig, StreamReconfiguration},
         resources::{CreateMode, ListItemsRequestParts, Page, RequestToken},
         stream::{ListStreamsRequest, StreamInfo, StreamName},
     },
@@ -78,6 +76,7 @@ impl Backend {
                 name: stream,
                 created_at: meta.created_at,
                 deleted_at: meta.deleted_at,
+                encryption_algorithm: meta.encryption_algorithm,
             });
         }
         Ok(Page::new(streams, has_more))
@@ -142,6 +141,7 @@ impl Backend {
                             name: stream,
                             created_at: existing_meta.created_at,
                             deleted_at: None,
+                            encryption_algorithm: existing_meta.encryption_algorithm,
                         }))
                     } else {
                         Err(StreamAlreadyExistsError { basin, stream }.into())
@@ -154,24 +154,24 @@ impl Backend {
         }
 
         let is_reconfigure = existing_meta_opt.is_some();
-        let (resolved, created_at) = match existing_meta_opt {
-            Some(existing) => (existing.config.reconfigure(config), existing.created_at),
+        let (resolved, created_at, encryption_algorithm) = match existing_meta_opt {
+            Some(existing) => (
+                existing.config.reconfigure(config),
+                existing.created_at,
+                existing.encryption_algorithm,
+            ),
             None => (
                 OptionalStreamConfig::default().reconfigure(config),
                 OffsetDateTime::now_utc(),
+                basin_meta.config.stream_encryption_algorithm,
             ),
         };
         let basin_defaults = &basin_meta.config.default_stream_config;
-
-        validate_encryption_modes_subset(
-            &resolved.encryption.allowed_modes,
-            basin_defaults.encryption.allowed_modes,
-        )?;
-
         let resolved: OptionalStreamConfig = resolved.merge(basin_defaults.clone()).into();
 
         let meta = kv::stream_meta::StreamMeta {
             config: resolved.clone(),
+            encryption_algorithm,
             created_at,
             deleted_at: None,
             creation_idempotency_key,
@@ -232,6 +232,7 @@ impl Backend {
             name: stream,
             created_at,
             deleted_at: None,
+            encryption_algorithm,
         };
 
         Ok(if is_reconfigure {
@@ -300,32 +301,7 @@ impl Backend {
             .min_age
             .filter(|age| !age.is_zero());
 
-        let encryption_reconfigured =
-            matches!(reconfig.encryption, s2_common::maybe::Maybe::Specified(_));
         meta.config = meta.config.reconfigure(reconfig);
-
-        if encryption_reconfigured {
-            let basin_meta = db_txn_get(
-                &txn,
-                kv::basin_meta::ser_key(&basin),
-                kv::basin_meta::deser_value,
-            )
-            .await?
-            .ok_or_else(|| BasinNotFoundError {
-                basin: basin.clone(),
-            })?;
-            let basin_defaults = &basin_meta.config.default_stream_config;
-            validate_encryption_modes_subset(
-                &meta.config.encryption.allowed_modes,
-                basin_defaults.encryption.allowed_modes,
-            )?;
-            meta.config.encryption = meta
-                .config
-                .encryption
-                .clone()
-                .merge(basin_defaults.encryption.clone())
-                .into();
-        }
 
         txn.put(&meta_key, kv::stream_meta::ser_value(&meta))?;
 
@@ -402,30 +378,6 @@ impl Backend {
 
         Ok(())
     }
-}
-
-fn validate_encryption_modes_subset(
-    stream_modes: &enumset::EnumSet<EncryptionMode>,
-    basin_modes: enumset::EnumSet<EncryptionMode>,
-) -> Result<(), ValidationError> {
-    if stream_modes.is_empty() {
-        return Ok(());
-    }
-
-    let basin_modes = if basin_modes.is_empty() {
-        DEFAULT_ALLOWED_ENCRYPTION_MODES
-    } else {
-        basin_modes
-    };
-
-    if !stream_modes.is_subset(basin_modes) {
-        return Err(ValidationError(
-            "stream encryption modes must be a subset of the default encryption modes for the basin"
-                .to_owned(),
-        ));
-    }
-
-    Ok(())
 }
 
 fn creation_idempotency_key(req_token: &RequestToken, config: &OptionalStreamConfig) -> Bash {

--- a/lite/src/backend/streams.rs
+++ b/lite/src/backend/streams.rs
@@ -163,7 +163,7 @@ impl Backend {
             None => (
                 OptionalStreamConfig::default().reconfigure(config),
                 OffsetDateTime::now_utc(),
-                basin_meta.config.stream_encryption_algorithm,
+                basin_meta.config.stream_cipher,
             ),
         };
         let basin_defaults = &basin_meta.config.default_stream_config;

--- a/lite/src/backend/streams.rs
+++ b/lite/src/backend/streams.rs
@@ -76,7 +76,7 @@ impl Backend {
                 name: stream,
                 created_at: meta.created_at,
                 deleted_at: meta.deleted_at,
-                encryption_algorithm: meta.encryption_algorithm,
+                cipher: meta.cipher,
             });
         }
         Ok(Page::new(streams, has_more))
@@ -141,7 +141,7 @@ impl Backend {
                             name: stream,
                             created_at: existing_meta.created_at,
                             deleted_at: None,
-                            encryption_algorithm: existing_meta.encryption_algorithm,
+                            cipher: existing_meta.cipher,
                         }))
                     } else {
                         Err(StreamAlreadyExistsError { basin, stream }.into())
@@ -154,11 +154,11 @@ impl Backend {
         }
 
         let is_reconfigure = existing_meta_opt.is_some();
-        let (resolved, created_at, encryption_algorithm) = match existing_meta_opt {
+        let (resolved, created_at, cipher) = match existing_meta_opt {
             Some(existing) => (
                 existing.config.reconfigure(config),
                 existing.created_at,
-                existing.encryption_algorithm,
+                existing.cipher,
             ),
             None => (
                 OptionalStreamConfig::default().reconfigure(config),
@@ -171,7 +171,7 @@ impl Backend {
 
         let meta = kv::stream_meta::StreamMeta {
             config: resolved.clone(),
-            encryption_algorithm,
+            cipher,
             created_at,
             deleted_at: None,
             creation_idempotency_key,
@@ -232,7 +232,7 @@ impl Backend {
             name: stream,
             created_at,
             deleted_at: None,
-            encryption_algorithm,
+            cipher,
         };
 
         Ok(if is_reconfigure {

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -19,6 +19,7 @@ use crate::backend::error::{
     AppendConditionFailedError, AppendError, CheckTailError, CreateBasinError, CreateStreamError,
     DeleteBasinError, DeleteStreamError, GetBasinConfigError, GetStreamConfigError,
     ListBasinsError, ListStreamsError, ReadError, ReconfigureBasinError, ReconfigureStreamError,
+    ResolveAppendError, ResolveReadError,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -83,6 +84,24 @@ impl From<AppendRequestRejection> for ServiceError {
 impl From<EncryptionSpecResolutionError> for ServiceError {
     fn from(e: EncryptionSpecResolutionError) -> Self {
         ServiceError::Validation(ValidationError(e.to_string()))
+    }
+}
+
+impl From<ResolveAppendError> for ServiceError {
+    fn from(value: ResolveAppendError) -> Self {
+        match value {
+            ResolveAppendError::Append(e) => ServiceError::Append(e),
+            ResolveAppendError::EncryptionSpecResolution(e) => ServiceError::from(e),
+        }
+    }
+}
+
+impl From<ResolveReadError> for ServiceError {
+    fn from(value: ResolveReadError) -> Self {
+        match value {
+            ResolveReadError::Read(e) => ServiceError::Read(e),
+            ResolveReadError::EncryptionSpecResolution(e) => ServiceError::from(e),
+        }
     }
 }
 

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -38,8 +38,6 @@ pub enum ServiceError {
     #[error(transparent)]
     Validation(#[from] ValidationError),
     #[error(transparent)]
-    EncryptionResolution(#[from] EncryptionResolutionError),
-    #[error(transparent)]
     RecordDecryption(#[from] RecordDecryptionError),
     #[error(transparent)]
     ListBasins(#[from] ListBasinsError),
@@ -82,6 +80,12 @@ impl From<AppendRequestRejection> for ServiceError {
     }
 }
 
+impl From<EncryptionResolutionError> for ServiceError {
+    fn from(e: EncryptionResolutionError) -> Self {
+        ServiceError::Validation(ValidationError(e.to_string()))
+    }
+}
+
 impl ServiceError {
     pub fn to_response(&self) -> ErrorResponse {
         match self {
@@ -99,7 +103,6 @@ impl ServiceError {
                 }
             },
             ServiceError::Validation(e) => standard(ErrorCode::Invalid, e.to_string()),
-            ServiceError::EncryptionResolution(e) => standard(ErrorCode::Invalid, e.to_string()),
             ServiceError::RecordDecryption(e) => match e {
                 RecordDecryptionError::AlgorithmMismatch { .. } => {
                     standard(ErrorCode::Invalid, e.to_string())

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -11,8 +11,7 @@ use s2_api::{
     },
 };
 use s2_common::{
-    encryption::EncryptionSpecResolutionError, http::extract::HeaderRejection,
-    record::RecordDecryptionError, types::ValidationError,
+    http::extract::HeaderRejection, record::RecordDecryptionError, types::ValidationError,
 };
 
 use crate::backend::error::{
@@ -37,8 +36,6 @@ pub enum ServiceError {
     AppendInputStream(#[from] AppendInputStreamError),
     #[error(transparent)]
     Validation(#[from] ValidationError),
-    #[error(transparent)]
-    RecordDecryption(#[from] RecordDecryptionError),
     #[error(transparent)]
     ListBasins(#[from] ListBasinsError),
     #[error(transparent)]
@@ -80,12 +77,6 @@ impl From<AppendRequestRejection> for ServiceError {
     }
 }
 
-impl From<EncryptionSpecResolutionError> for ServiceError {
-    fn from(e: EncryptionSpecResolutionError) -> Self {
-        ServiceError::Validation(ValidationError(e.to_string()))
-    }
-}
-
 impl ServiceError {
     pub fn to_response(&self) -> ErrorResponse {
         match self {
@@ -103,19 +94,6 @@ impl ServiceError {
                 }
             },
             ServiceError::Validation(e) => standard(ErrorCode::Invalid, e.to_string()),
-            ServiceError::RecordDecryption(e) => match e {
-                RecordDecryptionError::AlgorithmMismatch { .. } => {
-                    standard(ErrorCode::Invalid, e.to_string())
-                }
-                RecordDecryptionError::AuthenticationFailed => {
-                    standard(ErrorCode::DecryptionFailed, e.to_string())
-                }
-                RecordDecryptionError::MalformedEncryptedRecord
-                | RecordDecryptionError::MeteredSizeMismatch { .. }
-                | RecordDecryptionError::MalformedDecryptedRecord(_) => {
-                    standard(ErrorCode::Storage, e.to_string())
-                }
-            },
             ServiceError::ListBasins(e) => match e {
                 ListBasinsError::Storage(e) => standard(ErrorCode::Storage, e.to_string()),
             },
@@ -238,6 +216,9 @@ impl ServiceError {
             },
             ServiceError::Append(e) => match e {
                 AppendError::Storage(e) => standard(ErrorCode::Storage, e.to_string()),
+                AppendError::EncryptionSpecResolution(e) => {
+                    standard(ErrorCode::Invalid, e.to_string())
+                }
                 AppendError::TransactionConflict(e) => {
                     standard(ErrorCode::TransactionConflict, e.to_string())
                 }
@@ -274,6 +255,22 @@ impl ServiceError {
             },
             ServiceError::Read(e) => match e {
                 ReadError::Storage(e) => standard(ErrorCode::Storage, e.to_string()),
+                ReadError::EncryptionSpecResolution(e) => {
+                    standard(ErrorCode::Invalid, e.to_string())
+                }
+                ReadError::RecordDecryption(e) => match e {
+                    RecordDecryptionError::AlgorithmMismatch { .. } => {
+                        standard(ErrorCode::Invalid, e.to_string())
+                    }
+                    RecordDecryptionError::AuthenticationFailed => {
+                        standard(ErrorCode::DecryptionFailed, e.to_string())
+                    }
+                    RecordDecryptionError::MalformedEncryptedRecord
+                    | RecordDecryptionError::MeteredSizeMismatch { .. }
+                    | RecordDecryptionError::MalformedDecryptedRecord(_) => {
+                        standard(ErrorCode::Storage, e.to_string())
+                    }
+                },
                 ReadError::TransactionConflict(e) => {
                     standard(ErrorCode::TransactionConflict, e.to_string())
                 }

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -19,7 +19,6 @@ use crate::backend::error::{
     AppendConditionFailedError, AppendError, CheckTailError, CreateBasinError, CreateStreamError,
     DeleteBasinError, DeleteStreamError, GetBasinConfigError, GetStreamConfigError,
     ListBasinsError, ListStreamsError, ReadError, ReconfigureBasinError, ReconfigureStreamError,
-    ResolveAppendError, ResolveReadError,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -84,24 +83,6 @@ impl From<AppendRequestRejection> for ServiceError {
 impl From<EncryptionSpecResolutionError> for ServiceError {
     fn from(e: EncryptionSpecResolutionError) -> Self {
         ServiceError::Validation(ValidationError(e.to_string()))
-    }
-}
-
-impl From<ResolveAppendError> for ServiceError {
-    fn from(value: ResolveAppendError) -> Self {
-        match value {
-            ResolveAppendError::Append(e) => ServiceError::Append(e),
-            ResolveAppendError::EncryptionSpecResolution(e) => ServiceError::from(e),
-        }
-    }
-}
-
-impl From<ResolveReadError> for ServiceError {
-    fn from(value: ResolveReadError) -> Self {
-        match value {
-            ResolveReadError::Read(e) => ServiceError::Read(e),
-            ResolveReadError::EncryptionSpecResolution(e) => ServiceError::from(e),
-        }
     }
 }
 

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -11,7 +11,8 @@ use s2_api::{
     },
 };
 use s2_common::{
-    http::extract::HeaderRejection, record::RecordDecryptionError, types::ValidationError,
+    encryption::EncryptionResolutionError, http::extract::HeaderRejection,
+    record::RecordDecryptionError, types::ValidationError,
 };
 
 use crate::backend::error::{
@@ -36,6 +37,8 @@ pub enum ServiceError {
     AppendInputStream(#[from] AppendInputStreamError),
     #[error(transparent)]
     Validation(#[from] ValidationError),
+    #[error(transparent)]
+    EncryptionResolution(#[from] EncryptionResolutionError),
     #[error(transparent)]
     RecordDecryption(#[from] RecordDecryptionError),
     #[error(transparent)]
@@ -96,6 +99,7 @@ impl ServiceError {
                 }
             },
             ServiceError::Validation(e) => standard(ErrorCode::Invalid, e.to_string()),
+            ServiceError::EncryptionResolution(e) => standard(ErrorCode::Invalid, e.to_string()),
             ServiceError::RecordDecryption(e) => match e {
                 RecordDecryptionError::ModeMismatch { .. } => {
                     standard(ErrorCode::Invalid, e.to_string())
@@ -261,7 +265,7 @@ impl ServiceError {
                     } => v1t::stream::AppendConditionFailed::SeqNumMismatch(*assigned_seq_num),
                 }),
                 AppendError::TimestampMissing(e) => standard(ErrorCode::Invalid, e.to_string()),
-                AppendError::EncryptionModeNotAllowed(e) => {
+                AppendError::EncryptionModeMismatch(e) => {
                     standard(ErrorCode::Invalid, e.to_string())
                 }
             },

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -101,7 +101,7 @@ impl ServiceError {
             ServiceError::Validation(e) => standard(ErrorCode::Invalid, e.to_string()),
             ServiceError::EncryptionResolution(e) => standard(ErrorCode::Invalid, e.to_string()),
             ServiceError::RecordDecryption(e) => match e {
-                RecordDecryptionError::ModeMismatch { .. } => {
+                RecordDecryptionError::AlgorithmMismatch { .. } => {
                     standard(ErrorCode::Invalid, e.to_string())
                 }
                 RecordDecryptionError::AuthenticationFailed => {
@@ -265,7 +265,7 @@ impl ServiceError {
                     } => v1t::stream::AppendConditionFailed::SeqNumMismatch(*assigned_seq_num),
                 }),
                 AppendError::TimestampMissing(e) => standard(ErrorCode::Invalid, e.to_string()),
-                AppendError::EncryptionModeMismatch(e) => {
+                AppendError::EncryptionAlgorithmMismatch(e) => {
                     standard(ErrorCode::Invalid, e.to_string())
                 }
             },

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -11,7 +11,7 @@ use s2_api::{
     },
 };
 use s2_common::{
-    encryption::EncryptionResolutionError, http::extract::HeaderRejection,
+    encryption::EncryptionSpecResolutionError, http::extract::HeaderRejection,
     record::RecordDecryptionError, types::ValidationError,
 };
 
@@ -80,8 +80,8 @@ impl From<AppendRequestRejection> for ServiceError {
     }
 }
 
-impl From<EncryptionResolutionError> for ServiceError {
-    fn from(e: EncryptionResolutionError) -> Self {
+impl From<EncryptionSpecResolutionError> for ServiceError {
+    fn from(e: EncryptionSpecResolutionError) -> Self {
         ServiceError::Validation(ValidationError(e.to_string()))
     }
 }

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -573,7 +573,7 @@ mod tests {
         (app, backend, basin, stream)
     }
 
-    async fn setup_app_with_basin_only(
+    async fn setup_app_with_missing_stream(
         test_suffix: &str,
         basin_config: BasinConfig,
     ) -> (axum::Router, Backend, BasinName, StreamName) {
@@ -799,7 +799,7 @@ mod tests {
         let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
         basin_config.create_stream_on_append = true;
         let (app, backend, basin, stream) =
-            setup_app_with_basin_only("append-auto-create-encrypted", basin_config).await;
+            setup_app_with_missing_stream("append-auto-create-encrypted", basin_config).await;
 
         let input = proto::AppendInput {
             records: vec![proto::AppendRecord {
@@ -867,7 +867,7 @@ mod tests {
         let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
         basin_config.create_stream_on_read = true;
         let (app, backend, basin, stream) =
-            setup_app_with_basin_only("read-auto-create-encrypted", basin_config).await;
+            setup_app_with_missing_stream("read-auto-create-encrypted", basin_config).await;
 
         let response = send(
             &app,
@@ -897,7 +897,7 @@ mod tests {
             ..Default::default()
         };
         let (app, backend, basin, stream) =
-            setup_app_with_basin_only("read-invalid-bounds-no-create", basin_config).await;
+            setup_app_with_missing_stream("read-invalid-bounds-no-create", basin_config).await;
 
         let response = send(
             &app,

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -28,7 +28,11 @@ use s2_common::{
     },
 };
 
-use crate::{backend::Backend, handlers::v1::error::ServiceError, stream_id::StreamId};
+use crate::{
+    backend::{Backend, error::ReadError},
+    handlers::v1::error::ServiceError,
+    stream_id::StreamId,
+};
 
 pub fn router() -> axum::Router<Backend> {
     use axum::routing::{get, post};
@@ -44,7 +48,7 @@ fn decrypt_session<S>(
     stream_id: StreamId,
 ) -> impl Stream<Item = Result<ReadSessionOutput, ServiceError>>
 where
-    S: Stream<Item = Result<StoredReadSessionOutput, crate::backend::error::ReadError>>,
+    S: Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
 {
     async_stream::stream! {
         tokio::pin!(session);
@@ -215,9 +219,7 @@ pub async fn read(
             response_mime,
         } => {
             let (start, end) = prepare_read(start, end, ReadMode::Unary)?;
-            let handle = backend
-                .resolve_read_handle::<crate::backend::error::ReadError>(&basin, &stream)
-                .await?;
+            let handle = backend.open_for_read::<ReadError>(&basin, &stream).await?;
             let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let stream_id = handle.stream_id();
             let session = handle.read(start, end).await?;
@@ -241,9 +243,7 @@ pub async fn read(
         } => {
             let (start, end) = apply_last_event_id(start, end, last_event_id);
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
-            let handle = backend
-                .resolve_read_handle::<crate::backend::error::ReadError>(&basin, &stream)
-                .await?;
+            let handle = backend.open_for_read::<ReadError>(&basin, &stream).await?;
             let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let stream_id = handle.stream_id();
             let session = handle.read(start, end).await?;
@@ -289,9 +289,7 @@ pub async fn read(
             response_compression,
         } => {
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
-            let handle = backend
-                .resolve_read_handle::<crate::backend::error::ReadError>(&basin, &stream)
-                .await?;
+            let handle = backend.open_for_read::<ReadError>(&basin, &stream).await?;
             let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let stream_id = handle.stream_id();
             let session = handle.read(start, end).await?;
@@ -409,7 +407,7 @@ pub async fn append(
             input,
             response_mime,
         } => {
-            let handle = backend.resolve_append_handle(&basin, &stream).await?;
+            let handle = backend.open_for_append(&basin, &stream).await?;
             let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let stream_id = handle.stream_id();
             let input = input.encrypt(&encryption, stream_id.as_bytes());
@@ -430,7 +428,7 @@ pub async fn append(
             inputs,
             response_compression,
         } => {
-            let handle = backend.resolve_append_handle(&basin, &stream).await?;
+            let handle = backend.open_for_append(&basin, &stream).await?;
             let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let stream_id = handle.stream_id();
             let (err_tx, err_rx) = tokio::sync::oneshot::channel();

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -14,7 +14,7 @@ use s2_api::{
 };
 use s2_common::{
     caps::RECORD_BATCH_MAX,
-    encryption::EncryptionSpec,
+    encryption::Encryption,
     http::extract::Header,
     read_extent::{CountOrBytes, ReadLimit},
     record::{Metered, MeteredSize as _},
@@ -40,7 +40,7 @@ pub fn router() -> axum::Router<Backend> {
 
 fn decrypt_session<S>(
     session: S,
-    encryption: EncryptionSpec,
+    encryption: Encryption,
     stream_id: StreamId,
 ) -> impl Stream<Item = Result<ReadSessionOutput, ServiceError>>
 where
@@ -211,10 +211,18 @@ pub async fn read(
     let stream_id = StreamId::new(&basin, &stream);
     match request {
         v1t::stream::ReadRequest::Unary {
-            encryption,
+            encryption_key,
             format,
             response_mime,
         } => {
+            let encryption_algorithm = backend
+                .stream_encryption_algorithm_with_auto_create::<crate::backend::error::ReadError>(
+                    &basin,
+                    &stream,
+                    |config| config.create_stream_on_read,
+                )
+                .await?;
+            let encryption = Encryption::resolve(encryption_algorithm, encryption_key)?;
             let (start, end) = prepare_read(start, end, ReadMode::Unary)?;
             let session = backend.read(basin, stream, start, end).await?;
             let session = decrypt_session(session, encryption, stream_id);
@@ -231,10 +239,18 @@ pub async fn read(
             }
         }
         v1t::stream::ReadRequest::EventStream {
-            encryption,
+            encryption_key,
             format,
             last_event_id,
         } => {
+            let encryption_algorithm = backend
+                .stream_encryption_algorithm_with_auto_create::<crate::backend::error::ReadError>(
+                    &basin,
+                    &stream,
+                    |config| config.create_stream_on_read,
+                )
+                .await?;
+            let encryption = Encryption::resolve(encryption_algorithm, encryption_key)?;
             let (start, end) = apply_last_event_id(start, end, last_event_id);
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
             let session = backend.read(basin, stream, start, end).await?;
@@ -276,9 +292,17 @@ pub async fn read(
             Ok(axum::response::Sse::new(events).into_response())
         }
         v1t::stream::ReadRequest::S2s {
-            encryption,
+            encryption_key,
             response_compression,
         } => {
+            let encryption_algorithm = backend
+                .stream_encryption_algorithm_with_auto_create::<crate::backend::error::ReadError>(
+                    &basin,
+                    &stream,
+                    |config| config.create_stream_on_read,
+                )
+                .await?;
+            let encryption = Encryption::resolve(encryption_algorithm, encryption_key)?;
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
             let session = backend.read(basin, stream, start, end).await?;
             let s2s_stream =
@@ -392,10 +416,18 @@ pub async fn append(
     let stream_id = StreamId::new(&basin, &stream);
     match request {
         v1t::stream::AppendRequest::Unary {
-            encryption,
+            encryption_key,
             input,
             response_mime,
         } => {
+            let encryption_algorithm = backend
+                .stream_encryption_algorithm_with_auto_create::<crate::backend::error::AppendError>(
+                    &basin,
+                    &stream,
+                    |config| config.create_stream_on_append,
+                )
+                .await?;
+            let encryption = Encryption::resolve(encryption_algorithm, encryption_key)?;
             let input = input.encrypt(&encryption, stream_id.as_bytes());
             let ack = backend.append(basin, stream, input).await?;
             match response_mime {
@@ -410,10 +442,18 @@ pub async fn append(
             }
         }
         v1t::stream::AppendRequest::S2s {
-            encryption,
+            encryption_key,
             inputs,
             response_compression,
         } => {
+            let encryption_algorithm = backend
+                .stream_encryption_algorithm_with_auto_create::<crate::backend::error::AppendError>(
+                    &basin,
+                    &stream,
+                    |config| config.create_stream_on_append,
+                )
+                .await?;
+            let encryption = Encryption::resolve(encryption_algorithm, encryption_key)?;
             let (err_tx, err_rx) = tokio::sync::oneshot::channel();
 
             let inputs = async_stream::stream! {
@@ -476,10 +516,13 @@ mod tests {
     use prost::Message as _;
     use s2_api::v1::stream::{
         proto,
-        s2s::{FrameDecoder, SessionMessage, TerminalMessage},
+        s2s::{FrameDecoder, SessionMessage},
     };
     use s2_common::{
-        encryption::{EncryptionMode, EncryptionSpec, S2_ENCRYPTION_HEADER},
+        encryption::{
+            Encryption, EncryptionAlgorithm, EncryptionKey, EncryptionMode,
+            S2_ENCRYPTION_KEY_HEADER,
+        },
         read_extent::{ReadLimit, ReadUntil},
         record::{EnvelopeRecord, Metered, Record, RecordDecryptionError},
         types::{
@@ -500,25 +543,19 @@ mod tests {
     use crate::{backend::Backend, handlers, stream_id::StreamId};
 
     fn all_encryption_modes_stream_config() -> OptionalStreamConfig {
-        use s2_common::types::config::OptionalEncryptionConfig;
-        OptionalStreamConfig {
-            encryption: OptionalEncryptionConfig {
-                allowed_modes: [
-                    EncryptionMode::Plain,
-                    EncryptionMode::Aegis256,
-                    EncryptionMode::Aes256Gcm,
-                ]
-                .into(),
-            },
-            ..Default::default()
-        }
+        OptionalStreamConfig::default()
     }
 
     fn all_encryption_modes_basin_config() -> BasinConfig {
         BasinConfig {
             default_stream_config: all_encryption_modes_stream_config(),
+            stream_encryption_algorithm: Some(EncryptionAlgorithm::Aegis256),
             ..Default::default()
         }
+    }
+
+    fn aegis_key(byte: u8) -> EncryptionKey {
+        EncryptionKey::new([byte; 32])
     }
 
     async fn create_backend() -> Backend {
@@ -582,7 +619,7 @@ mod tests {
         basin: &BasinName,
         stream: &StreamName,
         body: &'static [u8],
-        encryption: &EncryptionSpec,
+        encryption: &Encryption,
     ) {
         let stream_id = StreamId::new(basin, stream);
         let input = append_input(body).encrypt(encryption, stream_id.as_bytes());
@@ -678,7 +715,8 @@ mod tests {
 
     #[tokio::test]
     async fn unary_append_with_encryption_header_persists_encrypted_record() {
-        let encryption = EncryptionSpec::aegis256([0x42; 32]);
+        let encryption = Encryption::aegis256([0x42; 32]);
+        let encryption_key = aegis_key(0x42);
         let (app, backend, basin, stream) = setup_app_with_config(
             "append-unary-encrypted",
             all_encryption_modes_basin_config(),
@@ -701,7 +739,10 @@ mod tests {
             request_builder("POST", format!("/v1/streams/{stream}/records"), &basin)
                 .header(header::CONTENT_TYPE, "application/protobuf")
                 .header(header::ACCEPT, "application/protobuf")
-                .header(S2_ENCRYPTION_HEADER.as_str(), encryption.to_header_value())
+                .header(
+                    S2_ENCRYPTION_KEY_HEADER.as_str(),
+                    encryption_key.to_header_value(),
+                )
                 .body(Body::from(input.encode_to_vec()))
                 .unwrap(),
         )
@@ -715,7 +756,7 @@ mod tests {
         let stored_batch = first_stored_batch(&backend, &basin, &stream).await;
 
         assert!(matches!(
-            stored_batch.clone().decrypt(&EncryptionSpec::Plain, &[]),
+            stored_batch.clone().decrypt(&Encryption::Plain, &[]),
             Err(RecordDecryptionError::ModeMismatch {
                 expected: EncryptionMode::Plain,
                 actual: EncryptionMode::Aegis256,
@@ -736,8 +777,8 @@ mod tests {
 
     #[tokio::test]
     async fn unary_read_with_wrong_key_returns_decryption_failed_error() {
-        let encryption = EncryptionSpec::aegis256([0x42; 32]);
-        let wrong_key = EncryptionSpec::aegis256([0x24; 32]);
+        let encryption = Encryption::aegis256([0x42; 32]);
+        let wrong_key = aegis_key(0x24);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-unary-bad-key",
             all_encryption_modes_basin_config(),
@@ -749,7 +790,10 @@ mod tests {
         let response = send(
             &app,
             request_builder("GET", read_uri(&stream), &basin)
-                .header(S2_ENCRYPTION_HEADER.as_str(), wrong_key.to_header_value())
+                .header(
+                    S2_ENCRYPTION_KEY_HEADER.as_str(),
+                    wrong_key.to_header_value(),
+                )
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -767,8 +811,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sse_read_with_plain_header_emits_error_event_and_terminates() {
-        let encryption = EncryptionSpec::aegis256([0x42; 32]);
+    async fn sse_read_without_key_header_emits_error_event_and_terminates() {
+        let encryption = Encryption::aegis256([0x42; 32]);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-sse-plain",
             all_encryption_modes_basin_config(),
@@ -785,31 +829,19 @@ mod tests {
                 &basin,
             )
             .header(header::ACCEPT, "text/event-stream")
-            .header(
-                S2_ENCRYPTION_HEADER.as_str(),
-                EncryptionSpec::Plain.to_header_value(),
-            )
             .body(Body::empty())
             .unwrap(),
         )
         .await;
 
-        assert_eq!(response.status(), StatusCode::OK);
-        let body =
-            tokio::time::timeout(Duration::from_secs(1), response_bytes(response, "sse body"))
-                .await
-                .expect("sse body should terminate after the first error event");
-        let body = String::from_utf8(body.to_vec()).expect("utf8 sse body");
-        assert!(body.contains("event: error"));
-        assert!(body.contains("\"code\":\"invalid\""));
-        assert!(body.contains("record encryption mode mismatch"));
-        assert!(!body.contains("event: ping"));
-        assert!(!body.contains("[DONE]"));
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let info = response_json(response, "sse read error body").await;
+        assert_invalid_error(&info, "missing encryption key");
     }
 
     #[tokio::test]
-    async fn s2s_read_with_plain_header_returns_terminal_invalid_frame() {
-        let encryption = EncryptionSpec::aegis256([0x42; 32]);
+    async fn s2s_read_without_key_header_returns_terminal_invalid_frame() {
+        let encryption = Encryption::aegis256([0x42; 32]);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-s2s-plain",
             all_encryption_modes_basin_config(),
@@ -822,30 +854,20 @@ mod tests {
             &app,
             request_builder("GET", read_uri(&stream), &basin)
                 .header(header::CONTENT_TYPE, "s2s/proto")
-                .header(
-                    S2_ENCRYPTION_HEADER.as_str(),
-                    EncryptionSpec::Plain.to_header_value(),
-                )
                 .body(Body::empty())
                 .unwrap(),
         )
         .await;
 
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_bytes(response, "s2s body").await;
-        let frame = decode_single_frame(body, "terminal frame");
-        let SessionMessage::Terminal(TerminalMessage { status, body }) = frame else {
-            panic!("expected terminal frame");
-        };
-        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY.as_u16());
-        let info: serde_json::Value =
-            serde_json::from_str(&body).expect("terminal json error info");
-        assert_invalid_error(&info, "record encryption mode mismatch");
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let info = response_json(response, "s2s read error body").await;
+        assert_invalid_error(&info, "missing encryption key");
     }
 
     #[tokio::test]
     async fn s2s_read_with_correct_encryption_returns_batch_frame() {
-        let encryption = EncryptionSpec::aegis256([0x42; 32]);
+        let encryption = Encryption::aegis256([0x42; 32]);
+        let encryption_key = aegis_key(0x42);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-s2s-ok",
             all_encryption_modes_basin_config(),
@@ -858,7 +880,10 @@ mod tests {
             &app,
             request_builder("GET", read_uri(&stream), &basin)
                 .header(header::CONTENT_TYPE, "s2s/proto")
-                .header(S2_ENCRYPTION_HEADER.as_str(), encryption.to_header_value())
+                .header(
+                    S2_ENCRYPTION_KEY_HEADER.as_str(),
+                    encryption_key.to_header_value(),
+                )
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -208,23 +208,23 @@ pub async fn read(
     }: ReadArgs,
 ) -> Result<Response, ServiceError> {
     let start: ReadStart = start.try_into()?;
-    let stream_id = StreamId::new(&basin, &stream);
+    let handle = backend
+        .stream_handle_with_auto_create::<crate::backend::error::ReadError>(
+            &basin,
+            &stream,
+            |config| config.create_stream_on_read,
+        )
+        .await?;
+    let stream_id = handle.stream_id();
     match request {
         v1t::stream::ReadRequest::Unary {
             encryption_key,
             format,
             response_mime,
         } => {
-            let cipher = backend
-                .stream_cipher_with_auto_create::<crate::backend::error::ReadError>(
-                    &basin,
-                    &stream,
-                    |config| config.create_stream_on_read,
-                )
-                .await?;
-            let encryption = EncryptionSpec::resolve(cipher, encryption_key)?;
+            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let (start, end) = prepare_read(start, end, ReadMode::Unary)?;
-            let session = backend.read(basin, stream, start, end).await?;
+            let session = handle.read(start, end).await?;
             let session = decrypt_session(session, encryption, stream_id);
             let batch = merge_read_session(session, end.wait).await?;
             match response_mime {
@@ -243,17 +243,10 @@ pub async fn read(
             format,
             last_event_id,
         } => {
-            let cipher = backend
-                .stream_cipher_with_auto_create::<crate::backend::error::ReadError>(
-                    &basin,
-                    &stream,
-                    |config| config.create_stream_on_read,
-                )
-                .await?;
-            let encryption = EncryptionSpec::resolve(cipher, encryption_key)?;
+            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let (start, end) = apply_last_event_id(start, end, last_event_id);
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
-            let session = backend.read(basin, stream, start, end).await?;
+            let session = handle.read(start, end).await?;
             let session = decrypt_session(session, encryption, stream_id);
             let events = async_stream::stream! {
                 let mut processed = CountOrBytes::ZERO;
@@ -295,16 +288,9 @@ pub async fn read(
             encryption_key,
             response_compression,
         } => {
-            let cipher = backend
-                .stream_cipher_with_auto_create::<crate::backend::error::ReadError>(
-                    &basin,
-                    &stream,
-                    |config| config.create_stream_on_read,
-                )
-                .await?;
-            let encryption = EncryptionSpec::resolve(cipher, encryption_key)?;
+            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
-            let session = backend.read(basin, stream, start, end).await?;
+            let session = handle.read(start, end).await?;
             let s2s_stream =
                 decrypt_session(session, encryption, stream_id).map_ok(|msg| match msg {
                     ReadSessionOutput::Heartbeat(tail) => v1t::stream::proto::ReadBatch {
@@ -413,23 +399,23 @@ pub async fn append(
         request,
     }: AppendArgs,
 ) -> Result<Response, ServiceError> {
-    let stream_id = StreamId::new(&basin, &stream);
+    let handle = backend
+        .stream_handle_with_auto_create::<crate::backend::error::AppendError>(
+            &basin,
+            &stream,
+            |config| config.create_stream_on_append,
+        )
+        .await?;
+    let stream_id = handle.stream_id();
     match request {
         v1t::stream::AppendRequest::Unary {
             encryption_key,
             input,
             response_mime,
         } => {
-            let cipher = backend
-                .stream_cipher_with_auto_create::<crate::backend::error::AppendError>(
-                    &basin,
-                    &stream,
-                    |config| config.create_stream_on_append,
-                )
-                .await?;
-            let encryption = EncryptionSpec::resolve(cipher, encryption_key)?;
+            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let input = input.encrypt(&encryption, stream_id.as_bytes());
-            let ack = backend.append(basin, stream, input).await?;
+            let ack = handle.append(input).await?;
             match response_mime {
                 JsonOrProto::Json => {
                     let ack: v1t::stream::AppendAck = ack.into();
@@ -446,14 +432,7 @@ pub async fn append(
             inputs,
             response_compression,
         } => {
-            let cipher = backend
-                .stream_cipher_with_auto_create::<crate::backend::error::AppendError>(
-                    &basin,
-                    &stream,
-                    |config| config.create_stream_on_append,
-                )
-                .await?;
-            let encryption = EncryptionSpec::resolve(cipher, encryption_key)?;
+            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let (err_tx, err_rx) = tokio::sync::oneshot::channel();
 
             let inputs = async_stream::stream! {
@@ -472,13 +451,10 @@ pub async fn append(
                 }
             };
 
-            let ack_stream = backend
-                .append_session(basin, stream, inputs)
-                .await?
-                .map(|res| {
-                    res.map(v1t::stream::proto::AppendAck::from)
-                        .map_err(ServiceError::from)
-                });
+            let ack_stream = handle.append_session(inputs).map(|res| {
+                res.map(v1t::stream::proto::AppendAck::from)
+                    .map_err(ServiceError::from)
+            });
 
             let input_err_stream = futures::stream::once(err_rx).filter_map(|res| async move {
                 match res {
@@ -529,8 +505,9 @@ mod tests {
             config::{BasinConfig, OptionalStreamConfig},
             resources::CreateMode,
             stream::{
-                AppendInput, AppendRecord, AppendRecordBatch, AppendRecordParts, ReadEnd, ReadFrom,
-                ReadStart, StoredReadBatch, StoredReadSessionOutput, StreamName,
+                AppendInput, AppendRecord, AppendRecordBatch, AppendRecordParts,
+                ListStreamsRequest, ReadEnd, ReadFrom, ReadStart, StoredReadBatch,
+                StoredReadSessionOutput, StreamName,
             },
         },
     };
@@ -588,6 +565,21 @@ mod tests {
             )
             .await
             .expect("create stream");
+        let app = handlers::router().with_state(backend.clone());
+        (app, backend, basin, stream)
+    }
+
+    async fn setup_app_with_basin_only(
+        test_suffix: &str,
+        basin_config: BasinConfig,
+    ) -> (axum::Router, Backend, BasinName, StreamName) {
+        let backend = create_backend().await;
+        let basin: BasinName = format!("test-basin-{test_suffix}").parse().unwrap();
+        backend
+            .create_basin(basin.clone(), basin_config, CreateMode::CreateOnly(None))
+            .await
+            .expect("create basin");
+        let stream: StreamName = format!("test-stream-{test_suffix}").parse().unwrap();
         let app = handlers::router().with_state(backend.clone());
         (app, backend, basin, stream)
     }
@@ -708,6 +700,25 @@ mod tests {
         );
     }
 
+    async fn assert_listed_stream_cipher(
+        backend: &Backend,
+        basin: &BasinName,
+        stream: &StreamName,
+        expected_cipher: Option<EncryptionAlgorithm>,
+    ) {
+        let stream_list = backend
+            .list_streams(basin.clone(), ListStreamsRequest::default())
+            .await
+            .expect("list streams");
+        let stream_names: Vec<_> = stream_list
+            .values
+            .iter()
+            .map(|info| info.name.as_ref())
+            .collect();
+        assert_eq!(stream_names, vec![stream.as_ref()]);
+        assert_eq!(stream_list.values[0].cipher, expected_cipher);
+    }
+
     #[tokio::test]
     async fn unary_append_with_encryption_header_persists_encrypted_record() {
         let encryption = EncryptionSpec::aegis256([0x42; 32]);
@@ -768,6 +779,115 @@ mod tests {
             panic!("expected envelope record");
         };
         assert_eq!(record.body().as_ref(), b"secret");
+    }
+
+    #[tokio::test]
+    async fn unary_append_auto_creates_encrypted_stream() {
+        let encryption_key = aegis_key(0x42);
+        let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
+        basin_config.create_stream_on_append = true;
+        let (app, backend, basin, stream) =
+            setup_app_with_basin_only("append-auto-create-encrypted", basin_config).await;
+
+        let input = proto::AppendInput {
+            records: vec![proto::AppendRecord {
+                timestamp: None,
+                headers: vec![],
+                body: Bytes::from_static(b"secret"),
+            }],
+            match_seq_num: None,
+            fencing_token: None,
+        };
+
+        let response = send(
+            &app,
+            request_builder("POST", format!("/v1/streams/{stream}/records"), &basin)
+                .header(header::CONTENT_TYPE, "application/protobuf")
+                .header(header::ACCEPT, "application/protobuf")
+                .header(
+                    S2_ENCRYPTION_KEY_HEADER.as_str(),
+                    encryption_key.to_header_value(),
+                )
+                .body(Body::from(input.encode_to_vec()))
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_bytes(response, "append ack body").await;
+        let ack = proto::AppendAck::decode(body).expect("append ack");
+        assert_eq!(ack.end.as_ref().map(|pos| pos.seq_num), Some(1));
+
+        assert_listed_stream_cipher(
+            &backend,
+            &basin,
+            &stream,
+            Some(EncryptionAlgorithm::Aegis256),
+        )
+        .await;
+
+        let response = send(
+            &app,
+            request_builder(
+                "GET",
+                format!("/v1/streams/{stream}/records?seq_num=0&wait=1"),
+                &basin,
+            )
+            .header(header::ACCEPT, "application/protobuf")
+            .header(
+                S2_ENCRYPTION_KEY_HEADER.as_str(),
+                encryption_key.to_header_value(),
+            )
+            .body(Body::empty())
+            .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_bytes(response, "read batch body").await;
+        let batch = proto::ReadBatch::decode(body).expect("read batch");
+        assert_eq!(batch.records.len(), 1);
+        assert_eq!(batch.records[0].body.as_ref(), b"secret");
+    }
+
+    #[tokio::test]
+    async fn check_tail_auto_creates_stream_with_basin_cipher() {
+        let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
+        basin_config.create_stream_on_read = true;
+        let (app, backend, basin, stream) =
+            setup_app_with_basin_only("read-auto-create-encrypted", basin_config).await;
+
+        let response = send(
+            &app,
+            request_builder("GET", format!("/v1/streams/{stream}/records/tail"), &basin)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response, "tail response body").await;
+        assert_eq!(body["tail"]["seq_num"], 0);
+
+        assert_listed_stream_cipher(
+            &backend,
+            &basin,
+            &stream,
+            Some(EncryptionAlgorithm::Aegis256),
+        )
+        .await;
+
+        let response = send(
+            &app,
+            request_builder("GET", read_uri(&stream), &basin)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let info = response_json(response, "read error body").await;
+        assert_invalid_error(&info, "missing encryption key");
     }
 
     #[tokio::test]

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -215,9 +215,10 @@ pub async fn read(
             response_mime,
         } => {
             let (start, end) = prepare_read(start, end, ReadMode::Unary)?;
-            let (handle, encryption) = backend
-                .resolve_read_target(&basin, &stream, encryption_key)
+            let handle = backend
+                .resolve_read_handle::<crate::backend::error::ReadError>(&basin, &stream)
                 .await?;
+            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let stream_id = handle.stream_id();
             let session = handle.read(start, end).await?;
             let session = decrypt_session(session, encryption, stream_id);
@@ -240,9 +241,10 @@ pub async fn read(
         } => {
             let (start, end) = apply_last_event_id(start, end, last_event_id);
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
-            let (handle, encryption) = backend
-                .resolve_read_target(&basin, &stream, encryption_key)
+            let handle = backend
+                .resolve_read_handle::<crate::backend::error::ReadError>(&basin, &stream)
                 .await?;
+            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let stream_id = handle.stream_id();
             let session = handle.read(start, end).await?;
             let session = decrypt_session(session, encryption, stream_id);
@@ -287,9 +289,10 @@ pub async fn read(
             response_compression,
         } => {
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
-            let (handle, encryption) = backend
-                .resolve_read_target(&basin, &stream, encryption_key)
+            let handle = backend
+                .resolve_read_handle::<crate::backend::error::ReadError>(&basin, &stream)
                 .await?;
+            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let stream_id = handle.stream_id();
             let session = handle.read(start, end).await?;
             let s2s_stream =
@@ -406,9 +409,8 @@ pub async fn append(
             input,
             response_mime,
         } => {
-            let (handle, encryption) = backend
-                .resolve_append_target(&basin, &stream, encryption_key)
-                .await?;
+            let handle = backend.resolve_append_handle(&basin, &stream).await?;
+            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let stream_id = handle.stream_id();
             let input = input.encrypt(&encryption, stream_id.as_bytes());
             let ack = handle.append(input).await?;
@@ -428,9 +430,8 @@ pub async fn append(
             inputs,
             response_compression,
         } => {
-            let (handle, encryption) = backend
-                .resolve_append_target(&basin, &stream, encryption_key)
-                .await?;
+            let handle = backend.resolve_append_handle(&basin, &stream).await?;
+            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let stream_id = handle.stream_id();
             let (err_tx, err_rx) = tokio::sync::oneshot::channel();
 

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -14,7 +14,7 @@ use s2_api::{
 };
 use s2_common::{
     caps::RECORD_BATCH_MAX,
-    encryption::EncryptionSpec,
+    encryption::{EncryptionKey, EncryptionSpec},
     http::extract::Header,
     read_extent::{CountOrBytes, ReadLimit},
     record::{Metered, MeteredSize as _},
@@ -114,6 +114,21 @@ fn prepare_read(
     }
     validate_read_until(start, end)?;
     Ok((start, end))
+}
+
+async fn open_read_session(
+    backend: &Backend,
+    basin: &BasinName,
+    stream: &StreamName,
+    start: ReadStart,
+    end: ReadEnd,
+    encryption_key: Option<EncryptionKey>,
+) -> Result<impl Stream<Item = Result<ReadSessionOutput, ServiceError>> + use<>, ServiceError> {
+    let handle = backend.open_for_read::<ReadError>(basin, stream).await?;
+    let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
+    let stream_id = handle.stream_id();
+    let session = handle.read(start, end).await?;
+    Ok(decrypt_session(session, encryption, stream_id))
 }
 
 #[derive(FromRequest)]
@@ -219,11 +234,8 @@ pub async fn read(
             response_mime,
         } => {
             let (start, end) = prepare_read(start, end, ReadMode::Unary)?;
-            let handle = backend.open_for_read::<ReadError>(&basin, &stream).await?;
-            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
-            let stream_id = handle.stream_id();
-            let session = handle.read(start, end).await?;
-            let session = decrypt_session(session, encryption, stream_id);
+            let session =
+                open_read_session(&backend, &basin, &stream, start, end, encryption_key).await?;
             let batch = merge_read_session(session, end.wait).await?;
             match response_mime {
                 JsonOrProto::Json => Ok(Json(v1t::stream::json::serialize_read_batch(
@@ -243,11 +255,8 @@ pub async fn read(
         } => {
             let (start, end) = apply_last_event_id(start, end, last_event_id);
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
-            let handle = backend.open_for_read::<ReadError>(&basin, &stream).await?;
-            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
-            let stream_id = handle.stream_id();
-            let session = handle.read(start, end).await?;
-            let session = decrypt_session(session, encryption, stream_id);
+            let session =
+                open_read_session(&backend, &basin, &stream, start, end, encryption_key).await?;
             let events = async_stream::stream! {
                 let mut processed = CountOrBytes::ZERO;
                 tokio::pin!(session);
@@ -289,18 +298,15 @@ pub async fn read(
             response_compression,
         } => {
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
-            let handle = backend.open_for_read::<ReadError>(&basin, &stream).await?;
-            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
-            let stream_id = handle.stream_id();
-            let session = handle.read(start, end).await?;
-            let s2s_stream =
-                decrypt_session(session, encryption, stream_id).map_ok(|msg| match msg {
-                    ReadSessionOutput::Heartbeat(tail) => v1t::stream::proto::ReadBatch {
-                        records: vec![],
-                        tail: Some(tail.into()),
-                    },
-                    ReadSessionOutput::Batch(batch) => v1t::stream::proto::ReadBatch::from(batch),
-                });
+            let session =
+                open_read_session(&backend, &basin, &stream, start, end, encryption_key).await?;
+            let s2s_stream = session.map_ok(|msg| match msg {
+                ReadSessionOutput::Heartbeat(tail) => v1t::stream::proto::ReadBatch {
+                    records: vec![],
+                    tail: Some(tail.into()),
+                },
+                ReadSessionOutput::Batch(batch) => v1t::stream::proto::ReadBatch::from(batch),
+            });
             let response_stream = s2s::FramedMessageStream::<_>::new(
                 response_compression,
                 Box::pin(s2s_stream.map_err(ServiceError::from)),
@@ -401,15 +407,16 @@ pub async fn append(
         request,
     }: AppendArgs,
 ) -> Result<Response, ServiceError> {
+    let handle = backend.open_for_append(&basin, &stream).await?;
+    let stream_id = handle.stream_id();
     match request {
         v1t::stream::AppendRequest::Unary {
             encryption_key,
             input,
             response_mime,
         } => {
-            let handle = backend.open_for_append(&basin, &stream).await?;
             let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
-            let stream_id = handle.stream_id();
+
             let input = input.encrypt(&encryption, stream_id.as_bytes());
             let ack = handle.append(input).await?;
             match response_mime {
@@ -428,9 +435,8 @@ pub async fn append(
             inputs,
             response_compression,
         } => {
-            let handle = backend.open_for_append(&basin, &stream).await?;
             let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
-            let stream_id = handle.stream_id();
+
             let (err_tx, err_rx) = tokio::sync::oneshot::channel();
 
             let inputs = async_stream::stream! {

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -755,7 +755,9 @@ mod tests {
         let stored_batch = first_stored_batch(&backend, &basin, &stream).await;
 
         assert!(matches!(
-            stored_batch.clone().decrypt(&EncryptionSpec::plain(), &[]),
+            stored_batch
+                .clone()
+                .decrypt(&EncryptionSpec::Plaintext, &[]),
             Err(RecordDecryptionError::AlgorithmMismatch {
                 expected: None,
                 actual: Some(EncryptionAlgorithm::Aegis256),

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -519,10 +519,7 @@ mod tests {
         s2s::{FrameDecoder, SessionMessage},
     };
     use s2_common::{
-        encryption::{
-            Encryption, EncryptionAlgorithm, EncryptionKey, EncryptionMode,
-            S2_ENCRYPTION_KEY_HEADER,
-        },
+        encryption::{Encryption, EncryptionAlgorithm, EncryptionKey, S2_ENCRYPTION_KEY_HEADER},
         read_extent::{ReadLimit, ReadUntil},
         record::{EnvelopeRecord, Metered, Record, RecordDecryptionError},
         types::{
@@ -757,9 +754,9 @@ mod tests {
 
         assert!(matches!(
             stored_batch.clone().decrypt(&Encryption::Plain, &[]),
-            Err(RecordDecryptionError::ModeMismatch {
-                expected: EncryptionMode::Plain,
-                actual: EncryptionMode::Aegis256,
+            Err(RecordDecryptionError::AlgorithmMismatch {
+                expected: None,
+                actual: Some(EncryptionAlgorithm::Aegis256),
             })
         ));
 

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -755,9 +755,7 @@ mod tests {
         let stored_batch = first_stored_batch(&backend, &basin, &stream).await;
 
         assert!(matches!(
-            stored_batch
-                .clone()
-                .decrypt(&EncryptionSpec::Plaintext, &[]),
+            stored_batch.clone().decrypt(&EncryptionSpec::Plain, &[]),
             Err(RecordDecryptionError::AlgorithmMismatch {
                 expected: None,
                 actual: Some(EncryptionAlgorithm::Aegis256),

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -541,14 +541,10 @@ mod tests {
 
     use crate::{backend::Backend, handlers, stream_id::StreamId};
 
-    fn all_encryption_modes_stream_config() -> OptionalStreamConfig {
-        OptionalStreamConfig::default()
-    }
-
-    fn all_encryption_modes_basin_config() -> BasinConfig {
+    fn basin_config_with_stream_cipher(stream_cipher: EncryptionAlgorithm) -> BasinConfig {
         BasinConfig {
-            default_stream_config: all_encryption_modes_stream_config(),
-            stream_cipher: Some(EncryptionAlgorithm::Aegis256),
+            default_stream_config: OptionalStreamConfig::default(),
+            stream_cipher: Some(stream_cipher),
             ..Default::default()
         }
     }
@@ -718,8 +714,8 @@ mod tests {
         let encryption_key = aegis_key(0x42);
         let (app, backend, basin, stream) = setup_app_with_config(
             "append-unary-encrypted",
-            all_encryption_modes_basin_config(),
-            all_encryption_modes_stream_config(),
+            basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256),
+            OptionalStreamConfig::default(),
         )
         .await;
 
@@ -780,8 +776,8 @@ mod tests {
         let wrong_key = aegis_key(0x24);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-unary-bad-key",
-            all_encryption_modes_basin_config(),
-            all_encryption_modes_stream_config(),
+            basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256),
+            OptionalStreamConfig::default(),
         )
         .await;
         append_encrypted_payload(&backend, &basin, &stream, b"secret", &encryption).await;
@@ -814,8 +810,8 @@ mod tests {
         let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-sse-plain",
-            all_encryption_modes_basin_config(),
-            all_encryption_modes_stream_config(),
+            basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256),
+            OptionalStreamConfig::default(),
         )
         .await;
         append_encrypted_payload(&backend, &basin, &stream, b"secret", &encryption).await;
@@ -843,8 +839,8 @@ mod tests {
         let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-s2s-plain",
-            all_encryption_modes_basin_config(),
-            all_encryption_modes_stream_config(),
+            basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256),
+            OptionalStreamConfig::default(),
         )
         .await;
         append_encrypted_payload(&backend, &basin, &stream, b"secret", &encryption).await;
@@ -869,8 +865,8 @@ mod tests {
         let encryption_key = aegis_key(0x42);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-s2s-ok",
-            all_encryption_modes_basin_config(),
-            all_encryption_modes_stream_config(),
+            basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256),
+            OptionalStreamConfig::default(),
         )
         .await;
         append_encrypted_payload(&backend, &basin, &stream, b"secret", &encryption).await;

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -208,22 +208,17 @@ pub async fn read(
     }: ReadArgs,
 ) -> Result<Response, ServiceError> {
     let start: ReadStart = start.try_into()?;
-    let handle = backend
-        .stream_handle_with_auto_create::<crate::backend::error::ReadError>(
-            &basin,
-            &stream,
-            |config| config.create_stream_on_read,
-        )
-        .await?;
-    let stream_id = handle.stream_id();
     match request {
         v1t::stream::ReadRequest::Unary {
             encryption_key,
             format,
             response_mime,
         } => {
-            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let (start, end) = prepare_read(start, end, ReadMode::Unary)?;
+            let (handle, encryption) = backend
+                .resolve_read_target(&basin, &stream, encryption_key)
+                .await?;
+            let stream_id = handle.stream_id();
             let session = handle.read(start, end).await?;
             let session = decrypt_session(session, encryption, stream_id);
             let batch = merge_read_session(session, end.wait).await?;
@@ -243,9 +238,12 @@ pub async fn read(
             format,
             last_event_id,
         } => {
-            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let (start, end) = apply_last_event_id(start, end, last_event_id);
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
+            let (handle, encryption) = backend
+                .resolve_read_target(&basin, &stream, encryption_key)
+                .await?;
+            let stream_id = handle.stream_id();
             let session = handle.read(start, end).await?;
             let session = decrypt_session(session, encryption, stream_id);
             let events = async_stream::stream! {
@@ -288,8 +286,11 @@ pub async fn read(
             encryption_key,
             response_compression,
         } => {
-            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
+            let (handle, encryption) = backend
+                .resolve_read_target(&basin, &stream, encryption_key)
+                .await?;
+            let stream_id = handle.stream_id();
             let session = handle.read(start, end).await?;
             let s2s_stream =
                 decrypt_session(session, encryption, stream_id).map_ok(|msg| match msg {
@@ -399,21 +400,16 @@ pub async fn append(
         request,
     }: AppendArgs,
 ) -> Result<Response, ServiceError> {
-    let handle = backend
-        .stream_handle_with_auto_create::<crate::backend::error::AppendError>(
-            &basin,
-            &stream,
-            |config| config.create_stream_on_append,
-        )
-        .await?;
-    let stream_id = handle.stream_id();
     match request {
         v1t::stream::AppendRequest::Unary {
             encryption_key,
             input,
             response_mime,
         } => {
-            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
+            let (handle, encryption) = backend
+                .resolve_append_target(&basin, &stream, encryption_key)
+                .await?;
+            let stream_id = handle.stream_id();
             let input = input.encrypt(&encryption, stream_id.as_bytes());
             let ack = handle.append(input).await?;
             match response_mime {
@@ -432,7 +428,10 @@ pub async fn append(
             inputs,
             response_compression,
         } => {
-            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
+            let (handle, encryption) = backend
+                .resolve_append_target(&basin, &stream, encryption_key)
+                .await?;
+            let stream_id = handle.stream_id();
             let (err_tx, err_rx) = tokio::sync::oneshot::channel();
 
             let inputs = async_stream::stream! {
@@ -719,6 +718,14 @@ mod tests {
         assert_eq!(stream_list.values[0].cipher, expected_cipher);
     }
 
+    async fn assert_no_streams(backend: &Backend, basin: &BasinName) {
+        let stream_list = backend
+            .list_streams(basin.clone(), ListStreamsRequest::default())
+            .await
+            .expect("list streams");
+        assert!(stream_list.values.is_empty());
+    }
+
     #[tokio::test]
     async fn unary_append_with_encryption_header_persists_encrypted_record() {
         let encryption = EncryptionSpec::aegis256([0x42; 32]);
@@ -851,6 +858,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unary_append_missing_key_still_auto_creates_stream() {
+        let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
+        basin_config.create_stream_on_append = true;
+        let (app, backend, basin, stream) =
+            setup_app_with_basin_only("append-missing-key-create", basin_config).await;
+
+        let input = proto::AppendInput {
+            records: vec![proto::AppendRecord {
+                timestamp: None,
+                headers: vec![],
+                body: Bytes::from_static(b"secret"),
+            }],
+            match_seq_num: None,
+            fencing_token: None,
+        };
+
+        let response = send(
+            &app,
+            request_builder("POST", format!("/v1/streams/{stream}/records"), &basin)
+                .header(header::CONTENT_TYPE, "application/protobuf")
+                .header(header::ACCEPT, "application/protobuf")
+                .body(Body::from(input.encode_to_vec()))
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let info = response_json(response, "append error body").await;
+        assert_invalid_error(&info, "missing encryption key");
+        assert_listed_stream_cipher(
+            &backend,
+            &basin,
+            &stream,
+            Some(EncryptionAlgorithm::Aegis256),
+        )
+        .await;
+
+        let response = send(
+            &app,
+            request_builder("GET", format!("/v1/streams/{stream}/records/tail"), &basin)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response, "tail response body").await;
+        assert_eq!(body["tail"]["seq_num"], 0);
+    }
+
+    #[tokio::test]
     async fn check_tail_auto_creates_stream_with_basin_cipher() {
         let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
         basin_config.create_stream_on_read = true;
@@ -888,6 +946,60 @@ mod tests {
         assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
         let info = response_json(response, "read error body").await;
         assert_invalid_error(&info, "missing encryption key");
+    }
+
+    #[tokio::test]
+    async fn unary_read_missing_key_still_auto_creates_stream() {
+        let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
+        basin_config.create_stream_on_read = true;
+        let (app, backend, basin, stream) =
+            setup_app_with_basin_only("read-missing-key-create", basin_config).await;
+
+        let response = send(
+            &app,
+            request_builder("GET", read_uri(&stream), &basin)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let info = response_json(response, "read error body").await;
+        assert_invalid_error(&info, "missing encryption key");
+        assert_listed_stream_cipher(
+            &backend,
+            &basin,
+            &stream,
+            Some(EncryptionAlgorithm::Aegis256),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn invalid_read_bounds_do_not_auto_create_stream() {
+        let basin_config = BasinConfig {
+            create_stream_on_read: true,
+            ..Default::default()
+        };
+        let (app, backend, basin, stream) =
+            setup_app_with_basin_only("read-invalid-bounds-no-create", basin_config).await;
+
+        let response = send(
+            &app,
+            request_builder(
+                "GET",
+                format!("/v1/streams/{stream}/records?timestamp=5&until=5"),
+                &basin,
+            )
+            .body(Body::empty())
+            .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let info = response_json(response, "read error body").await;
+        assert_invalid_error(&info, "start `timestamp` exceeds or equal to `until`");
+        assert_no_streams(&backend, &basin).await;
     }
 
     #[tokio::test]

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -573,7 +573,7 @@ mod tests {
         (app, backend, basin, stream)
     }
 
-    async fn setup_app_with_missing_stream(
+    async fn setup_app_without_stream(
         test_suffix: &str,
         basin_config: BasinConfig,
     ) -> (axum::Router, Backend, BasinName, StreamName) {
@@ -799,7 +799,7 @@ mod tests {
         let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
         basin_config.create_stream_on_append = true;
         let (app, backend, basin, stream) =
-            setup_app_with_missing_stream("append-auto-create-encrypted", basin_config).await;
+            setup_app_without_stream("append-auto-create-encrypted", basin_config).await;
 
         let input = proto::AppendInput {
             records: vec![proto::AppendRecord {
@@ -867,7 +867,7 @@ mod tests {
         let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
         basin_config.create_stream_on_read = true;
         let (app, backend, basin, stream) =
-            setup_app_with_missing_stream("read-auto-create-encrypted", basin_config).await;
+            setup_app_without_stream("read-auto-create-encrypted", basin_config).await;
 
         let response = send(
             &app,
@@ -897,7 +897,7 @@ mod tests {
             ..Default::default()
         };
         let (app, backend, basin, stream) =
-            setup_app_with_missing_stream("read-invalid-bounds-no-create", basin_config).await;
+            setup_app_without_stream("read-invalid-bounds-no-create", basin_config).await;
 
         let response = send(
             &app,

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -548,7 +548,7 @@ mod tests {
     fn all_encryption_modes_basin_config() -> BasinConfig {
         BasinConfig {
             default_stream_config: all_encryption_modes_stream_config(),
-            stream_encryption_algorithm: Some(EncryptionAlgorithm::Aegis256),
+            stream_cipher: Some(EncryptionAlgorithm::Aegis256),
             ..Default::default()
         }
     }

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -637,25 +637,6 @@ mod tests {
         );
     }
 
-    async fn assert_listed_stream_cipher(
-        backend: &Backend,
-        basin: &BasinName,
-        stream: &StreamName,
-        expected_cipher: Option<EncryptionAlgorithm>,
-    ) {
-        let stream_list = backend
-            .list_streams(basin.clone(), ListStreamsRequest::default())
-            .await
-            .expect("list streams");
-        let stream_names: Vec<_> = stream_list
-            .values
-            .iter()
-            .map(|info| info.name.as_ref())
-            .collect();
-        assert_eq!(stream_names, vec![stream.as_ref()]);
-        assert_eq!(stream_list.values[0].cipher, expected_cipher);
-    }
-
     async fn assert_no_streams(backend: &Backend, basin: &BasinName) {
         let stream_list = backend
             .list_streams(basin.clone(), ListStreamsRequest::default())
@@ -736,103 +717,6 @@ mod tests {
             panic!("expected envelope record");
         };
         assert_eq!(record.body().as_ref(), b"secret");
-    }
-
-    #[tokio::test]
-    async fn unary_append_auto_creates_encrypted_stream() {
-        let encryption_key = aegis_key(0x42);
-        let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
-        basin_config.create_stream_on_append = true;
-        let (app, backend, basin, stream) =
-            setup_app_without_stream("append-auto-create-encrypted", basin_config).await;
-
-        let input = proto::AppendInput {
-            records: vec![proto::AppendRecord {
-                timestamp: None,
-                headers: vec![],
-                body: Bytes::from_static(b"secret"),
-            }],
-            match_seq_num: None,
-            fencing_token: None,
-        };
-
-        let response = send(
-            &app,
-            request_builder("POST", format!("/v1/streams/{stream}/records"), &basin)
-                .header(header::CONTENT_TYPE, "application/protobuf")
-                .header(header::ACCEPT, "application/protobuf")
-                .header(
-                    S2_ENCRYPTION_KEY_HEADER.as_str(),
-                    encryption_key.to_header_value(),
-                )
-                .body(Body::from(input.encode_to_vec()))
-                .unwrap(),
-        )
-        .await;
-
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_bytes(response, "append ack body").await;
-        let ack = proto::AppendAck::decode(body).expect("append ack");
-        assert_eq!(ack.end.as_ref().map(|pos| pos.seq_num), Some(1));
-
-        assert_listed_stream_cipher(
-            &backend,
-            &basin,
-            &stream,
-            Some(EncryptionAlgorithm::Aegis256),
-        )
-        .await;
-
-        let response = send(
-            &app,
-            request_builder(
-                "GET",
-                format!("/v1/streams/{stream}/records?seq_num=0&wait=1"),
-                &basin,
-            )
-            .header(header::ACCEPT, "application/protobuf")
-            .header(
-                S2_ENCRYPTION_KEY_HEADER.as_str(),
-                encryption_key.to_header_value(),
-            )
-            .body(Body::empty())
-            .unwrap(),
-        )
-        .await;
-
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_bytes(response, "read batch body").await;
-        let batch = proto::ReadBatch::decode(body).expect("read batch");
-        assert_eq!(batch.records.len(), 1);
-        assert_eq!(batch.records[0].body.as_ref(), b"secret");
-    }
-
-    #[tokio::test]
-    async fn check_tail_auto_creates_stream_with_basin_cipher() {
-        let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
-        basin_config.create_stream_on_read = true;
-        let (app, backend, basin, stream) =
-            setup_app_without_stream("read-auto-create-encrypted", basin_config).await;
-
-        let response = send(
-            &app,
-            request_builder("GET", format!("/v1/streams/{stream}/records/tail"), &basin)
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await;
-
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_json(response, "tail response body").await;
-        assert_eq!(body["tail"]["seq_num"], 0);
-
-        assert_listed_stream_cipher(
-            &backend,
-            &basin,
-            &stream,
-            Some(EncryptionAlgorithm::Aegis256),
-        )
-        .await;
     }
 
     #[tokio::test]

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -215,14 +215,14 @@ pub async fn read(
             format,
             response_mime,
         } => {
-            let encryption_algorithm = backend
-                .stream_encryption_algorithm_with_auto_create::<crate::backend::error::ReadError>(
+            let cipher = backend
+                .stream_cipher_with_auto_create::<crate::backend::error::ReadError>(
                     &basin,
                     &stream,
                     |config| config.create_stream_on_read,
                 )
                 .await?;
-            let encryption = EncryptionSpec::resolve(encryption_algorithm, encryption_key)?;
+            let encryption = EncryptionSpec::resolve(cipher, encryption_key)?;
             let (start, end) = prepare_read(start, end, ReadMode::Unary)?;
             let session = backend.read(basin, stream, start, end).await?;
             let session = decrypt_session(session, encryption, stream_id);
@@ -243,14 +243,14 @@ pub async fn read(
             format,
             last_event_id,
         } => {
-            let encryption_algorithm = backend
-                .stream_encryption_algorithm_with_auto_create::<crate::backend::error::ReadError>(
+            let cipher = backend
+                .stream_cipher_with_auto_create::<crate::backend::error::ReadError>(
                     &basin,
                     &stream,
                     |config| config.create_stream_on_read,
                 )
                 .await?;
-            let encryption = EncryptionSpec::resolve(encryption_algorithm, encryption_key)?;
+            let encryption = EncryptionSpec::resolve(cipher, encryption_key)?;
             let (start, end) = apply_last_event_id(start, end, last_event_id);
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
             let session = backend.read(basin, stream, start, end).await?;
@@ -295,14 +295,14 @@ pub async fn read(
             encryption_key,
             response_compression,
         } => {
-            let encryption_algorithm = backend
-                .stream_encryption_algorithm_with_auto_create::<crate::backend::error::ReadError>(
+            let cipher = backend
+                .stream_cipher_with_auto_create::<crate::backend::error::ReadError>(
                     &basin,
                     &stream,
                     |config| config.create_stream_on_read,
                 )
                 .await?;
-            let encryption = EncryptionSpec::resolve(encryption_algorithm, encryption_key)?;
+            let encryption = EncryptionSpec::resolve(cipher, encryption_key)?;
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
             let session = backend.read(basin, stream, start, end).await?;
             let s2s_stream =
@@ -420,14 +420,14 @@ pub async fn append(
             input,
             response_mime,
         } => {
-            let encryption_algorithm = backend
-                .stream_encryption_algorithm_with_auto_create::<crate::backend::error::AppendError>(
+            let cipher = backend
+                .stream_cipher_with_auto_create::<crate::backend::error::AppendError>(
                     &basin,
                     &stream,
                     |config| config.create_stream_on_append,
                 )
                 .await?;
-            let encryption = EncryptionSpec::resolve(encryption_algorithm, encryption_key)?;
+            let encryption = EncryptionSpec::resolve(cipher, encryption_key)?;
             let input = input.encrypt(&encryption, stream_id.as_bytes());
             let ack = backend.append(basin, stream, input).await?;
             match response_mime {
@@ -446,14 +446,14 @@ pub async fn append(
             inputs,
             response_compression,
         } => {
-            let encryption_algorithm = backend
-                .stream_encryption_algorithm_with_auto_create::<crate::backend::error::AppendError>(
+            let cipher = backend
+                .stream_cipher_with_auto_create::<crate::backend::error::AppendError>(
                     &basin,
                     &stream,
                     |config| config.create_stream_on_append,
                 )
                 .await?;
-            let encryption = EncryptionSpec::resolve(encryption_algorithm, encryption_key)?;
+            let encryption = EncryptionSpec::resolve(cipher, encryption_key)?;
             let (err_tx, err_rx) = tokio::sync::oneshot::channel();
 
             let inputs = async_stream::stream! {

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -14,7 +14,7 @@ use s2_api::{
 };
 use s2_common::{
     caps::RECORD_BATCH_MAX,
-    encryption::Encryption,
+    encryption::EncryptionSpec,
     http::extract::Header,
     read_extent::{CountOrBytes, ReadLimit},
     record::{Metered, MeteredSize as _},
@@ -40,7 +40,7 @@ pub fn router() -> axum::Router<Backend> {
 
 fn decrypt_session<S>(
     session: S,
-    encryption: Encryption,
+    encryption: EncryptionSpec,
     stream_id: StreamId,
 ) -> impl Stream<Item = Result<ReadSessionOutput, ServiceError>>
 where
@@ -185,7 +185,7 @@ pub struct ReadArgs {
     params(
         v1t::StreamNamePathSegment,
         s2_api::data::S2FormatHeader,
-        s2_api::data::S2EncryptionHeader,
+        s2_api::data::S2EncryptionKeyHeader,
         v1t::stream::ReadStart,
         v1t::stream::ReadEnd,
     ),
@@ -222,7 +222,7 @@ pub async fn read(
                     |config| config.create_stream_on_read,
                 )
                 .await?;
-            let encryption = Encryption::resolve(encryption_algorithm, encryption_key)?;
+            let encryption = EncryptionSpec::resolve(encryption_algorithm, encryption_key)?;
             let (start, end) = prepare_read(start, end, ReadMode::Unary)?;
             let session = backend.read(basin, stream, start, end).await?;
             let session = decrypt_session(session, encryption, stream_id);
@@ -250,7 +250,7 @@ pub async fn read(
                     |config| config.create_stream_on_read,
                 )
                 .await?;
-            let encryption = Encryption::resolve(encryption_algorithm, encryption_key)?;
+            let encryption = EncryptionSpec::resolve(encryption_algorithm, encryption_key)?;
             let (start, end) = apply_last_event_id(start, end, last_event_id);
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
             let session = backend.read(basin, stream, start, end).await?;
@@ -302,7 +302,7 @@ pub async fn read(
                     |config| config.create_stream_on_read,
                 )
                 .await?;
-            let encryption = Encryption::resolve(encryption_algorithm, encryption_key)?;
+            let encryption = EncryptionSpec::resolve(encryption_algorithm, encryption_key)?;
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
             let session = backend.read(basin, stream, start, end).await?;
             let s2s_stream =
@@ -395,7 +395,7 @@ pub struct AppendArgs {
     params(
         v1t::StreamNamePathSegment,
         s2_api::data::S2FormatHeader,
-        s2_api::data::S2EncryptionHeader,
+        s2_api::data::S2EncryptionKeyHeader,
     ),
     servers(
         (url = super::paths::cloud_endpoints::BASIN, variables(
@@ -427,7 +427,7 @@ pub async fn append(
                     |config| config.create_stream_on_append,
                 )
                 .await?;
-            let encryption = Encryption::resolve(encryption_algorithm, encryption_key)?;
+            let encryption = EncryptionSpec::resolve(encryption_algorithm, encryption_key)?;
             let input = input.encrypt(&encryption, stream_id.as_bytes());
             let ack = backend.append(basin, stream, input).await?;
             match response_mime {
@@ -453,7 +453,7 @@ pub async fn append(
                     |config| config.create_stream_on_append,
                 )
                 .await?;
-            let encryption = Encryption::resolve(encryption_algorithm, encryption_key)?;
+            let encryption = EncryptionSpec::resolve(encryption_algorithm, encryption_key)?;
             let (err_tx, err_rx) = tokio::sync::oneshot::channel();
 
             let inputs = async_stream::stream! {
@@ -519,7 +519,9 @@ mod tests {
         s2s::{FrameDecoder, SessionMessage},
     };
     use s2_common::{
-        encryption::{Encryption, EncryptionAlgorithm, EncryptionKey, S2_ENCRYPTION_KEY_HEADER},
+        encryption::{
+            EncryptionAlgorithm, EncryptionKey, EncryptionSpec, S2_ENCRYPTION_KEY_HEADER,
+        },
         read_extent::{ReadLimit, ReadUntil},
         record::{EnvelopeRecord, Metered, Record, RecordDecryptionError},
         types::{
@@ -616,7 +618,7 @@ mod tests {
         basin: &BasinName,
         stream: &StreamName,
         body: &'static [u8],
-        encryption: &Encryption,
+        encryption: &EncryptionSpec,
     ) {
         let stream_id = StreamId::new(basin, stream);
         let input = append_input(body).encrypt(encryption, stream_id.as_bytes());
@@ -712,7 +714,7 @@ mod tests {
 
     #[tokio::test]
     async fn unary_append_with_encryption_header_persists_encrypted_record() {
-        let encryption = Encryption::aegis256([0x42; 32]);
+        let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let encryption_key = aegis_key(0x42);
         let (app, backend, basin, stream) = setup_app_with_config(
             "append-unary-encrypted",
@@ -753,7 +755,7 @@ mod tests {
         let stored_batch = first_stored_batch(&backend, &basin, &stream).await;
 
         assert!(matches!(
-            stored_batch.clone().decrypt(&Encryption::Plain, &[]),
+            stored_batch.clone().decrypt(&EncryptionSpec::plain(), &[]),
             Err(RecordDecryptionError::AlgorithmMismatch {
                 expected: None,
                 actual: Some(EncryptionAlgorithm::Aegis256),
@@ -774,7 +776,7 @@ mod tests {
 
     #[tokio::test]
     async fn unary_read_with_wrong_key_returns_decryption_failed_error() {
-        let encryption = Encryption::aegis256([0x42; 32]);
+        let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let wrong_key = aegis_key(0x24);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-unary-bad-key",
@@ -809,7 +811,7 @@ mod tests {
 
     #[tokio::test]
     async fn sse_read_without_key_header_emits_error_event_and_terminates() {
-        let encryption = Encryption::aegis256([0x42; 32]);
+        let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-sse-plain",
             all_encryption_modes_basin_config(),
@@ -838,7 +840,7 @@ mod tests {
 
     #[tokio::test]
     async fn s2s_read_without_key_header_returns_terminal_invalid_frame() {
-        let encryption = Encryption::aegis256([0x42; 32]);
+        let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-s2s-plain",
             all_encryption_modes_basin_config(),
@@ -863,7 +865,7 @@ mod tests {
 
     #[tokio::test]
     async fn s2s_read_with_correct_encryption_returns_batch_frame() {
-        let encryption = Encryption::aegis256([0x42; 32]);
+        let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let encryption_key = aegis_key(0x42);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-s2s-ok",

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -858,57 +858,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unary_append_missing_key_still_auto_creates_stream() {
-        let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
-        basin_config.create_stream_on_append = true;
-        let (app, backend, basin, stream) =
-            setup_app_with_basin_only("append-missing-key-create", basin_config).await;
-
-        let input = proto::AppendInput {
-            records: vec![proto::AppendRecord {
-                timestamp: None,
-                headers: vec![],
-                body: Bytes::from_static(b"secret"),
-            }],
-            match_seq_num: None,
-            fencing_token: None,
-        };
-
-        let response = send(
-            &app,
-            request_builder("POST", format!("/v1/streams/{stream}/records"), &basin)
-                .header(header::CONTENT_TYPE, "application/protobuf")
-                .header(header::ACCEPT, "application/protobuf")
-                .body(Body::from(input.encode_to_vec()))
-                .unwrap(),
-        )
-        .await;
-
-        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
-        let info = response_json(response, "append error body").await;
-        assert_invalid_error(&info, "missing encryption key");
-        assert_listed_stream_cipher(
-            &backend,
-            &basin,
-            &stream,
-            Some(EncryptionAlgorithm::Aegis256),
-        )
-        .await;
-
-        let response = send(
-            &app,
-            request_builder("GET", format!("/v1/streams/{stream}/records/tail"), &basin)
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await;
-
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response_json(response, "tail response body").await;
-        assert_eq!(body["tail"]["seq_num"], 0);
-    }
-
-    #[tokio::test]
     async fn check_tail_auto_creates_stream_with_basin_cipher() {
         let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
         basin_config.create_stream_on_read = true;
@@ -927,45 +876,6 @@ mod tests {
         let body = response_json(response, "tail response body").await;
         assert_eq!(body["tail"]["seq_num"], 0);
 
-        assert_listed_stream_cipher(
-            &backend,
-            &basin,
-            &stream,
-            Some(EncryptionAlgorithm::Aegis256),
-        )
-        .await;
-
-        let response = send(
-            &app,
-            request_builder("GET", read_uri(&stream), &basin)
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await;
-
-        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
-        let info = response_json(response, "read error body").await;
-        assert_invalid_error(&info, "missing encryption key");
-    }
-
-    #[tokio::test]
-    async fn unary_read_missing_key_still_auto_creates_stream() {
-        let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
-        basin_config.create_stream_on_read = true;
-        let (app, backend, basin, stream) =
-            setup_app_with_basin_only("read-missing-key-create", basin_config).await;
-
-        let response = send(
-            &app,
-            request_builder("GET", read_uri(&stream), &basin)
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await;
-
-        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
-        let info = response_json(response, "read error body").await;
-        assert_invalid_error(&info, "missing encryption key");
         assert_listed_stream_cipher(
             &backend,
             &basin,

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -14,24 +14,19 @@ use s2_api::{
 };
 use s2_common::{
     caps::RECORD_BATCH_MAX,
-    encryption::{EncryptionKey, EncryptionSpec},
     http::extract::Header,
     read_extent::{CountOrBytes, ReadLimit},
     record::{Metered, MeteredSize as _},
     types::{
         ValidationError,
         basin::BasinName,
-        stream::{
-            ReadBatch, ReadEnd, ReadFrom, ReadSessionOutput, ReadStart, StoredReadSessionOutput,
-            StreamName,
-        },
+        stream::{ReadBatch, ReadEnd, ReadFrom, ReadSessionOutput, ReadStart, StreamName},
     },
 };
 
 use crate::{
     backend::{Backend, error::ReadError},
     handlers::v1::error::ServiceError,
-    stream_id::StreamId,
 };
 
 pub fn router() -> axum::Router<Backend> {
@@ -40,32 +35,6 @@ pub fn router() -> axum::Router<Backend> {
         .route(super::paths::streams::records::CHECK_TAIL, get(check_tail))
         .route(super::paths::streams::records::READ, get(read))
         .route(super::paths::streams::records::APPEND, post(append))
-}
-
-fn decrypt_session<S>(
-    session: S,
-    encryption: EncryptionSpec,
-    stream_id: StreamId,
-) -> impl Stream<Item = Result<ReadSessionOutput, ServiceError>>
-where
-    S: Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
-{
-    async_stream::stream! {
-        tokio::pin!(session);
-        while let Some(output) = session.next().await {
-            let output = match output {
-                Ok(output) => output
-                    .decrypt(&encryption, stream_id.as_bytes())
-                    .map_err(ServiceError::from),
-                Err(err) => Err(err.into()),
-            };
-            let should_stop = output.is_err();
-            yield output;
-            if should_stop {
-                break;
-            }
-        }
-    }
 }
 
 fn validate_read_until(start: ReadStart, end: ReadEnd) -> Result<(), ServiceError> {
@@ -116,21 +85,6 @@ fn prepare_read(
     Ok((start, end))
 }
 
-async fn open_read_session(
-    backend: &Backend,
-    basin: &BasinName,
-    stream: &StreamName,
-    start: ReadStart,
-    end: ReadEnd,
-    encryption_key: Option<EncryptionKey>,
-) -> Result<impl Stream<Item = Result<ReadSessionOutput, ServiceError>> + use<>, ServiceError> {
-    let handle = backend.open_for_read::<ReadError>(basin, stream).await?;
-    let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
-    let stream_id = handle.stream_id();
-    let session = handle.read(start, end).await?;
-    Ok(decrypt_session(session, encryption, stream_id))
-}
-
 #[derive(FromRequest)]
 #[from_request(rejection(ServiceError))]
 pub struct CheckTailArgs {
@@ -166,7 +120,11 @@ pub async fn check_tail(
     State(backend): State<Backend>,
     CheckTailArgs { basin, stream }: CheckTailArgs,
 ) -> Result<Json<v1t::stream::TailResponse>, ServiceError> {
-    let tail = backend.check_tail(basin, stream).await?;
+    let tail = backend
+        .open_for_check_tail(&basin, &stream)
+        .await?
+        .check_tail()
+        .await?;
     Ok(Json(v1t::stream::TailResponse { tail: tail.into() }))
 }
 
@@ -234,8 +192,11 @@ pub async fn read(
             response_mime,
         } => {
             let (start, end) = prepare_read(start, end, ReadMode::Unary)?;
-            let session =
-                open_read_session(&backend, &basin, &stream, start, end, encryption_key).await?;
+            let session = backend
+                .open_for_read(&basin, &stream, encryption_key)
+                .await?
+                .read(start, end)
+                .await?;
             let batch = merge_read_session(session, end.wait).await?;
             match response_mime {
                 JsonOrProto::Json => Ok(Json(v1t::stream::json::serialize_read_batch(
@@ -255,8 +216,11 @@ pub async fn read(
         } => {
             let (start, end) = apply_last_event_id(start, end, last_event_id);
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
-            let session =
-                open_read_session(&backend, &basin, &stream, start, end, encryption_key).await?;
+            let session = backend
+                .open_for_read(&basin, &stream, encryption_key)
+                .await?
+                .read(start, end)
+                .await?;
             let events = async_stream::stream! {
                 let mut processed = CountOrBytes::ZERO;
                 tokio::pin!(session);
@@ -280,7 +244,7 @@ pub async fn read(
                             yield v1t::stream::sse::read_batch_event(format, &batch, id);
                         },
                         Err(err) => {
-                            let (_, body) = err.to_response().to_parts();
+                            let (_, body) = ServiceError::from(err).to_response().to_parts();
                             yield v1t::stream::sse::error_event(body);
                             errored = true;
                         }
@@ -298,19 +262,21 @@ pub async fn read(
             response_compression,
         } => {
             let (start, end) = prepare_read(start, end, ReadMode::Streaming)?;
-            let session =
-                open_read_session(&backend, &basin, &stream, start, end, encryption_key).await?;
-            let s2s_stream = session.map_ok(|msg| match msg {
-                ReadSessionOutput::Heartbeat(tail) => v1t::stream::proto::ReadBatch {
-                    records: vec![],
-                    tail: Some(tail.into()),
-                },
-                ReadSessionOutput::Batch(batch) => v1t::stream::proto::ReadBatch::from(batch),
-            });
-            let response_stream = s2s::FramedMessageStream::<_>::new(
-                response_compression,
-                Box::pin(s2s_stream.map_err(ServiceError::from)),
-            );
+            let s2s_stream = backend
+                .open_for_read(&basin, &stream, encryption_key)
+                .await?
+                .read(start, end)
+                .await?
+                .map_ok(|msg| match msg {
+                    ReadSessionOutput::Heartbeat(tail) => v1t::stream::proto::ReadBatch {
+                        records: vec![],
+                        tail: Some(tail.into()),
+                    },
+                    ReadSessionOutput::Batch(batch) => v1t::stream::proto::ReadBatch::from(batch),
+                })
+                .map_err(ServiceError::from);
+            let response_stream =
+                s2s::FramedMessageStream::<_>::new(response_compression, Box::pin(s2s_stream));
             Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header(http::header::CONTENT_TYPE, "s2s/proto")
@@ -321,7 +287,7 @@ pub async fn read(
 }
 
 async fn merge_read_session(
-    session: impl Stream<Item = Result<ReadSessionOutput, ServiceError>>,
+    session: impl Stream<Item = Result<ReadSessionOutput, ReadError>>,
     wait: Option<Duration>,
 ) -> Result<ReadBatch, ServiceError> {
     let mut acc = ReadBatch {
@@ -407,17 +373,15 @@ pub async fn append(
         request,
     }: AppendArgs,
 ) -> Result<Response, ServiceError> {
-    let handle = backend.open_for_append(&basin, &stream).await?;
-    let stream_id = handle.stream_id();
     match request {
         v1t::stream::AppendRequest::Unary {
             encryption_key,
             input,
             response_mime,
         } => {
-            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
-
-            let input = input.encrypt(&encryption, stream_id.as_bytes());
+            let handle = backend
+                .open_for_append(&basin, &stream, encryption_key)
+                .await?;
             let ack = handle.append(input).await?;
             match response_mime {
                 JsonOrProto::Json => {
@@ -435,8 +399,9 @@ pub async fn append(
             inputs,
             response_compression,
         } => {
-            let encryption = EncryptionSpec::resolve(handle.cipher(), encryption_key)?;
-
+            let handle = backend
+                .open_for_append(&basin, &stream, encryption_key)
+                .await?;
             let (err_tx, err_rx) = tokio::sync::oneshot::channel();
 
             let inputs = async_stream::stream! {
@@ -444,7 +409,7 @@ pub async fn append(
                 let mut err_tx = Some(err_tx);
                 while let Some(input) = inputs.next().await {
                     match input {
-                        Ok(input) => yield input.encrypt(&encryption, stream_id.as_bytes()),
+                        Ok(input) => yield input,
                         Err(e) => {
                             if let Some(tx) = err_tx.take() {
                                 let _ = tx.send(e);
@@ -492,26 +457,23 @@ mod tests {
     };
     use bytes::{Bytes, BytesMut};
     use bytesize::ByteSize;
-    use futures::StreamExt as _;
+    use futures::TryStreamExt as _;
     use prost::Message as _;
     use s2_api::v1::stream::{
         proto,
         s2s::{FrameDecoder, SessionMessage},
     };
     use s2_common::{
-        encryption::{
-            EncryptionAlgorithm, EncryptionKey, EncryptionSpec, S2_ENCRYPTION_KEY_HEADER,
-        },
+        encryption::{EncryptionAlgorithm, EncryptionKey, S2_ENCRYPTION_KEY_HEADER},
         read_extent::{ReadLimit, ReadUntil},
-        record::{EnvelopeRecord, Metered, Record, RecordDecryptionError},
+        record::{EnvelopeRecord, Metered, Record},
         types::{
             basin::{BASIN_HEADER, BasinName},
             config::{BasinConfig, OptionalStreamConfig},
             resources::CreateMode,
             stream::{
                 AppendInput, AppendRecord, AppendRecordBatch, AppendRecordParts,
-                ListStreamsRequest, ReadEnd, ReadFrom, ReadStart, StoredReadBatch,
-                StoredReadSessionOutput, StreamName,
+                ListStreamsRequest, ReadEnd, ReadFrom, ReadSessionOutput, ReadStart, StreamName,
             },
         },
     };
@@ -520,7 +482,7 @@ mod tests {
     use tower::ServiceExt as _;
     use uuid::Uuid;
 
-    use crate::{backend::Backend, handlers, stream_id::StreamId};
+    use crate::{backend::Backend, handlers};
 
     fn basin_config_with_stream_cipher(stream_cipher: EncryptionAlgorithm) -> BasinConfig {
         BasinConfig {
@@ -610,12 +572,13 @@ mod tests {
         basin: &BasinName,
         stream: &StreamName,
         body: &'static [u8],
-        encryption: &EncryptionSpec,
+        encryption_key: EncryptionKey,
     ) {
-        let stream_id = StreamId::new(basin, stream);
-        let input = append_input(body).encrypt(encryption, stream_id.as_bytes());
         backend
-            .append(basin.clone(), stream.clone(), input)
+            .open_for_append(basin, stream, Some(encryption_key))
+            .await
+            .expect("open append handle")
+            .append(append_input(body))
             .await
             .expect("append encrypted payload");
     }
@@ -664,36 +627,6 @@ mod tests {
         frame
     }
 
-    async fn first_stored_batch(
-        backend: &Backend,
-        basin: &BasinName,
-        stream: &StreamName,
-    ) -> StoredReadBatch {
-        let session = backend
-            .read(
-                basin.clone(),
-                stream.clone(),
-                ReadStart {
-                    from: ReadFrom::SeqNum(0),
-                    clamp: false,
-                },
-                ReadEnd {
-                    limit: ReadLimit::Unbounded,
-                    until: ReadUntil::Unbounded,
-                    wait: Some(Duration::ZERO),
-                },
-            )
-            .await
-            .expect("create stored read session");
-        let mut session = Box::pin(session);
-        match session.next().await {
-            Some(Ok(StoredReadSessionOutput::Batch(batch))) => batch,
-            Some(Ok(other)) => panic!("unexpected first output: {other:?}"),
-            Some(Err(err)) => panic!("unexpected read error: {err:?}"),
-            None => panic!("read session ended without batch"),
-        }
-    }
-
     fn assert_invalid_error(info: &serde_json::Value, expected_message: &str) {
         assert_eq!(info["code"], "invalid");
         assert!(
@@ -733,7 +666,6 @@ mod tests {
 
     #[tokio::test]
     async fn unary_append_with_encryption_header_persists_encrypted_record() {
-        let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let encryption_key = aegis_key(0x42);
         let (app, backend, basin, stream) = setup_app_with_config(
             "append-unary-encrypted",
@@ -771,20 +703,33 @@ mod tests {
         let ack = proto::AppendAck::decode(body).expect("append ack");
         assert_eq!(ack.end.as_ref().map(|pos| pos.seq_num), Some(1));
 
-        let stored_batch = first_stored_batch(&backend, &basin, &stream).await;
-
-        assert!(matches!(
-            stored_batch.clone().decrypt(&EncryptionSpec::Plain, &[]),
-            Err(RecordDecryptionError::AlgorithmMismatch {
-                expected: None,
-                actual: Some(EncryptionAlgorithm::Aegis256),
+        let records = backend
+            .open_for_read(&basin, &stream, Some(encryption_key.clone()))
+            .await
+            .expect("open read handle")
+            .read(
+                ReadStart {
+                    from: ReadFrom::SeqNum(0),
+                    clamp: false,
+                },
+                ReadEnd {
+                    limit: ReadLimit::Unbounded,
+                    until: ReadUntil::Unbounded,
+                    wait: Some(Duration::ZERO),
+                },
+            )
+            .await
+            .expect("create read session")
+            .try_filter_map(|output| async move {
+                match output {
+                    ReadSessionOutput::Batch(batch) => Ok(Some(batch)),
+                    ReadSessionOutput::Heartbeat(_) => Ok(None),
+                }
             })
-        ));
-
-        let stream_id = StreamId::new(&basin, &stream);
-        let batch = stored_batch
-            .decrypt(&encryption, stream_id.as_bytes())
-            .expect("decrypt stored batch");
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("read encrypted record");
+        let batch = records.into_iter().next().expect("batch");
         assert_eq!(batch.records.len(), 1);
         let record = batch.records.first().expect("record");
         let Record::Envelope(record) = record.inner() else {
@@ -919,7 +864,7 @@ mod tests {
 
     #[tokio::test]
     async fn unary_read_with_wrong_key_returns_decryption_failed_error() {
-        let encryption = EncryptionSpec::aegis256([0x42; 32]);
+        let encryption_key = aegis_key(0x42);
         let wrong_key = aegis_key(0x24);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-unary-bad-key",
@@ -927,7 +872,7 @@ mod tests {
             OptionalStreamConfig::default(),
         )
         .await;
-        append_encrypted_payload(&backend, &basin, &stream, b"secret", &encryption).await;
+        append_encrypted_payload(&backend, &basin, &stream, b"secret", encryption_key).await;
 
         let response = send(
             &app,
@@ -953,15 +898,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sse_read_without_key_header_emits_error_event_and_terminates() {
-        let encryption = EncryptionSpec::aegis256([0x42; 32]);
+    async fn sse_read_without_key_header_is_rejected_before_stream_starts() {
+        let encryption_key = aegis_key(0x42);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-sse-plain",
             basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256),
             OptionalStreamConfig::default(),
         )
         .await;
-        append_encrypted_payload(&backend, &basin, &stream, b"secret", &encryption).await;
+        append_encrypted_payload(&backend, &basin, &stream, b"secret", encryption_key).await;
 
         let response = send(
             &app,
@@ -982,15 +927,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn s2s_read_without_key_header_returns_terminal_invalid_frame() {
-        let encryption = EncryptionSpec::aegis256([0x42; 32]);
+    async fn s2s_read_without_key_header_is_rejected_before_stream_starts() {
+        let encryption_key = aegis_key(0x42);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-s2s-plain",
             basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256),
             OptionalStreamConfig::default(),
         )
         .await;
-        append_encrypted_payload(&backend, &basin, &stream, b"secret", &encryption).await;
+        append_encrypted_payload(&backend, &basin, &stream, b"secret", encryption_key).await;
 
         let response = send(
             &app,
@@ -1008,7 +953,6 @@ mod tests {
 
     #[tokio::test]
     async fn s2s_read_with_correct_encryption_returns_batch_frame() {
-        let encryption = EncryptionSpec::aegis256([0x42; 32]);
         let encryption_key = aegis_key(0x42);
         let (app, backend, basin, stream) = setup_app_with_config(
             "read-s2s-ok",
@@ -1016,7 +960,8 @@ mod tests {
             OptionalStreamConfig::default(),
         )
         .await;
-        append_encrypted_payload(&backend, &basin, &stream, b"secret", &encryption).await;
+        append_encrypted_payload(&backend, &basin, &stream, b"secret", encryption_key.clone())
+            .await;
 
         let response = send(
             &app,

--- a/lite/src/init.rs
+++ b/lite/src/init.rs
@@ -50,7 +50,7 @@ pub struct StreamSpec {
 pub struct BasinConfigSpec {
     #[serde(default)]
     pub default_stream_config: Option<StreamConfigSpec>,
-    /// Cipher to apply to newly created streams in the basin.
+    /// Encryption algorithm to apply to newly created streams in the basin.
     #[serde(default)]
     pub stream_cipher: Option<EncryptionAlgorithmSpec>,
     /// Create stream on append if it doesn't exist, using the default stream configuration.
@@ -125,7 +125,7 @@ impl schemars::JsonSchema for EncryptionAlgorithmSpec {
     fn json_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
         schemars::json_schema!({
             "type": "string",
-            "description": "Cipher to apply to newly created streams in the basin.",
+            "description": "Encryption algorithm to apply to newly created streams in the basin.",
             "enum": ["aegis-256", "aes-256-gcm"]
         })
     }

--- a/lite/src/init.rs
+++ b/lite/src/init.rs
@@ -685,20 +685,4 @@ mod tests {
         assert!(matches!(reconfig.timestamping, Maybe::Unspecified));
         assert!(matches!(reconfig.delete_on_empty, Maybe::Unspecified));
     }
-
-    #[test]
-    fn basin_config_conversion_includes_stream_cipher() {
-        let spec = BasinConfigSpec {
-            default_stream_config: None,
-            stream_cipher: Some(EncryptionAlgorithmSpec::Aegis256),
-            create_stream_on_append: None,
-            create_stream_on_read: None,
-        };
-
-        let reconfig = BasinReconfiguration::from(spec);
-        assert!(matches!(
-            reconfig.stream_cipher,
-            Maybe::Specified(Some(s2_common::encryption::EncryptionAlgorithm::Aegis256))
-        ));
-    }
 }

--- a/lite/src/init.rs
+++ b/lite/src/init.rs
@@ -50,6 +50,9 @@ pub struct StreamSpec {
 pub struct BasinConfigSpec {
     #[serde(default)]
     pub default_stream_config: Option<StreamConfigSpec>,
+    /// Encryption algorithm materialized into streams created in the basin.
+    #[serde(default)]
+    pub stream_encryption_algorithm: Option<EncryptionAlgorithmSpec>,
     /// Create stream on append if it doesn't exist, using the default stream configuration.
     #[serde(default)]
     pub create_stream_on_append: Option<bool>,
@@ -74,9 +77,6 @@ pub struct StreamConfigSpec {
     /// Delete-on-empty configuration.
     #[serde(default)]
     pub delete_on_empty: Option<DeleteOnEmptySpec>,
-    /// Encryption configuration.
-    #[serde(default)]
-    pub encryption: Option<EncryptionConfigSpec>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -110,44 +110,32 @@ impl From<StorageClassSpec> for StorageClass {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub enum EncryptionModeSpec {
-    #[serde(rename = "plain")]
-    Plain,
+pub enum EncryptionAlgorithmSpec {
     #[serde(rename = "aegis-256")]
     Aegis256,
     #[serde(rename = "aes-256-gcm")]
     Aes256Gcm,
 }
 
-impl schemars::JsonSchema for EncryptionModeSpec {
+impl schemars::JsonSchema for EncryptionAlgorithmSpec {
     fn schema_name() -> Cow<'static, str> {
-        "EncryptionModeSpec".into()
+        "EncryptionAlgorithmSpec".into()
     }
 
     fn json_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
         schemars::json_schema!({
             "type": "string",
-            "description": "Allowed encryption mode.",
-            "enum": ["plain", "aegis-256", "aes-256-gcm"]
+            "description": "Encryption algorithm materialized into streams created in the basin.",
+            "enum": ["aegis-256", "aes-256-gcm"]
         })
     }
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize, schemars::JsonSchema)]
-#[serde(deny_unknown_fields)]
-pub struct EncryptionConfigSpec {
-    /// Allowed encryption modes.
-    /// If empty, use defaults. If no default is configured, only plaintext is allowed.
-    #[serde(default)]
-    pub allowed_modes: Vec<EncryptionModeSpec>,
-}
-
-impl From<EncryptionModeSpec> for s2_common::encryption::EncryptionMode {
-    fn from(m: EncryptionModeSpec) -> Self {
+impl From<EncryptionAlgorithmSpec> for s2_common::encryption::EncryptionAlgorithm {
+    fn from(m: EncryptionAlgorithmSpec) -> Self {
         match m {
-            EncryptionModeSpec::Plain => Self::Plain,
-            EncryptionModeSpec::Aegis256 => Self::Aegis256,
-            EncryptionModeSpec::Aes256Gcm => Self::Aes256Gcm,
+            EncryptionAlgorithmSpec::Aegis256 => Self::Aegis256,
+            EncryptionAlgorithmSpec::Aes256Gcm => Self::Aes256Gcm,
         }
     }
 }
@@ -292,6 +280,10 @@ impl From<BasinConfigSpec> for BasinReconfiguration {
                 .default_stream_config
                 .map(|dsc| Some(StreamReconfiguration::from(dsc)))
                 .map_or(Maybe::Unspecified, Maybe::Specified),
+            stream_encryption_algorithm: s
+                .stream_encryption_algorithm
+                .map(|algorithm| Some(algorithm.into()))
+                .map_or(Maybe::Unspecified, Maybe::Specified),
             create_stream_on_append: s
                 .create_stream_on_append
                 .map_or(Maybe::Unspecified, Maybe::Specified),
@@ -336,19 +328,6 @@ impl From<StreamConfigSpec> for StreamReconfiguration {
                             .min_age
                             .map(|h| Some(h.0))
                             .map_or(Maybe::Unspecified, Maybe::Specified),
-                    })
-                })
-                .map_or(Maybe::Unspecified, Maybe::Specified),
-            encryption: s
-                .encryption
-                .map(|enc| {
-                    Some(s2_common::types::config::EncryptionReconfiguration {
-                        allowed_modes: Maybe::Specified(
-                            enc.allowed_modes
-                                .into_iter()
-                                .map(s2_common::encryption::EncryptionMode::from)
-                                .collect(),
-                        ),
                     })
                 })
                 .map_or(Maybe::Unspecified, Maybe::Specified),
@@ -595,6 +574,7 @@ mod tests {
     fn basin_config_conversion() {
         let spec = BasinConfigSpec {
             default_stream_config: None,
+            stream_encryption_algorithm: None,
             create_stream_on_append: Some(true),
             create_stream_on_read: None,
         };
@@ -692,7 +672,6 @@ mod tests {
             retention_policy: Some(RetentionPolicySpec(RetentionPolicy::Infinite())),
             timestamping: None,
             delete_on_empty: None,
-            encryption: None,
         };
         let reconfig = StreamReconfiguration::from(spec);
         assert!(matches!(
@@ -708,27 +687,18 @@ mod tests {
     }
 
     #[test]
-    fn stream_config_empty_encryption_modes_clear_override() {
-        let spec = StreamConfigSpec {
-            storage_class: None,
-            retention_policy: None,
-            timestamping: None,
-            delete_on_empty: None,
-            encryption: Some(EncryptionConfigSpec {
-                allowed_modes: vec![],
-            }),
+    fn basin_config_conversion_includes_stream_encryption_algorithm() {
+        let spec = BasinConfigSpec {
+            default_stream_config: None,
+            stream_encryption_algorithm: Some(EncryptionAlgorithmSpec::Aegis256),
+            create_stream_on_append: None,
+            create_stream_on_read: None,
         };
 
-        let reconfig = StreamReconfiguration::from(spec);
-
-        match reconfig.encryption {
-            Maybe::Specified(Some(encryption)) => {
-                assert!(matches!(
-                    encryption.allowed_modes,
-                    Maybe::Specified(modes) if modes.is_empty()
-                ));
-            }
-            other => panic!("expected explicit encryption reconfiguration, got {other:?}"),
-        }
+        let reconfig = BasinReconfiguration::from(spec);
+        assert!(matches!(
+            reconfig.stream_encryption_algorithm,
+            Maybe::Specified(Some(s2_common::encryption::EncryptionAlgorithm::Aegis256))
+        ));
     }
 }

--- a/lite/src/init.rs
+++ b/lite/src/init.rs
@@ -50,7 +50,7 @@ pub struct StreamSpec {
 pub struct BasinConfigSpec {
     #[serde(default)]
     pub default_stream_config: Option<StreamConfigSpec>,
-    /// Encryption algorithm materialized into streams created in the basin.
+    /// Encryption algorithm to apply to newly created streams in the basin.
     #[serde(default)]
     pub stream_encryption_algorithm: Option<EncryptionAlgorithmSpec>,
     /// Create stream on append if it doesn't exist, using the default stream configuration.
@@ -125,7 +125,7 @@ impl schemars::JsonSchema for EncryptionAlgorithmSpec {
     fn json_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
         schemars::json_schema!({
             "type": "string",
-            "description": "Encryption algorithm materialized into streams created in the basin.",
+            "description": "Encryption algorithm to apply to newly created streams in the basin.",
             "enum": ["aegis-256", "aes-256-gcm"]
         })
     }

--- a/lite/src/init.rs
+++ b/lite/src/init.rs
@@ -52,7 +52,7 @@ pub struct BasinConfigSpec {
     pub default_stream_config: Option<StreamConfigSpec>,
     /// Encryption algorithm to apply to newly created streams in the basin.
     #[serde(default)]
-    pub stream_encryption_algorithm: Option<EncryptionAlgorithmSpec>,
+    pub stream_cipher: Option<EncryptionAlgorithmSpec>,
     /// Create stream on append if it doesn't exist, using the default stream configuration.
     #[serde(default)]
     pub create_stream_on_append: Option<bool>,
@@ -280,8 +280,8 @@ impl From<BasinConfigSpec> for BasinReconfiguration {
                 .default_stream_config
                 .map(|dsc| Some(StreamReconfiguration::from(dsc)))
                 .map_or(Maybe::Unspecified, Maybe::Specified),
-            stream_encryption_algorithm: s
-                .stream_encryption_algorithm
+            stream_cipher: s
+                .stream_cipher
                 .map(|algorithm| Some(algorithm.into()))
                 .map_or(Maybe::Unspecified, Maybe::Specified),
             create_stream_on_append: s
@@ -574,7 +574,7 @@ mod tests {
     fn basin_config_conversion() {
         let spec = BasinConfigSpec {
             default_stream_config: None,
-            stream_encryption_algorithm: None,
+            stream_cipher: None,
             create_stream_on_append: Some(true),
             create_stream_on_read: None,
         };
@@ -687,17 +687,17 @@ mod tests {
     }
 
     #[test]
-    fn basin_config_conversion_includes_stream_encryption_algorithm() {
+    fn basin_config_conversion_includes_stream_cipher() {
         let spec = BasinConfigSpec {
             default_stream_config: None,
-            stream_encryption_algorithm: Some(EncryptionAlgorithmSpec::Aegis256),
+            stream_cipher: Some(EncryptionAlgorithmSpec::Aegis256),
             create_stream_on_append: None,
             create_stream_on_read: None,
         };
 
         let reconfig = BasinReconfiguration::from(spec);
         assert!(matches!(
-            reconfig.stream_encryption_algorithm,
+            reconfig.stream_cipher,
             Maybe::Specified(Some(s2_common::encryption::EncryptionAlgorithm::Aegis256))
         ));
     }

--- a/lite/src/init.rs
+++ b/lite/src/init.rs
@@ -50,7 +50,7 @@ pub struct StreamSpec {
 pub struct BasinConfigSpec {
     #[serde(default)]
     pub default_stream_config: Option<StreamConfigSpec>,
-    /// Encryption algorithm to apply to newly created streams in the basin.
+    /// Cipher to apply to newly created streams in the basin.
     #[serde(default)]
     pub stream_cipher: Option<EncryptionAlgorithmSpec>,
     /// Create stream on append if it doesn't exist, using the default stream configuration.
@@ -125,7 +125,7 @@ impl schemars::JsonSchema for EncryptionAlgorithmSpec {
     fn json_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
         schemars::json_schema!({
             "type": "string",
-            "description": "Encryption algorithm to apply to newly created streams in the basin.",
+            "description": "Cipher to apply to newly created streams in the basin.",
             "enum": ["aegis-256", "aes-256-gcm"]
         })
     }

--- a/lite/src/lib.rs
+++ b/lite/src/lib.rs
@@ -5,4 +5,4 @@ pub mod handlers;
 pub mod init;
 pub mod metrics;
 pub mod server;
-pub(crate) mod stream_id;
+pub mod stream_id;

--- a/lite/src/server.rs
+++ b/lite/src/server.rs
@@ -8,7 +8,7 @@ use std::{
 use axum_server::tls_rustls::RustlsConfig;
 use bytesize::ByteSize;
 use http::header::AUTHORIZATION;
-use s2_common::encryption::S2_ENCRYPTION_HEADER;
+use s2_common::encryption::S2_ENCRYPTION_KEY_HEADER;
 use slatedb::object_store;
 use tokio::time::Instant;
 use tower_http::{
@@ -215,7 +215,7 @@ pub async fn run(args: LiteArgs) -> eyre::Result<()> {
         )
         .layer(SetSensitiveRequestHeadersLayer::new([
             AUTHORIZATION,
-            S2_ENCRYPTION_HEADER.clone(),
+            S2_ENCRYPTION_KEY_HEADER.clone(),
         ]));
 
     if !args.no_cors {

--- a/lite/tests/backend/common/mod.rs
+++ b/lite/tests/backend/common/mod.rs
@@ -1,5 +1,72 @@
+use std::pin::Pin;
+
+use futures::Stream;
+use s2_common::{
+    encryption::EncryptionSpec,
+    record::StreamPosition,
+    types::{
+        basin::BasinName,
+        stream::{AppendAck, AppendInput, StreamName},
+    },
+};
+use s2_lite::backend::{
+    Backend,
+    error::{AppendError, CheckTailError},
+};
+
 mod read;
 mod setup;
 
 pub use read::*;
 pub use setup::*;
+
+pub async fn append(
+    backend: &Backend,
+    basin: BasinName,
+    stream: StreamName,
+    input: AppendInput,
+    encryption: Option<&EncryptionSpec>,
+) -> Result<AppendAck, AppendError> {
+    backend
+        .open_for_append(
+            &basin,
+            &stream,
+            encryption.and_then(encryption_key_for_spec),
+        )
+        .await?
+        .append(input)
+        .await
+}
+
+pub async fn append_session<S>(
+    backend: &Backend,
+    basin: BasinName,
+    stream: StreamName,
+    encryption: Option<&EncryptionSpec>,
+    inputs: S,
+) -> Result<Pin<Box<dyn Stream<Item = Result<AppendAck, AppendError>>>>, AppendError>
+where
+    S: Stream<Item = AppendInput> + 'static,
+{
+    let session = backend
+        .open_for_append(
+            &basin,
+            &stream,
+            encryption.and_then(encryption_key_for_spec),
+        )
+        .await?
+        .append_session(inputs);
+    Ok(Box::pin(session))
+}
+
+pub async fn check_tail(
+    backend: &Backend,
+    basin: BasinName,
+    stream: StreamName,
+) -> Result<StreamPosition, CheckTailError> {
+    backend
+        .open_for_check_tail(&basin, &stream)
+        .await?
+        .check_tail()
+        .await
+}

--- a/lite/tests/backend/common/read.rs
+++ b/lite/tests/backend/common/read.rs
@@ -7,19 +7,12 @@ use s2_common::{
     record::{Record, SequencedRecord},
     types::{
         basin::BasinName,
-        stream::{
-            ReadBatch, ReadEnd, ReadFrom, ReadStart, StoredReadBatch, StoredReadSessionOutput,
-            StreamName,
-        },
+        stream::{ReadEnd, ReadFrom, ReadSessionOutput, ReadStart, StreamName},
     },
 };
 use s2_lite::backend::{Backend, error::ReadError};
 
-pub fn decrypt_plain_batch(batch: StoredReadBatch) -> ReadBatch {
-    batch
-        .decrypt(&EncryptionSpec::Plain, &[])
-        .expect("Failed to decode batch")
-}
+use super::encryption_key_for_spec;
 
 pub fn read_all_bounds() -> (ReadStart, ReadEnd) {
     (
@@ -35,37 +28,68 @@ pub fn read_all_bounds() -> (ReadStart, ReadEnd) {
     )
 }
 
-pub async fn first_stored_batch(
-    backend: &Backend,
-    basin: &BasinName,
-    stream: &StreamName,
-) -> StoredReadBatch {
-    let (start, end) = read_all_bounds();
-    let read_session = backend
-        .read(basin.clone(), stream.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
-    let mut read_session = Box::pin(read_session);
-    match read_session.next().await {
-        Some(Ok(StoredReadSessionOutput::Batch(batch))) => batch,
-        Some(Ok(other)) => panic!("Unexpected first output: {other:?}"),
-        Some(Err(err)) => panic!("Unexpected backend read error: {err:?}"),
-        None => panic!("Read session ended without delivering batch"),
-    }
-}
-
 pub async fn open_read_session(
     backend: &Backend,
     basin: &BasinName,
     stream: &StreamName,
     start: ReadStart,
     end: ReadEnd,
-) -> Pin<Box<impl futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>>> {
-    let read_session = backend
-        .read(basin.clone(), stream.clone(), start, end)
+) -> Pin<Box<impl futures::Stream<Item = Result<ReadSessionOutput, ReadError>> + use<>>> {
+    open_read_session_with_encryption(backend, basin, stream, start, end, &EncryptionSpec::Plain)
         .await
-        .expect("Failed to create read session");
-    Box::pin(read_session)
+}
+
+pub async fn open_read_session_with_encryption(
+    backend: &Backend,
+    basin: &BasinName,
+    stream: &StreamName,
+    start: ReadStart,
+    end: ReadEnd,
+    encryption: &EncryptionSpec,
+) -> Pin<Box<impl futures::Stream<Item = Result<ReadSessionOutput, ReadError>> + use<>>> {
+    try_open_read_session_with_encryption(backend, basin, stream, start, end, encryption)
+        .await
+        .expect("Failed to create read session")
+}
+
+pub async fn try_open_read_session(
+    backend: &Backend,
+    basin: &BasinName,
+    stream: &StreamName,
+    start: ReadStart,
+    end: ReadEnd,
+) -> Result<
+    Pin<Box<impl futures::Stream<Item = Result<ReadSessionOutput, ReadError>> + use<>>>,
+    ReadError,
+> {
+    try_open_read_session_with_encryption(
+        backend,
+        basin,
+        stream,
+        start,
+        end,
+        &EncryptionSpec::Plain,
+    )
+    .await
+}
+
+pub async fn try_open_read_session_with_encryption(
+    backend: &Backend,
+    basin: &BasinName,
+    stream: &StreamName,
+    start: ReadStart,
+    end: ReadEnd,
+    encryption: &EncryptionSpec,
+) -> Result<
+    Pin<Box<impl futures::Stream<Item = Result<ReadSessionOutput, ReadError>> + use<>>>,
+    ReadError,
+> {
+    let read_session = backend
+        .open_for_read(basin, stream, encryption_key_for_spec(encryption))
+        .await?
+        .read(start, end)
+        .await?;
+    Ok(Box::pin(read_session))
 }
 
 pub async fn advance_time(by: Duration) {
@@ -73,30 +97,18 @@ pub async fn advance_time(by: Duration) {
     tokio::task::yield_now().await;
 }
 
-pub fn decrypt_batch_for_stream(
-    batch: StoredReadBatch,
-    basin: &BasinName,
-    stream: &StreamName,
-    encryption: &EncryptionSpec,
-) -> ReadBatch {
-    let stream_id = s2_lite::backend::StreamId::new(basin, stream);
-    batch
-        .decrypt(encryption, stream_id.as_bytes())
-        .expect("Failed to decode batch")
-}
-
 pub enum SessionPoll {
-    Output(StoredReadSessionOutput),
+    Output(ReadSessionOutput),
     Closed,
     TimedOut,
 }
 
 pub struct ClosedSessionOutputs {
-    pub outputs: Vec<StoredReadSessionOutput>,
+    pub outputs: Vec<ReadSessionOutput>,
     pub closed_at: tokio::time::Instant,
 }
 
-fn map_session_output(output: Option<Result<StoredReadSessionOutput, ReadError>>) -> SessionPoll {
+fn map_session_output(output: Option<Result<ReadSessionOutput, ReadError>>) -> SessionPoll {
     match output {
         Some(Ok(output)) => SessionPoll::Output(output),
         Some(Err(e)) => panic!("Read error: {:?}", e),
@@ -110,7 +122,7 @@ pub async fn poll_session_with_deadline<S>(
     advance_step: Option<Duration>,
 ) -> SessionPoll
 where
-    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+    S: futures::Stream<Item = Result<ReadSessionOutput, ReadError>>,
 {
     if let Some(step) = advance_step {
         let mut pinned_session = session.as_mut();
@@ -140,10 +152,6 @@ where
         }
     }
 
-    // The wall-clock polling path is only used by `collect_records` and
-    // `collect_records_with_encryption`, which intentionally block without their
-    // own timeout budget. Timed callers should use `advance_step` instead. A
-    // stuck session here will only surface via the outer test-runner timeout.
     loop {
         let now = tokio::time::Instant::now();
         let Some(remaining) = deadline.checked_duration_since(now) else {
@@ -162,16 +170,14 @@ where
     }
 }
 
-async fn collect_records_with_decoder<S, D>(
+async fn collect_records_inner<S>(
     session: &mut Pin<Box<S>>,
     timeout: Option<Duration>,
     target_count: Option<usize>,
     advance_step: Option<Duration>,
-    mut decode_batch: D,
 ) -> Vec<SequencedRecord>
 where
-    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
-    D: FnMut(StoredReadBatch) -> ReadBatch,
+    S: futures::Stream<Item = Result<ReadSessionOutput, ReadError>>,
 {
     let deadline = timeout.map(|timeout| tokio::time::Instant::now() + timeout);
     let mut records = Vec::new();
@@ -194,8 +200,7 @@ where
         };
 
         match polled {
-            SessionPoll::Output(StoredReadSessionOutput::Batch(batch)) => {
-                let batch = decode_batch(batch);
+            SessionPoll::Output(ReadSessionOutput::Batch(batch)) => {
                 if let Some(target_count) = target_count {
                     let remaining = target_count.saturating_sub(records.len());
                     records.extend(batch.records.iter().take(remaining).cloned());
@@ -206,7 +211,7 @@ where
                     records.extend(batch.records.iter().cloned());
                 }
             }
-            SessionPoll::Output(StoredReadSessionOutput::Heartbeat(_)) => {}
+            SessionPoll::Output(ReadSessionOutput::Heartbeat(_)) => {}
             SessionPoll::Closed | SessionPoll::TimedOut => break,
         }
     }
@@ -216,9 +221,9 @@ where
 
 pub async fn collect_records<S>(session: &mut Pin<Box<S>>) -> Vec<SequencedRecord>
 where
-    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+    S: futures::Stream<Item = Result<ReadSessionOutput, ReadError>>,
 {
-    collect_records_with_decoder(session, None, None, None, decrypt_plain_batch).await
+    collect_records_inner(session, None, None, None).await
 }
 
 pub async fn collect_records_until_advanced<S>(
@@ -228,30 +233,14 @@ pub async fn collect_records_until_advanced<S>(
     advance_step: Duration,
 ) -> Vec<SequencedRecord>
 where
-    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+    S: futures::Stream<Item = Result<ReadSessionOutput, ReadError>>,
 {
-    collect_records_with_decoder(
+    collect_records_inner(
         session,
         Some(timeout),
         Some(target_count),
         Some(advance_step),
-        decrypt_plain_batch,
     )
-    .await
-}
-
-pub async fn collect_records_with_encryption<S>(
-    session: &mut Pin<Box<S>>,
-    basin: &BasinName,
-    stream: &StreamName,
-    encryption: &EncryptionSpec,
-) -> Vec<SequencedRecord>
-where
-    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
-{
-    collect_records_with_decoder(session, None, None, None, |batch| {
-        decrypt_batch_for_stream(batch, basin, stream, encryption)
-    })
     .await
 }
 
@@ -260,7 +249,7 @@ pub async fn expect_heartbeat_advanced<S>(
     timeout: Duration,
     advance_step: Duration,
 ) where
-    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+    S: futures::Stream<Item = Result<ReadSessionOutput, ReadError>>,
 {
     let deadline = tokio::time::Instant::now() + timeout;
     let output = match poll_session_with_deadline(session, deadline, Some(advance_step)).await {
@@ -270,7 +259,7 @@ pub async fn expect_heartbeat_advanced<S>(
     };
 
     assert!(
-        matches!(output, StoredReadSessionOutput::Heartbeat(_)),
+        matches!(output, ReadSessionOutput::Heartbeat(_)),
         "Unexpected first output: {output:?}"
     );
 }
@@ -281,7 +270,7 @@ pub async fn collect_outputs_until_closed_advanced<S>(
     advance_step: Duration,
 ) -> ClosedSessionOutputs
 where
-    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
+    S: futures::Stream<Item = Result<ReadSessionOutput, ReadError>>,
 {
     let deadline = tokio::time::Instant::now() + timeout;
     let mut outputs = Vec::new();
@@ -306,32 +295,17 @@ pub async fn collect_records_until_closed_advanced<S>(
     advance_step: Duration,
 ) -> Vec<SequencedRecord>
 where
-    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
-{
-    collect_records_until_closed_with_decoder(session, timeout, advance_step, decrypt_plain_batch)
-        .await
-}
-
-async fn collect_records_until_closed_with_decoder<S, D>(
-    session: &mut Pin<Box<S>>,
-    timeout: Duration,
-    advance_step: Duration,
-    mut decode_batch: D,
-) -> Vec<SequencedRecord>
-where
-    S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
-    D: FnMut(StoredReadBatch) -> ReadBatch,
+    S: futures::Stream<Item = Result<ReadSessionOutput, ReadError>>,
 {
     let deadline = tokio::time::Instant::now() + timeout;
     let mut records = Vec::new();
 
     loop {
         match poll_session_with_deadline(session, deadline, Some(advance_step)).await {
-            SessionPoll::Output(StoredReadSessionOutput::Batch(batch)) => {
-                let batch = decode_batch(batch);
+            SessionPoll::Output(ReadSessionOutput::Batch(batch)) => {
                 records.extend(batch.records.iter().cloned());
             }
-            SessionPoll::Output(StoredReadSessionOutput::Heartbeat(_)) => {}
+            SessionPoll::Output(ReadSessionOutput::Heartbeat(_)) => {}
             SessionPoll::Closed => break,
             SessionPoll::TimedOut => panic!("Timed out waiting for read session to close"),
         }
@@ -347,10 +321,7 @@ pub async fn read_records(
     start: ReadStart,
     end: ReadEnd,
 ) -> Vec<SequencedRecord> {
-    let read_session = backend
-        .read(basin.clone(), stream.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
+    let read_session = open_read_session(backend, basin, stream, start, end).await;
     let mut read_session = Box::pin(read_session);
     collect_records(&mut read_session).await
 }
@@ -363,12 +334,10 @@ pub async fn read_records_with_encryption(
     end: ReadEnd,
     encryption: &EncryptionSpec,
 ) -> Vec<SequencedRecord> {
-    let read_session = backend
-        .read(basin.clone(), stream.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
+    let read_session =
+        open_read_session_with_encryption(backend, basin, stream, start, end, encryption).await;
     let mut read_session = Box::pin(read_session);
-    collect_records_with_encryption(&mut read_session, basin, stream, encryption).await
+    collect_records(&mut read_session).await
 }
 
 pub fn envelope_bodies(records: &[SequencedRecord]) -> Vec<Vec<u8>> {

--- a/lite/tests/backend/common/read.rs
+++ b/lite/tests/backend/common/read.rs
@@ -17,7 +17,7 @@ use s2_lite::backend::{Backend, error::ReadError};
 
 pub fn decrypt_plain_batch(batch: StoredReadBatch) -> ReadBatch {
     batch
-        .decrypt(&EncryptionSpec::Plaintext, &[])
+        .decrypt(&EncryptionSpec::Plain, &[])
         .expect("Failed to decode batch")
 }
 

--- a/lite/tests/backend/common/read.rs
+++ b/lite/tests/backend/common/read.rs
@@ -2,7 +2,7 @@ use std::{pin::Pin, task::Poll, time::Duration};
 
 use futures::StreamExt;
 use s2_common::{
-    encryption::Encryption,
+    encryption::EncryptionSpec,
     read_extent::{ReadLimit, ReadUntil},
     record::{Record, SequencedRecord},
     types::{
@@ -17,7 +17,7 @@ use s2_lite::backend::{Backend, error::ReadError};
 
 pub fn decrypt_plain_batch(batch: StoredReadBatch) -> ReadBatch {
     batch
-        .decrypt(&Encryption::Plain, &[])
+        .decrypt(&EncryptionSpec::plain(), &[])
         .expect("Failed to decode batch")
 }
 
@@ -77,7 +77,7 @@ pub fn decrypt_batch_for_stream(
     batch: StoredReadBatch,
     basin: &BasinName,
     stream: &StreamName,
-    encryption: &Encryption,
+    encryption: &EncryptionSpec,
 ) -> ReadBatch {
     let stream_id = s2_lite::backend::StreamId::new(basin, stream);
     batch
@@ -244,7 +244,7 @@ pub async fn collect_records_with_encryption<S>(
     session: &mut Pin<Box<S>>,
     basin: &BasinName,
     stream: &StreamName,
-    encryption: &Encryption,
+    encryption: &EncryptionSpec,
 ) -> Vec<SequencedRecord>
 where
     S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
@@ -361,7 +361,7 @@ pub async fn read_records_with_encryption(
     stream: &StreamName,
     start: ReadStart,
     end: ReadEnd,
-    encryption: &Encryption,
+    encryption: &EncryptionSpec,
 ) -> Vec<SequencedRecord> {
     let read_session = backend
         .read(basin.clone(), stream.clone(), start, end)

--- a/lite/tests/backend/common/read.rs
+++ b/lite/tests/backend/common/read.rs
@@ -17,7 +17,7 @@ use s2_lite::backend::{Backend, error::ReadError};
 
 pub fn decrypt_plain_batch(batch: StoredReadBatch) -> ReadBatch {
     batch
-        .decrypt(&EncryptionSpec::plain(), &[])
+        .decrypt(&EncryptionSpec::Plaintext, &[])
         .expect("Failed to decode batch")
 }
 

--- a/lite/tests/backend/common/read.rs
+++ b/lite/tests/backend/common/read.rs
@@ -2,7 +2,7 @@ use std::{pin::Pin, task::Poll, time::Duration};
 
 use futures::StreamExt;
 use s2_common::{
-    encryption::EncryptionSpec,
+    encryption::Encryption,
     read_extent::{ReadLimit, ReadUntil},
     record::{Record, SequencedRecord},
     types::{
@@ -17,7 +17,7 @@ use s2_lite::backend::{Backend, error::ReadError};
 
 pub fn decrypt_plain_batch(batch: StoredReadBatch) -> ReadBatch {
     batch
-        .decrypt(&EncryptionSpec::Plain, &[])
+        .decrypt(&Encryption::Plain, &[])
         .expect("Failed to decode batch")
 }
 
@@ -77,7 +77,7 @@ pub fn decrypt_batch_for_stream(
     batch: StoredReadBatch,
     basin: &BasinName,
     stream: &StreamName,
-    encryption: &EncryptionSpec,
+    encryption: &Encryption,
 ) -> ReadBatch {
     let stream_id = s2_lite::backend::StreamId::new(basin, stream);
     batch
@@ -244,7 +244,7 @@ pub async fn collect_records_with_encryption<S>(
     session: &mut Pin<Box<S>>,
     basin: &BasinName,
     stream: &StreamName,
-    encryption: &EncryptionSpec,
+    encryption: &Encryption,
 ) -> Vec<SequencedRecord>
 where
     S: futures::Stream<Item = Result<StoredReadSessionOutput, ReadError>>,
@@ -361,7 +361,7 @@ pub async fn read_records_with_encryption(
     stream: &StreamName,
     start: ReadStart,
     end: ReadEnd,
-    encryption: &EncryptionSpec,
+    encryption: &Encryption,
 ) -> Vec<SequencedRecord> {
     let read_session = backend
         .read(basin.clone(), stream.clone(), start, end)

--- a/lite/tests/backend/common/setup.rs
+++ b/lite/tests/backend/common/setup.rs
@@ -3,21 +3,21 @@ use std::{sync::Arc, time::Duration};
 use bytes::Bytes;
 use bytesize::ByteSize;
 use s2_common::{
-    encryption::{EncryptionAlgorithm, EncryptionSpec},
+    encryption::{EncryptionAlgorithm, EncryptionKey, EncryptionSpec},
     record::{CommandRecord, FencingToken, Metered, Record, Timestamp},
     types::{
         basin::BasinName,
         config::{BasinConfig, OptionalStreamConfig},
         resources::CreateMode,
-        stream::{
-            AppendInput, AppendRecord, AppendRecordBatch, AppendRecordParts, StoredAppendInput,
-            StreamName,
-        },
+        stream::{AppendInput, AppendRecord, AppendRecordBatch, AppendRecordParts, StreamName},
     },
 };
 use s2_lite::backend::Backend;
 use slatedb::{Db, config::Settings, object_store::memory::InMemory};
 use uuid::Uuid;
+
+const TEST_AEGIS256_KEY: [u8; 32] = [0x42; 32];
+const TEST_AES256_GCM_KEY: [u8; 32] = [0x24; 32];
 
 pub async fn create_in_memory_db() -> Db {
     let object_store = Arc::new(InMemory::new());
@@ -55,7 +55,24 @@ pub fn basin_config_with_stream_cipher(stream_cipher: EncryptionAlgorithm) -> Ba
 }
 
 pub fn aegis256_encryption_spec() -> EncryptionSpec {
-    EncryptionSpec::aegis256([0x42; 32])
+    EncryptionSpec::aegis256(TEST_AEGIS256_KEY)
+}
+
+pub fn aegis256_encryption_key() -> EncryptionKey {
+    EncryptionKey::new(TEST_AEGIS256_KEY)
+}
+
+pub fn aes256_gcm_encryption_key() -> EncryptionKey {
+    EncryptionKey::new(TEST_AES256_GCM_KEY)
+}
+
+pub fn encryption_key_for_spec(encryption: &EncryptionSpec) -> Option<EncryptionKey> {
+    match encryption {
+        EncryptionSpec::Plain => None,
+        // Test helpers use fixed key material for encrypted cases.
+        EncryptionSpec::Aegis256(_) => Some(aegis256_encryption_key()),
+        EncryptionSpec::Aes256Gcm(_) => Some(aes256_gcm_encryption_key()),
+    }
 }
 
 pub async fn setup_backend_for_encryption_spec(
@@ -211,10 +228,11 @@ pub async fn append_payloads_with_encryption(
         match_seq_num: None,
         fencing_token: None,
     };
-    let stream_id = s2_lite::backend::StreamId::new(basin, stream);
-    let input = input.encrypt(encryption, stream_id.as_bytes());
     backend
-        .append(basin.clone(), stream.clone(), input)
+        .open_for_append(basin, stream, encryption_key_for_spec(encryption))
+        .await
+        .expect("Failed to open append handle")
+        .append(input)
         .await
         .expect("Failed to append payloads")
 }
@@ -231,19 +249,12 @@ pub async fn append_timestamped_payloads(
         fencing_token: None,
     };
     backend
-        .append(basin.clone(), stream.clone(), input)
+        .open_for_append(basin, stream, None)
+        .await
+        .expect("Failed to open append handle")
+        .append(input)
         .await
         .expect("Failed to append timestamped payloads")
-}
-
-pub fn encrypt_input_for_stream(
-    input: AppendInput,
-    basin: &BasinName,
-    stream: &StreamName,
-    encryption: &EncryptionSpec,
-) -> StoredAppendInput {
-    let stream_id = s2_lite::backend::StreamId::new(basin, stream);
-    input.encrypt(encryption, stream_id.as_bytes())
 }
 
 pub async fn append_repeat(

--- a/lite/tests/backend/common/setup.rs
+++ b/lite/tests/backend/common/setup.rs
@@ -46,32 +46,47 @@ pub fn test_stream_name(suffix: &str) -> StreamName {
     format!("test-stream-{}", suffix).parse().unwrap()
 }
 
-pub fn all_encryption_modes_stream_config() -> OptionalStreamConfig {
-    OptionalStreamConfig::default()
-}
-
-pub fn all_encryption_modes_basin_config() -> BasinConfig {
+pub fn basin_config_with_stream_cipher(stream_cipher: EncryptionAlgorithm) -> BasinConfig {
     BasinConfig {
-        default_stream_config: all_encryption_modes_stream_config(),
-        stream_cipher: Some(EncryptionAlgorithm::Aegis256),
-        ..Default::default()
-    }
-}
-
-pub fn aegis_only_encryption_stream_config() -> OptionalStreamConfig {
-    OptionalStreamConfig::default()
-}
-
-pub fn aegis_only_encryption_basin_config() -> BasinConfig {
-    BasinConfig {
-        default_stream_config: aegis_only_encryption_stream_config(),
-        stream_cipher: Some(EncryptionAlgorithm::Aegis256),
+        default_stream_config: OptionalStreamConfig::default(),
+        stream_cipher: Some(stream_cipher),
         ..Default::default()
     }
 }
 
 pub fn aegis256_encryption_spec() -> EncryptionSpec {
     EncryptionSpec::aegis256([0x42; 32])
+}
+
+pub async fn setup_backend_for_encryption_spec(
+    basin_suffix: &str,
+    stream_suffix: &str,
+    encryption: &EncryptionSpec,
+) -> (Backend, BasinName, StreamName) {
+    match encryption {
+        EncryptionSpec::Plain => {
+            setup_backend_with_stream(basin_suffix, stream_suffix, OptionalStreamConfig::default())
+                .await
+        }
+        EncryptionSpec::Aegis256(_) => {
+            setup_backend_with_basin_and_stream(
+                basin_suffix,
+                stream_suffix,
+                basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256),
+                OptionalStreamConfig::default(),
+            )
+            .await
+        }
+        EncryptionSpec::Aes256Gcm(_) => {
+            setup_backend_with_basin_and_stream(
+                basin_suffix,
+                stream_suffix,
+                basin_config_with_stream_cipher(EncryptionAlgorithm::Aes256Gcm),
+                OptionalStreamConfig::default(),
+            )
+            .await
+        }
+    }
 }
 
 pub fn create_test_record(body: Bytes) -> AppendRecord {

--- a/lite/tests/backend/common/setup.rs
+++ b/lite/tests/backend/common/setup.rs
@@ -3,7 +3,7 @@ use std::{sync::Arc, time::Duration};
 use bytes::Bytes;
 use bytesize::ByteSize;
 use s2_common::{
-    encryption::{Encryption, EncryptionAlgorithm},
+    encryption::{EncryptionAlgorithm, EncryptionSpec},
     record::{CommandRecord, FencingToken, Metered, Record, Timestamp},
     types::{
         basin::BasinName,
@@ -70,8 +70,8 @@ pub fn aegis_only_encryption_basin_config() -> BasinConfig {
     }
 }
 
-pub fn aegis256_encryption_spec() -> Encryption {
-    Encryption::aegis256([0x42; 32])
+pub fn aegis256_encryption_spec() -> EncryptionSpec {
+    EncryptionSpec::aegis256([0x42; 32])
 }
 
 pub fn create_test_record(body: Bytes) -> AppendRecord {
@@ -176,7 +176,7 @@ pub async fn append_payloads(
     stream: &StreamName,
     payloads: &[&[u8]],
 ) -> s2_common::types::stream::AppendAck {
-    let encryption = Encryption::Plain;
+    let encryption = EncryptionSpec::plain();
     append_payloads_with_encryption(backend, basin, stream, payloads, &encryption).await
 }
 
@@ -185,7 +185,7 @@ pub async fn append_payloads_with_encryption(
     basin: &BasinName,
     stream: &StreamName,
     payloads: &[&[u8]],
-    encryption: &Encryption,
+    encryption: &EncryptionSpec,
 ) -> s2_common::types::stream::AppendAck {
     let bodies = payloads
         .iter()
@@ -225,7 +225,7 @@ pub fn encrypt_input_for_stream(
     input: AppendInput,
     basin: &BasinName,
     stream: &StreamName,
-    encryption: &Encryption,
+    encryption: &EncryptionSpec,
 ) -> StoredAppendInput {
     let stream_id = s2_lite::backend::StreamId::new(basin, stream);
     input.encrypt(encryption, stream_id.as_bytes())

--- a/lite/tests/backend/common/setup.rs
+++ b/lite/tests/backend/common/setup.rs
@@ -176,7 +176,7 @@ pub async fn append_payloads(
     stream: &StreamName,
     payloads: &[&[u8]],
 ) -> s2_common::types::stream::AppendAck {
-    let encryption = EncryptionSpec::plain();
+    let encryption = EncryptionSpec::Plaintext;
     append_payloads_with_encryption(backend, basin, stream, payloads, &encryption).await
 }
 

--- a/lite/tests/backend/common/setup.rs
+++ b/lite/tests/backend/common/setup.rs
@@ -3,7 +3,7 @@ use std::{sync::Arc, time::Duration};
 use bytes::Bytes;
 use bytesize::ByteSize;
 use s2_common::{
-    encryption::{EncryptionMode, EncryptionSpec},
+    encryption::{Encryption, EncryptionAlgorithm},
     record::{CommandRecord, FencingToken, Metered, Record, Timestamp},
     types::{
         basin::BasinName,
@@ -47,46 +47,31 @@ pub fn test_stream_name(suffix: &str) -> StreamName {
 }
 
 pub fn all_encryption_modes_stream_config() -> OptionalStreamConfig {
-    use s2_common::types::config::OptionalEncryptionConfig;
-    OptionalStreamConfig {
-        encryption: OptionalEncryptionConfig {
-            allowed_modes: [
-                EncryptionMode::Plain,
-                EncryptionMode::Aegis256,
-                EncryptionMode::Aes256Gcm,
-            ]
-            .into(),
-        },
-        ..Default::default()
-    }
+    OptionalStreamConfig::default()
 }
 
 pub fn all_encryption_modes_basin_config() -> BasinConfig {
     BasinConfig {
         default_stream_config: all_encryption_modes_stream_config(),
+        stream_encryption_algorithm: Some(EncryptionAlgorithm::Aegis256),
         ..Default::default()
     }
 }
 
 pub fn aegis_only_encryption_stream_config() -> OptionalStreamConfig {
-    use s2_common::types::config::OptionalEncryptionConfig;
-    OptionalStreamConfig {
-        encryption: OptionalEncryptionConfig {
-            allowed_modes: [EncryptionMode::Aegis256].into(),
-        },
-        ..Default::default()
-    }
+    OptionalStreamConfig::default()
 }
 
 pub fn aegis_only_encryption_basin_config() -> BasinConfig {
     BasinConfig {
         default_stream_config: aegis_only_encryption_stream_config(),
+        stream_encryption_algorithm: Some(EncryptionAlgorithm::Aegis256),
         ..Default::default()
     }
 }
 
-pub fn aegis256_encryption_spec() -> EncryptionSpec {
-    EncryptionSpec::aegis256([0x42; 32])
+pub fn aegis256_encryption_spec() -> Encryption {
+    Encryption::aegis256([0x42; 32])
 }
 
 pub fn create_test_record(body: Bytes) -> AppendRecord {
@@ -191,7 +176,7 @@ pub async fn append_payloads(
     stream: &StreamName,
     payloads: &[&[u8]],
 ) -> s2_common::types::stream::AppendAck {
-    let encryption = EncryptionSpec::Plain;
+    let encryption = Encryption::Plain;
     append_payloads_with_encryption(backend, basin, stream, payloads, &encryption).await
 }
 
@@ -200,7 +185,7 @@ pub async fn append_payloads_with_encryption(
     basin: &BasinName,
     stream: &StreamName,
     payloads: &[&[u8]],
-    encryption: &EncryptionSpec,
+    encryption: &Encryption,
 ) -> s2_common::types::stream::AppendAck {
     let bodies = payloads
         .iter()
@@ -240,7 +225,7 @@ pub fn encrypt_input_for_stream(
     input: AppendInput,
     basin: &BasinName,
     stream: &StreamName,
-    encryption: &EncryptionSpec,
+    encryption: &Encryption,
 ) -> StoredAppendInput {
     let stream_id = s2_lite::backend::StreamId::new(basin, stream);
     input.encrypt(encryption, stream_id.as_bytes())

--- a/lite/tests/backend/common/setup.rs
+++ b/lite/tests/backend/common/setup.rs
@@ -176,7 +176,7 @@ pub async fn append_payloads(
     stream: &StreamName,
     payloads: &[&[u8]],
 ) -> s2_common::types::stream::AppendAck {
-    let encryption = EncryptionSpec::Plaintext;
+    let encryption = EncryptionSpec::Plain;
     append_payloads_with_encryption(backend, basin, stream, payloads, &encryption).await
 }
 

--- a/lite/tests/backend/common/setup.rs
+++ b/lite/tests/backend/common/setup.rs
@@ -53,7 +53,7 @@ pub fn all_encryption_modes_stream_config() -> OptionalStreamConfig {
 pub fn all_encryption_modes_basin_config() -> BasinConfig {
     BasinConfig {
         default_stream_config: all_encryption_modes_stream_config(),
-        stream_encryption_algorithm: Some(EncryptionAlgorithm::Aegis256),
+        stream_cipher: Some(EncryptionAlgorithm::Aegis256),
         ..Default::default()
     }
 }
@@ -65,7 +65,7 @@ pub fn aegis_only_encryption_stream_config() -> OptionalStreamConfig {
 pub fn aegis_only_encryption_basin_config() -> BasinConfig {
     BasinConfig {
         default_stream_config: aegis_only_encryption_stream_config(),
-        stream_encryption_algorithm: Some(EncryptionAlgorithm::Aegis256),
+        stream_cipher: Some(EncryptionAlgorithm::Aegis256),
         ..Default::default()
     }
 }

--- a/lite/tests/backend/control_plane/basin.rs
+++ b/lite/tests/backend/control_plane/basin.rs
@@ -216,7 +216,7 @@ async fn test_reconfigure_basin_updates_nested_defaults() {
 
     let reconfig = BasinReconfiguration {
         default_stream_config: Maybe::from(Some(stream_reconfig)),
-        stream_encryption_algorithm: Maybe::default(),
+        stream_cipher: Maybe::default(),
         create_stream_on_append: Maybe::from(true),
         create_stream_on_read: Maybe::from(true),
     };

--- a/lite/tests/backend/control_plane/basin.rs
+++ b/lite/tests/backend/control_plane/basin.rs
@@ -216,6 +216,7 @@ async fn test_reconfigure_basin_updates_nested_defaults() {
 
     let reconfig = BasinReconfiguration {
         default_stream_config: Maybe::from(Some(stream_reconfig)),
+        stream_encryption_algorithm: Maybe::default(),
         create_stream_on_append: Maybe::from(true),
         create_stream_on_read: Maybe::from(true),
     };

--- a/lite/tests/backend/control_plane/stream.rs
+++ b/lite/tests/backend/control_plane/stream.rs
@@ -519,14 +519,14 @@ async fn test_delete_stream_allows_plaintext_command_records_on_encrypted_only_s
     let basin_name = create_test_basin(
         &backend,
         "stream-delete-encrypted-only",
-        aegis_only_encryption_basin_config(),
+        basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256),
     )
     .await;
     let stream_name = create_test_stream(
         &backend,
         &basin_name,
         "stream-delete-encrypted-only",
-        aegis_only_encryption_stream_config(),
+        OptionalStreamConfig::default(),
     )
     .await;
 

--- a/lite/tests/backend/control_plane/stream.rs
+++ b/lite/tests/backend/control_plane/stream.rs
@@ -2,13 +2,13 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use s2_common::{
-    encryption::EncryptionMode,
+    encryption::EncryptionAlgorithm,
     maybe::Maybe,
     types::{
         config::{
-            BasinConfig, EncryptionReconfiguration, OptionalEncryptionConfig, OptionalStreamConfig,
-            OptionalTimestampingConfig, RetentionPolicy, StorageClass, StreamReconfiguration,
-            TimestampingMode, TimestampingReconfiguration,
+            BasinConfig, BasinReconfiguration, OptionalStreamConfig, OptionalTimestampingConfig,
+            RetentionPolicy, StorageClass, StreamReconfiguration, TimestampingMode,
+            TimestampingReconfiguration,
         },
         resources::{CreateMode, ListItemsRequestParts, RequestToken},
         stream::{
@@ -76,7 +76,7 @@ async fn test_create_stream_honors_basin_defaults() {
 }
 
 #[tokio::test]
-async fn test_create_stream_defaults_encryption_to_plaintext_only() {
+async fn test_create_stream_defaults_to_no_encryption_algorithm() {
     let backend = create_backend().await;
     let basin_name =
         create_test_basin(&backend, "stream-default-enc", BasinConfig::default()).await;
@@ -88,129 +88,114 @@ async fn test_create_stream_defaults_encryption_to_plaintext_only() {
     )
     .await;
 
-    let config = backend
-        .get_stream_config(basin_name, stream_name)
+    let page = backend
+        .list_streams(basin_name, ListStreamsRequest::default())
         .await
-        .expect("Failed to fetch stream config");
-
-    let expected_modes: enumset::EnumSet<EncryptionMode> = [EncryptionMode::Plain].into();
-    assert_eq!(config.encryption.allowed_modes, expected_modes);
+        .expect("Failed to list streams");
+    let info = page
+        .values
+        .iter()
+        .find(|info| info.name == stream_name)
+        .expect("stream info should be present");
+    assert_eq!(info.encryption_algorithm, None);
 }
 
 #[tokio::test]
-async fn test_create_stream_rejects_encryption_modes_outside_basin_defaults() {
-    let backend = create_backend().await;
-    let basin_name =
-        create_test_basin(&backend, "stream-encryption-reject", BasinConfig::default()).await;
-    let stream_name = test_stream_name("stream-encryption-reject");
-
-    let result = backend
-        .create_stream(
-            basin_name,
-            stream_name,
-            all_encryption_modes_stream_config(),
-            CreateMode::CreateOnly(None),
-        )
-        .await;
-
-    assert!(matches!(result, Err(CreateStreamError::Validation(_))));
-}
-
-#[tokio::test]
-async fn test_reconfigure_stream_rejects_encryption_modes_outside_basin_defaults() {
+async fn test_create_stream_materializes_basin_encryption_algorithm() {
     let backend = create_backend().await;
     let basin_name = create_test_basin(
         &backend,
-        "stream-reconfigure-encryption-reject",
-        BasinConfig::default(),
+        "stream-encryption-materialize",
+        BasinConfig {
+            stream_encryption_algorithm: Some(EncryptionAlgorithm::Aegis256),
+            ..Default::default()
+        },
     )
     .await;
     let stream_name = create_test_stream(
         &backend,
         &basin_name,
-        "stream-reconfigure-encryption-reject",
+        "stream-encryption-materialize",
         OptionalStreamConfig::default(),
     )
     .await;
 
-    let result = backend
-        .reconfigure_stream(
-            basin_name.clone(),
-            stream_name.clone(),
-            StreamReconfiguration {
-                encryption: Maybe::Specified(Some(EncryptionReconfiguration {
-                    allowed_modes: Maybe::Specified([EncryptionMode::Aegis256].into()),
-                })),
-                ..Default::default()
-            },
-        )
+    let page = backend
+        .list_streams(basin_name, ListStreamsRequest::default())
         .await;
-
-    assert!(matches!(result, Err(ReconfigureStreamError::Validation(_))));
+    let page = page.expect("Failed to list streams");
+    let info = page
+        .values
+        .iter()
+        .find(|info| info.name == stream_name)
+        .expect("stream info should be present");
+    assert_eq!(
+        info.encryption_algorithm,
+        Some(EncryptionAlgorithm::Aegis256)
+    );
 }
 
 #[tokio::test]
-async fn test_reconfigure_stream_empty_encryption_uses_basin_defaults() {
+async fn test_existing_stream_keeps_materialized_algorithm_after_basin_reconfigure() {
     let backend = create_backend().await;
-    let basin_name = test_basin_name("stream-reconfigure-enc");
-    let basin_config = BasinConfig {
-        default_stream_config: OptionalStreamConfig {
-            encryption: OptionalEncryptionConfig {
-                allowed_modes: [EncryptionMode::Plain, EncryptionMode::Aegis256].into(),
-            },
+    let basin_name = create_test_basin(
+        &backend,
+        "stream-basin-encryption-reconfigure",
+        BasinConfig {
+            stream_encryption_algorithm: Some(EncryptionAlgorithm::Aegis256),
             ..Default::default()
         },
-        ..Default::default()
-    };
+    )
+    .await;
+    let stream_name = create_test_stream(
+        &backend,
+        &basin_name,
+        "stream-basin-encryption-reconfigure",
+        OptionalStreamConfig::default(),
+    )
+    .await;
 
     backend
-        .create_basin(
+        .reconfigure_basin(
             basin_name.clone(),
-            basin_config,
-            CreateMode::CreateOnly(None),
-        )
-        .await
-        .expect("Failed to create basin");
-
-    let stream_name = test_stream_name("stream-reconfigure-enc");
-    backend
-        .create_stream(
-            basin_name.clone(),
-            stream_name.clone(),
-            OptionalStreamConfig {
-                encryption: OptionalEncryptionConfig {
-                    allowed_modes: [EncryptionMode::Plain].into(),
-                },
-                ..Default::default()
-            },
-            CreateMode::CreateOnly(None),
-        )
-        .await
-        .expect("Failed to create stream");
-
-    let updated = backend
-        .reconfigure_stream(
-            basin_name.clone(),
-            stream_name.clone(),
-            StreamReconfiguration {
-                encryption: Maybe::Specified(Some(EncryptionReconfiguration {
-                    allowed_modes: Maybe::Specified(Default::default()),
-                })),
+            BasinReconfiguration {
+                stream_encryption_algorithm: Maybe::Specified(Some(EncryptionAlgorithm::Aes256Gcm)),
                 ..Default::default()
             },
         )
         .await
-        .expect("Failed to reconfigure stream");
+        .expect("Failed to reconfigure basin");
 
-    let expected_modes: enumset::EnumSet<EncryptionMode> =
-        [EncryptionMode::Plain, EncryptionMode::Aegis256].into();
-    assert_eq!(updated.encryption.allowed_modes, expected_modes);
+    let next_stream = create_test_stream(
+        &backend,
+        &basin_name,
+        "stream-basin-encryption-reconfigure-next",
+        OptionalStreamConfig::default(),
+    )
+    .await;
 
-    let fetched = backend
-        .get_stream_config(basin_name, stream_name)
+    let page = backend
+        .list_streams(basin_name, ListStreamsRequest::default())
         .await
-        .expect("Failed to fetch stream config after reconfigure");
-    assert_eq!(fetched.encryption.allowed_modes, expected_modes);
+        .expect("Failed to list streams");
+    let original = page
+        .values
+        .iter()
+        .find(|info| info.name == stream_name)
+        .expect("original stream info should be present");
+    let next = page
+        .values
+        .iter()
+        .find(|info| info.name == next_stream)
+        .expect("new stream info should be present");
+    assert_eq!(
+        original.encryption_algorithm,
+        Some(EncryptionAlgorithm::Aegis256)
+    );
+    assert_eq!(
+        next.encryption_algorithm,
+        Some(EncryptionAlgorithm::Aes256Gcm)
+    );
 }
 
 #[tokio::test]

--- a/lite/tests/backend/control_plane/stream.rs
+++ b/lite/tests/backend/control_plane/stream.rs
@@ -366,8 +366,7 @@ async fn test_reconfigure_stream_updates_active_streamer() {
         .await
         .expect("Failed to reconfigure stream");
 
-    backend
-        .check_tail(basin_name.clone(), stream_name.clone())
+    check_tail(&backend, basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to check tail");
 
@@ -376,7 +375,7 @@ async fn test_reconfigure_stream_updates_active_streamer() {
         match_seq_num: None,
         fencing_token: None,
     };
-    let result = backend.append(basin_name, stream_name, input).await;
+    let result = append(&backend, basin_name, stream_name, input, None).await;
     assert!(matches!(result, Err(AppendError::TimestampMissing(_))));
 }
 
@@ -409,8 +408,7 @@ async fn test_create_stream_create_or_reconfigure_updates_active_streamer() {
         .await
         .expect("CreateOrReconfigure should succeed for an existing stream");
 
-    backend
-        .check_tail(basin_name.clone(), stream_name.clone())
+    check_tail(&backend, basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to check tail");
 
@@ -419,7 +417,7 @@ async fn test_create_stream_create_or_reconfigure_updates_active_streamer() {
         match_seq_num: None,
         fencing_token: None,
     };
-    let result = backend.append(basin_name, stream_name, input).await;
+    let result = append(&backend, basin_name, stream_name, input, None).await;
     assert!(matches!(result, Err(AppendError::TimestampMissing(_))));
 }
 
@@ -575,9 +573,7 @@ async fn test_delete_stream_blocks_data_operations() {
         .await
         .expect("Failed to delete stream");
 
-    let tail = backend
-        .check_tail(basin_name.clone(), stream_name.clone())
-        .await;
+    let tail = check_tail(&backend, basin_name.clone(), stream_name.clone()).await;
     assert!(matches!(
         tail,
         Err(CheckTailError::StreamDeletionPending(_))
@@ -588,9 +584,14 @@ async fn test_delete_stream_blocks_data_operations() {
         match_seq_num: None,
         fencing_token: None,
     };
-    let append_result = backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await;
+    let append_result = append(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        input,
+        None,
+    )
+    .await;
     assert!(matches!(
         append_result,
         Err(AppendError::StreamDeletionPending(_))
@@ -601,7 +602,7 @@ async fn test_delete_stream_blocks_data_operations() {
         clamp: false,
     };
     let end = ReadEnd::default();
-    let read_result = backend.read(basin_name, stream_name, start, end).await;
+    let read_result = try_open_read_session(&backend, &basin_name, &stream_name, start, end).await;
     assert!(matches!(
         read_result,
         Err(ReadError::StreamDeletionPending(_))

--- a/lite/tests/backend/control_plane/stream.rs
+++ b/lite/tests/backend/control_plane/stream.rs
@@ -107,7 +107,7 @@ async fn test_create_stream_materializes_basin_encryption_algorithm() {
         &backend,
         "stream-encryption-materialize",
         BasinConfig {
-            stream_encryption_algorithm: Some(EncryptionAlgorithm::Aegis256),
+            stream_cipher: Some(EncryptionAlgorithm::Aegis256),
             ..Default::default()
         },
     )
@@ -142,7 +142,7 @@ async fn test_existing_stream_keeps_materialized_algorithm_after_basin_reconfigu
         &backend,
         "stream-basin-encryption-reconfigure",
         BasinConfig {
-            stream_encryption_algorithm: Some(EncryptionAlgorithm::Aegis256),
+            stream_cipher: Some(EncryptionAlgorithm::Aegis256),
             ..Default::default()
         },
     )
@@ -159,7 +159,7 @@ async fn test_existing_stream_keeps_materialized_algorithm_after_basin_reconfigu
         .reconfigure_basin(
             basin_name.clone(),
             BasinReconfiguration {
-                stream_encryption_algorithm: Maybe::Specified(Some(EncryptionAlgorithm::Aes256Gcm)),
+                stream_cipher: Maybe::Specified(Some(EncryptionAlgorithm::Aes256Gcm)),
                 ..Default::default()
             },
         )

--- a/lite/tests/backend/control_plane/stream.rs
+++ b/lite/tests/backend/control_plane/stream.rs
@@ -101,11 +101,11 @@ async fn test_create_stream_defaults_to_no_encryption_algorithm() {
 }
 
 #[tokio::test]
-async fn test_create_stream_materializes_basin_encryption_algorithm() {
+async fn test_create_stream_uses_basin_cipher() {
     let backend = create_backend().await;
     let basin_name = create_test_basin(
         &backend,
-        "stream-encryption-materialize",
+        "stream-cipher",
         BasinConfig {
             stream_cipher: Some(EncryptionAlgorithm::Aegis256),
             ..Default::default()
@@ -115,7 +115,7 @@ async fn test_create_stream_materializes_basin_encryption_algorithm() {
     let stream_name = create_test_stream(
         &backend,
         &basin_name,
-        "stream-encryption-materialize",
+        "stream-cipher",
         OptionalStreamConfig::default(),
     )
     .await;
@@ -133,11 +133,11 @@ async fn test_create_stream_materializes_basin_encryption_algorithm() {
 }
 
 #[tokio::test]
-async fn test_existing_stream_keeps_materialized_algorithm_after_basin_reconfigure() {
+async fn test_existing_stream_keeps_cipher_after_basin_reconfigure() {
     let backend = create_backend().await;
     let basin_name = create_test_basin(
         &backend,
-        "stream-basin-encryption-reconfigure",
+        "stream-basin-cipher-reconfigure",
         BasinConfig {
             stream_cipher: Some(EncryptionAlgorithm::Aegis256),
             ..Default::default()
@@ -147,7 +147,7 @@ async fn test_existing_stream_keeps_materialized_algorithm_after_basin_reconfigu
     let stream_name = create_test_stream(
         &backend,
         &basin_name,
-        "stream-basin-encryption-reconfigure",
+        "stream-basin-cipher-reconfigure",
         OptionalStreamConfig::default(),
     )
     .await;
@@ -166,7 +166,7 @@ async fn test_existing_stream_keeps_materialized_algorithm_after_basin_reconfigu
     let next_stream = create_test_stream(
         &backend,
         &basin_name,
-        "stream-basin-encryption-reconfigure-next",
+        "stream-basin-cipher-reconfigure-next",
         OptionalStreamConfig::default(),
     )
     .await;

--- a/lite/tests/backend/control_plane/stream.rs
+++ b/lite/tests/backend/control_plane/stream.rs
@@ -97,7 +97,7 @@ async fn test_create_stream_defaults_to_no_encryption_algorithm() {
         .iter()
         .find(|info| info.name == stream_name)
         .expect("stream info should be present");
-    assert_eq!(info.encryption_algorithm, None);
+    assert_eq!(info.cipher, None);
 }
 
 #[tokio::test]
@@ -129,10 +129,7 @@ async fn test_create_stream_materializes_basin_encryption_algorithm() {
         .iter()
         .find(|info| info.name == stream_name)
         .expect("stream info should be present");
-    assert_eq!(
-        info.encryption_algorithm,
-        Some(EncryptionAlgorithm::Aegis256)
-    );
+    assert_eq!(info.cipher, Some(EncryptionAlgorithm::Aegis256));
 }
 
 #[tokio::test]
@@ -188,14 +185,8 @@ async fn test_existing_stream_keeps_materialized_algorithm_after_basin_reconfigu
         .iter()
         .find(|info| info.name == next_stream)
         .expect("new stream info should be present");
-    assert_eq!(
-        original.encryption_algorithm,
-        Some(EncryptionAlgorithm::Aegis256)
-    );
-    assert_eq!(
-        next.encryption_algorithm,
-        Some(EncryptionAlgorithm::Aes256Gcm)
-    );
+    assert_eq!(original.cipher, Some(EncryptionAlgorithm::Aegis256));
+    assert_eq!(next.cipher, Some(EncryptionAlgorithm::Aes256Gcm));
 }
 
 #[tokio::test]

--- a/lite/tests/backend/data_plane/append.rs
+++ b/lite/tests/backend/data_plane/append.rs
@@ -18,16 +18,19 @@ use s2_lite::backend::{
 use super::common::*;
 
 async fn assert_append_session_roundtrip(test_suffix: &str, encryption: &EncryptionSpec) {
-    let (backend, basin_name, stream_name) = if encryption.is_plain() {
-        setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await
-    } else {
-        setup_backend_with_basin_and_stream(
-            test_suffix,
-            "stream",
-            all_encryption_modes_basin_config(),
-            all_encryption_modes_stream_config(),
-        )
-        .await
+    let (backend, basin_name, stream_name) = match encryption {
+        EncryptionSpec::Plaintext => {
+            setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await
+        }
+        EncryptionSpec::Aegis256(_) | EncryptionSpec::Aes256Gcm(_) => {
+            setup_backend_with_basin_and_stream(
+                test_suffix,
+                "stream",
+                all_encryption_modes_basin_config(),
+                all_encryption_modes_stream_config(),
+            )
+            .await
+        }
     };
 
     let expected_bodies = vec![
@@ -394,7 +397,7 @@ async fn test_append_with_seq_num_mismatch() {
 }
 
 #[rstest]
-#[case::plaintext("append-session-basic", EncryptionSpec::plain())]
+#[case::plaintext("append-session-basic", EncryptionSpec::Plaintext)]
 #[case::encrypted("appsess-enc", aegis256_encryption_spec())]
 #[tokio::test]
 async fn test_append_session_roundtrip(

--- a/lite/tests/backend/data_plane/append.rs
+++ b/lite/tests/backend/data_plane/append.rs
@@ -393,7 +393,7 @@ async fn test_append_session_roundtrip(
 }
 
 #[tokio::test]
-async fn test_append_session_auto_create_stream() {
+async fn test_append_session_auto_creates_missing_stream_when_enabled() {
     let backend = create_backend().await;
     let basin_config = BasinConfig {
         create_stream_on_append: true,
@@ -418,28 +418,28 @@ async fn test_append_session_auto_create_stream() {
         .clone()
         .append_session(basin_name.clone(), stream_name.clone(), inputs)
         .await
-        .expect("Failed to create append session");
+        .expect("Failed to create append session for missing stream");
     tokio::pin!(session);
 
     let ack = session
         .next()
         .await
-        .expect("Should have ack")
-        .expect("Append should succeed");
-    assert_eq!(ack.start.seq_num, 0);
+        .expect("Missing append ack")
+        .expect("Append session should succeed");
     assert_eq!(ack.end.seq_num, 1);
     assert!(session.next().await.is_none());
 
     let stream_list = backend
-        .list_streams(basin_name, ListStreamsRequest::default())
+        .list_streams(basin_name.clone(), ListStreamsRequest::default())
         .await
         .expect("Failed to list streams");
-    let stream_names: Vec<_> = stream_list
-        .values
-        .iter()
-        .map(|info| info.name.as_ref())
-        .collect();
-    assert_eq!(stream_names, vec![stream_name.as_ref()]);
+    assert_eq!(stream_list.values.len(), 1);
+
+    let tail = backend
+        .check_tail(basin_name, stream_name)
+        .await
+        .expect("Failed to check tail");
+    assert_eq!(tail.seq_num, 1);
 }
 
 #[tokio::test]

--- a/lite/tests/backend/data_plane/append.rs
+++ b/lite/tests/backend/data_plane/append.rs
@@ -35,14 +35,17 @@ async fn assert_append_session_roundtrip(test_suffix: &str, encryption: &Encrypt
                 fencing_token: None,
             })
             .collect::<Vec<_>>(),
-    )
-    .map(|input| encrypt_input_for_stream(input, &basin_name, &stream_name, encryption));
+    );
 
-    let session = backend
-        .clone()
-        .append_session(basin_name.clone(), stream_name.clone(), inputs)
-        .await
-        .expect("Failed to create append session");
+    let session = append_session(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        Some(encryption),
+        inputs,
+    )
+    .await
+    .expect("Failed to create append session");
     tokio::pin!(session);
 
     let mut acks = Vec::new();
@@ -57,8 +60,7 @@ async fn assert_append_session_roundtrip(test_suffix: &str, encryption: &Encrypt
         assert_eq!(ack.end.seq_num, index + 1);
     }
 
-    let tail = backend
-        .check_tail(basin_name.clone(), stream_name.clone())
+    let tail = check_tail(&backend, basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to check tail");
     assert_eq!(tail.seq_num, expected_bodies.len() as u64);
@@ -77,13 +79,7 @@ async fn append_with_optional_encryption(
     input: AppendInput,
     encryption: Option<&EncryptionSpec>,
 ) -> Result<s2_common::types::stream::AppendAck, AppendError> {
-    match encryption {
-        Some(encryption) => {
-            let input = encrypt_input_for_stream(input, basin, stream, encryption);
-            backend.append(basin.clone(), stream.clone(), input).await
-        }
-        None => backend.append(basin.clone(), stream.clone(), input).await,
-    }
+    append(backend, basin.clone(), stream.clone(), input, encryption).await
 }
 
 #[derive(Clone, Copy)]
@@ -287,9 +283,14 @@ async fn test_append_requires_timestamp() {
         fencing_token: None,
     };
 
-    let result = backend
-        .append(basin_name.clone(), stream_name.clone(), missing_timestamp)
-        .await;
+    let result = append(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        missing_timestamp,
+        None,
+    )
+    .await;
 
     assert!(matches!(result, Err(AppendError::TimestampMissing(_))));
 
@@ -302,8 +303,7 @@ async fn test_append_requires_timestamp() {
         fencing_token: None,
     };
 
-    let ack = backend
-        .append(basin_name, stream_name, with_timestamp)
+    let ack = append(&backend, basin_name, stream_name, with_timestamp, None)
         .await
         .expect("Expected append to succeed when timestamp is provided");
 
@@ -322,10 +322,15 @@ async fn test_append_with_seq_num_match() {
         fencing_token: None,
     };
 
-    let ack = backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("Failed to append with matching seq_num");
+    let ack = append(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        input,
+        None,
+    )
+    .await
+    .expect("Failed to append with matching seq_num");
 
     assert_eq!(ack.start.seq_num, 0);
 
@@ -335,10 +340,15 @@ async fn test_append_with_seq_num_match() {
         fencing_token: None,
     };
 
-    let ack2 = backend
-        .append(basin_name.clone(), stream_name.clone(), input2)
-        .await
-        .expect("Failed to append with matching seq_num");
+    let ack2 = append(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        input2,
+        None,
+    )
+    .await
+    .expect("Failed to append with matching seq_num");
 
     assert_eq!(ack2.start.seq_num, 1);
 }
@@ -358,10 +368,15 @@ async fn test_append_with_seq_num_mismatch() {
         fencing_token: None,
     };
 
-    backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("Failed to append first record");
+    append(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        input,
+        None,
+    )
+    .await
+    .expect("Failed to append first record");
 
     let input2 = AppendInput {
         records: create_test_record_batch(vec![Bytes::from_static(b"second record")]),
@@ -369,9 +384,14 @@ async fn test_append_with_seq_num_mismatch() {
         fencing_token: None,
     };
 
-    let result = backend
-        .append(basin_name.clone(), stream_name.clone(), input2)
-        .await;
+    let result = append(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        input2,
+        None,
+    )
+    .await;
 
     assert!(matches!(
         result,
@@ -403,18 +423,21 @@ async fn test_append_session_empty() {
 
     let inputs = futures::stream::iter(Vec::<AppendInput>::new());
 
-    let session = backend
-        .clone()
-        .append_session(basin_name.clone(), stream_name.clone(), inputs)
-        .await
-        .expect("Failed to create append session");
+    let session = append_session(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        None,
+        inputs,
+    )
+    .await
+    .expect("Failed to create append session");
     tokio::pin!(session);
 
     let ack = session.next().await;
     assert!(ack.is_none());
 
-    let tail = backend
-        .check_tail(basin_name, stream_name)
+    let tail = check_tail(&backend, basin_name, stream_name)
         .await
         .expect("Failed to check tail");
     assert_eq!(tail.seq_num, 0);
@@ -449,11 +472,15 @@ async fn test_append_session_multiple_records_per_batch() {
         },
     ]);
 
-    let session = backend
-        .clone()
-        .append_session(basin_name.clone(), stream_name.clone(), inputs)
-        .await
-        .expect("Failed to create append session");
+    let session = append_session(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        None,
+        inputs,
+    )
+    .await
+    .expect("Failed to create append session");
     tokio::pin!(session);
 
     let ack1 = session
@@ -472,8 +499,7 @@ async fn test_append_session_multiple_records_per_batch() {
     assert_eq!(ack2.start.seq_num, 2);
     assert_eq!(ack2.end.seq_num, 5);
 
-    let tail = backend
-        .check_tail(basin_name.clone(), stream_name.clone())
+    let tail = check_tail(&backend, basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to check tail");
     assert_eq!(tail.seq_num, 5);
@@ -515,10 +541,15 @@ async fn test_append_session_with_seq_num_conditions() {
         },
     ]);
 
-    let session = backend
-        .append_session(basin_name.clone(), stream_name.clone(), inputs)
-        .await
-        .expect("Failed to create append session");
+    let session = append_session(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        None,
+        inputs,
+    )
+    .await
+    .expect("Failed to create append session");
     tokio::pin!(session);
 
     let ack1 = session
@@ -553,8 +584,7 @@ async fn test_append_session_seq_num_mismatch() {
         fencing_token: None,
     }]);
 
-    let session = backend
-        .append_session(basin_name, stream_name, inputs)
+    let session = append_session(&backend, basin_name, stream_name, None, inputs)
         .await
         .expect("Failed to create append session");
     tokio::pin!(session);
@@ -590,11 +620,15 @@ async fn test_append_session_stops_after_condition_failure() {
         },
     ]);
 
-    let session = backend
-        .clone()
-        .append_session(basin_name.clone(), stream_name.clone(), inputs)
-        .await
-        .expect("Failed to create append session");
+    let session = append_session(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        None,
+        inputs,
+    )
+    .await
+    .expect("Failed to create append session");
     tokio::pin!(session);
 
     let ack = session
@@ -617,8 +651,7 @@ async fn test_append_session_stops_after_condition_failure() {
     ));
     assert!(session.next().await.is_none());
 
-    let tail = backend
-        .check_tail(basin_name.clone(), stream_name.clone())
+    let tail = check_tail(&backend, basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to check tail");
     assert_eq!(tail.seq_num, 1);
@@ -652,8 +685,7 @@ async fn test_append_session_with_fencing_token() {
         },
     ]);
 
-    let session = backend
-        .append_session(basin_name, stream_name, inputs)
+    let session = append_session(&backend, basin_name, stream_name, None, inputs)
         .await
         .expect("Failed to create append session");
     tokio::pin!(session);
@@ -685,17 +717,24 @@ async fn test_append_session_large_batches() {
     let large_record = vec![0u8; 100_000];
     let batch_count = 50;
 
-    let inputs = futures::stream::iter((0..batch_count).map(|_| AppendInput {
-        records: create_test_record_batch(vec![Bytes::from(large_record.clone())]),
-        match_seq_num: None,
-        fencing_token: None,
+    let inputs = futures::stream::iter((0..batch_count).map({
+        let large_record = large_record.clone();
+        move |_| AppendInput {
+            records: create_test_record_batch(vec![Bytes::from(large_record.clone())]),
+            match_seq_num: None,
+            fencing_token: None,
+        }
     }));
 
-    let session = backend
-        .clone()
-        .append_session(basin_name.clone(), stream_name.clone(), inputs)
-        .await
-        .expect("Failed to create append session");
+    let session = append_session(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        None,
+        inputs,
+    )
+    .await
+    .expect("Failed to create append session");
     tokio::pin!(session);
 
     let mut ack_count = 0;
@@ -706,8 +745,7 @@ async fn test_append_session_large_batches() {
 
     assert_eq!(ack_count, batch_count);
 
-    let tail = backend
-        .check_tail(basin_name, stream_name)
+    let tail = check_tail(&backend, basin_name, stream_name)
         .await
         .expect("Failed to check tail");
     assert_eq!(tail.seq_num, batch_count);
@@ -735,11 +773,15 @@ async fn test_append_session_pipeline_preserves_ack_tail_and_read_order() {
         .collect();
     let inputs = futures::stream::iter(inputs);
 
-    let session = backend
-        .clone()
-        .append_session(basin_name.clone(), stream_name.clone(), inputs)
-        .await
-        .expect("Failed to create append session");
+    let session = append_session(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        None,
+        inputs,
+    )
+    .await
+    .expect("Failed to create append session");
     tokio::pin!(session);
 
     let mut acks = Vec::new();
@@ -763,8 +805,7 @@ async fn test_append_session_pipeline_preserves_ack_tail_and_read_order() {
         }
     }
 
-    let tail = backend
-        .check_tail(basin_name.clone(), stream_name.clone())
+    let tail = check_tail(&backend, basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to check tail");
     assert_eq!(tail.seq_num, expected_bodies.len() as u64);

--- a/lite/tests/backend/data_plane/append.rs
+++ b/lite/tests/backend/data_plane/append.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use rstest::rstest;
 use s2_common::{
-    encryption::Encryption,
+    encryption::EncryptionSpec,
     record::FencingToken,
     types::{
         basin::BasinName,
@@ -17,8 +17,8 @@ use s2_lite::backend::{
 
 use super::common::*;
 
-async fn assert_append_session_roundtrip(test_suffix: &str, encryption: &Encryption) {
-    let (backend, basin_name, stream_name) = if matches!(encryption, Encryption::Plain) {
+async fn assert_append_session_roundtrip(test_suffix: &str, encryption: &EncryptionSpec) {
+    let (backend, basin_name, stream_name) = if encryption.is_plain() {
         setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await
     } else {
         setup_backend_with_basin_and_stream(
@@ -84,7 +84,7 @@ async fn append_with_optional_encryption(
     basin: &BasinName,
     stream: &StreamName,
     input: AppendInput,
-    encryption: Option<&Encryption>,
+    encryption: Option<&EncryptionSpec>,
 ) -> Result<s2_common::types::stream::AppendAck, AppendError> {
     match encryption {
         Some(encryption) => {
@@ -107,7 +107,7 @@ async fn issue_fencing_command(
     stream_name: &StreamName,
     matching_token: &FencingToken,
     new_token: &FencingToken,
-    encryption: Option<&Encryption>,
+    encryption: Option<&EncryptionSpec>,
     bootstrap: FencingBootstrap,
 ) -> s2_common::types::stream::AppendAck {
     let command_match_seq_num = match bootstrap {
@@ -162,7 +162,7 @@ async fn issue_fencing_command(
 
 async fn assert_fencing_command_controls_stream_state(
     test_suffix: &str,
-    encryption: Option<Encryption>,
+    encryption: Option<EncryptionSpec>,
     bootstrap: FencingBootstrap,
 ) {
     let (backend, basin_name, stream_name) = if encryption.is_some() {
@@ -274,7 +274,7 @@ async fn test_append_multiple_records() {
 #[tokio::test]
 async fn test_fencing_command_controls_stream_state(
     #[case] test_suffix: &str,
-    #[case] encryption: Option<Encryption>,
+    #[case] encryption: Option<EncryptionSpec>,
     #[case] bootstrap: FencingBootstrap,
 ) {
     assert_fencing_command_controls_stream_state(test_suffix, encryption, bootstrap).await;
@@ -394,10 +394,13 @@ async fn test_append_with_seq_num_mismatch() {
 }
 
 #[rstest]
-#[case::plaintext("append-session-basic", Encryption::Plain)]
+#[case::plaintext("append-session-basic", EncryptionSpec::plain())]
 #[case::encrypted("appsess-enc", aegis256_encryption_spec())]
 #[tokio::test]
-async fn test_append_session_roundtrip(#[case] test_suffix: &str, #[case] encryption: Encryption) {
+async fn test_append_session_roundtrip(
+    #[case] test_suffix: &str,
+    #[case] encryption: EncryptionSpec,
+) {
     assert_append_session_roundtrip(test_suffix, &encryption).await;
 }
 

--- a/lite/tests/backend/data_plane/append.rs
+++ b/lite/tests/backend/data_plane/append.rs
@@ -19,7 +19,7 @@ use super::common::*;
 
 async fn assert_append_session_roundtrip(test_suffix: &str, encryption: &EncryptionSpec) {
     let (backend, basin_name, stream_name) = match encryption {
-        EncryptionSpec::Plaintext => {
+        EncryptionSpec::Plain => {
             setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await
         }
         EncryptionSpec::Aegis256(_) | EncryptionSpec::Aes256Gcm(_) => {
@@ -397,7 +397,7 @@ async fn test_append_with_seq_num_mismatch() {
 }
 
 #[rstest]
-#[case::plaintext("append-session-basic", EncryptionSpec::Plaintext)]
+#[case::plaintext("append-session-basic", EncryptionSpec::Plain)]
 #[case::encrypted("appsess-enc", aegis256_encryption_spec())]
 #[tokio::test]
 async fn test_append_session_roundtrip(

--- a/lite/tests/backend/data_plane/append.rs
+++ b/lite/tests/backend/data_plane/append.rs
@@ -18,20 +18,8 @@ use s2_lite::backend::{
 use super::common::*;
 
 async fn assert_append_session_roundtrip(test_suffix: &str, encryption: &EncryptionSpec) {
-    let (backend, basin_name, stream_name) = match encryption {
-        EncryptionSpec::Plain => {
-            setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await
-        }
-        EncryptionSpec::Aegis256(_) | EncryptionSpec::Aes256Gcm(_) => {
-            setup_backend_with_basin_and_stream(
-                test_suffix,
-                "stream",
-                all_encryption_modes_basin_config(),
-                all_encryption_modes_stream_config(),
-            )
-            .await
-        }
-    };
+    let (backend, basin_name, stream_name) =
+        setup_backend_for_encryption_spec(test_suffix, "stream", encryption).await;
 
     let expected_bodies = vec![
         b"batch 1".to_vec(),
@@ -168,16 +156,13 @@ async fn assert_fencing_command_controls_stream_state(
     encryption: Option<EncryptionSpec>,
     bootstrap: FencingBootstrap,
 ) {
-    let (backend, basin_name, stream_name) = if encryption.is_some() {
-        setup_backend_with_basin_and_stream(
-            test_suffix,
-            "stream",
-            aegis_only_encryption_basin_config(),
-            aegis_only_encryption_stream_config(),
-        )
-        .await
-    } else {
-        setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await
+    let (backend, basin_name, stream_name) = match encryption.as_ref() {
+        Some(encryption) => {
+            setup_backend_for_encryption_spec(test_suffix, "stream", encryption).await
+        }
+        None => {
+            setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await
+        }
     };
 
     let encryption = encryption.as_ref();

--- a/lite/tests/backend/data_plane/append.rs
+++ b/lite/tests/backend/data_plane/append.rs
@@ -6,8 +6,8 @@ use s2_common::{
     record::FencingToken,
     types::{
         basin::BasinName,
-        config::{BasinConfig, OptionalStreamConfig, OptionalTimestampingConfig, TimestampingMode},
-        stream::{AppendInput, AppendRecordBatch, ListStreamsRequest, StreamName},
+        config::{OptionalStreamConfig, OptionalTimestampingConfig, TimestampingMode},
+        stream::{AppendInput, AppendRecordBatch, StreamName},
     },
 };
 use s2_lite::backend::{
@@ -390,56 +390,6 @@ async fn test_append_session_roundtrip(
     #[case] encryption: EncryptionSpec,
 ) {
     assert_append_session_roundtrip(test_suffix, &encryption).await;
-}
-
-#[tokio::test]
-async fn test_append_session_auto_creates_missing_stream_when_enabled() {
-    let backend = create_backend().await;
-    let basin_config = BasinConfig {
-        create_stream_on_append: true,
-        ..Default::default()
-    };
-    let basin_name = create_test_basin(&backend, "append-session-auto-create", basin_config).await;
-    let stream_name = test_stream_name("auto");
-
-    let stream_list = backend
-        .list_streams(basin_name.clone(), ListStreamsRequest::default())
-        .await
-        .expect("Failed to list streams");
-    assert!(stream_list.values.is_empty());
-
-    let inputs = futures::stream::iter(vec![AppendInput {
-        records: create_test_record_batch(vec![Bytes::from_static(b"auto created")]),
-        match_seq_num: None,
-        fencing_token: None,
-    }]);
-
-    let session = backend
-        .clone()
-        .append_session(basin_name.clone(), stream_name.clone(), inputs)
-        .await
-        .expect("Failed to create append session for missing stream");
-    tokio::pin!(session);
-
-    let ack = session
-        .next()
-        .await
-        .expect("Missing append ack")
-        .expect("Append session should succeed");
-    assert_eq!(ack.end.seq_num, 1);
-    assert!(session.next().await.is_none());
-
-    let stream_list = backend
-        .list_streams(basin_name.clone(), ListStreamsRequest::default())
-        .await
-        .expect("Failed to list streams");
-    assert_eq!(stream_list.values.len(), 1);
-
-    let tail = backend
-        .check_tail(basin_name, stream_name)
-        .await
-        .expect("Failed to check tail");
-    assert_eq!(tail.seq_num, 1);
 }
 
 #[tokio::test]

--- a/lite/tests/backend/data_plane/append.rs
+++ b/lite/tests/backend/data_plane/append.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use rstest::rstest;
 use s2_common::{
-    encryption::EncryptionSpec,
+    encryption::Encryption,
     record::FencingToken,
     types::{
         basin::BasinName,
@@ -17,14 +17,18 @@ use s2_lite::backend::{
 
 use super::common::*;
 
-async fn assert_append_session_roundtrip(test_suffix: &str, encryption: &EncryptionSpec) {
-    let (backend, basin_name, stream_name) = setup_backend_with_basin_and_stream(
-        test_suffix,
-        "stream",
-        all_encryption_modes_basin_config(),
-        all_encryption_modes_stream_config(),
-    )
-    .await;
+async fn assert_append_session_roundtrip(test_suffix: &str, encryption: &Encryption) {
+    let (backend, basin_name, stream_name) = if matches!(encryption, Encryption::Plain) {
+        setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await
+    } else {
+        setup_backend_with_basin_and_stream(
+            test_suffix,
+            "stream",
+            all_encryption_modes_basin_config(),
+            all_encryption_modes_stream_config(),
+        )
+        .await
+    };
 
     let expected_bodies = vec![
         b"batch 1".to_vec(),
@@ -80,7 +84,7 @@ async fn append_with_optional_encryption(
     basin: &BasinName,
     stream: &StreamName,
     input: AppendInput,
-    encryption: Option<&EncryptionSpec>,
+    encryption: Option<&Encryption>,
 ) -> Result<s2_common::types::stream::AppendAck, AppendError> {
     match encryption {
         Some(encryption) => {
@@ -103,7 +107,7 @@ async fn issue_fencing_command(
     stream_name: &StreamName,
     matching_token: &FencingToken,
     new_token: &FencingToken,
-    encryption: Option<&EncryptionSpec>,
+    encryption: Option<&Encryption>,
     bootstrap: FencingBootstrap,
 ) -> s2_common::types::stream::AppendAck {
     let command_match_seq_num = match bootstrap {
@@ -158,7 +162,7 @@ async fn issue_fencing_command(
 
 async fn assert_fencing_command_controls_stream_state(
     test_suffix: &str,
-    encryption: Option<EncryptionSpec>,
+    encryption: Option<Encryption>,
     bootstrap: FencingBootstrap,
 ) {
     let (backend, basin_name, stream_name) = if encryption.is_some() {
@@ -270,7 +274,7 @@ async fn test_append_multiple_records() {
 #[tokio::test]
 async fn test_fencing_command_controls_stream_state(
     #[case] test_suffix: &str,
-    #[case] encryption: Option<EncryptionSpec>,
+    #[case] encryption: Option<Encryption>,
     #[case] bootstrap: FencingBootstrap,
 ) {
     assert_fencing_command_controls_stream_state(test_suffix, encryption, bootstrap).await;
@@ -390,13 +394,10 @@ async fn test_append_with_seq_num_mismatch() {
 }
 
 #[rstest]
-#[case::plaintext("append-session-basic", EncryptionSpec::Plain)]
+#[case::plaintext("append-session-basic", Encryption::Plain)]
 #[case::encrypted("appsess-enc", aegis256_encryption_spec())]
 #[tokio::test]
-async fn test_append_session_roundtrip(
-    #[case] test_suffix: &str,
-    #[case] encryption: EncryptionSpec,
-) {
+async fn test_append_session_roundtrip(#[case] test_suffix: &str, #[case] encryption: Encryption) {
     assert_append_session_roundtrip(test_suffix, &encryption).await;
 }
 

--- a/lite/tests/backend/data_plane/auto_create.rs
+++ b/lite/tests/backend/data_plane/auto_create.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use s2_common::{
+    encryption::EncryptionAlgorithm,
     read_extent::{ReadLimit, ReadUntil},
     record::StreamPosition,
     types::{
@@ -25,6 +26,21 @@ async fn assert_stream_count(
         .await
         .expect("Failed to list streams");
     assert_eq!(stream_list.values.len(), expected);
+}
+
+async fn assert_stream_cipher(
+    backend: &s2_lite::backend::Backend,
+    basin_name: &s2_common::types::basin::BasinName,
+    stream_name: &s2_common::types::stream::StreamName,
+    expected: Option<EncryptionAlgorithm>,
+) {
+    let stream_list = backend
+        .list_streams(basin_name.clone(), ListStreamsRequest::default())
+        .await
+        .expect("Failed to list streams");
+    assert_eq!(stream_list.values.len(), 1);
+    assert_eq!(stream_list.values[0].name.as_ref(), stream_name.as_ref());
+    assert_eq!(stream_list.values[0].cipher, expected);
 }
 
 #[tokio::test]
@@ -59,6 +75,53 @@ async fn test_backend_append_auto_creates_stream() {
         .await
         .expect("Failed to check tail on auto-created stream");
     assert_eq!(tail.seq_num, 1);
+}
+
+#[tokio::test]
+async fn test_backend_append_auto_creates_stream_with_basin_cipher() {
+    let backend = create_backend().await;
+    let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
+    basin_config.create_stream_on_append = true;
+    let basin_name = create_test_basin(
+        &backend,
+        "backend-auto-create-append-encrypted",
+        basin_config,
+    )
+    .await;
+    let stream_name = test_stream_name("missing");
+    let encryption = aegis256_encryption_spec();
+
+    let input = AppendInput {
+        records: create_test_record_batch(vec![Bytes::from_static(b"secret")]),
+        match_seq_num: None,
+        fencing_token: None,
+    };
+
+    let ack = append(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        input,
+        Some(&encryption),
+    )
+    .await
+    .expect("Failed to append to auto-created encrypted stream");
+
+    assert_eq!(ack.end.seq_num, 1);
+    assert_stream_count(&backend, &basin_name, 1).await;
+    assert_stream_cipher(
+        &backend,
+        &basin_name,
+        &stream_name,
+        Some(EncryptionAlgorithm::Aegis256),
+    )
+    .await;
+
+    let (start, end) = read_all_bounds();
+    let records =
+        read_records_with_encryption(&backend, &basin_name, &stream_name, start, end, &encryption)
+            .await;
+    assert_eq!(envelope_bodies(&records), vec![b"secret".to_vec()]);
 }
 
 #[tokio::test]
@@ -157,6 +220,30 @@ async fn test_backend_check_tail_auto_creates_stream() {
 
     assert_eq!(tail.seq_num, 0);
     assert_stream_count(&backend, &basin_name, 1).await;
+}
+
+#[tokio::test]
+async fn test_backend_check_tail_auto_creates_stream_with_basin_cipher() {
+    let backend = create_backend().await;
+    let mut basin_config = basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256);
+    basin_config.create_stream_on_read = true;
+    let basin_name =
+        create_test_basin(&backend, "backend-auto-create-tail-encrypted", basin_config).await;
+    let stream_name = test_stream_name("missing");
+
+    let tail = check_tail(&backend, basin_name.clone(), stream_name.clone())
+        .await
+        .expect("Failed to check tail on auto-created encrypted stream");
+
+    assert_eq!(tail, StreamPosition::MIN);
+    assert_stream_count(&backend, &basin_name, 1).await;
+    assert_stream_cipher(
+        &backend,
+        &basin_name,
+        &stream_name,
+        Some(EncryptionAlgorithm::Aegis256),
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/lite/tests/backend/data_plane/auto_create.rs
+++ b/lite/tests/backend/data_plane/auto_create.rs
@@ -43,15 +43,19 @@ async fn test_backend_append_auto_creates_stream() {
         fencing_token: None,
     };
 
-    let ack = backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await
-        .expect("Failed to append to auto-created stream");
+    let ack = append(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        input,
+        None,
+    )
+    .await
+    .expect("Failed to append to auto-created stream");
 
     assert_eq!(ack.end.seq_num, 1);
     assert_stream_count(&backend, &basin_name, 1).await;
-    let tail = backend
-        .check_tail(basin_name, stream_name)
+    let tail = check_tail(&backend, basin_name, stream_name)
         .await
         .expect("Failed to check tail on auto-created stream");
     assert_eq!(tail.seq_num, 1);
@@ -74,7 +78,7 @@ async fn test_backend_append_without_auto_create_returns_not_found() {
         fencing_token: None,
     };
 
-    let result = backend.append(basin_name.clone(), stream_name, input).await;
+    let result = append(&backend, basin_name.clone(), stream_name, input, None).await;
 
     assert!(matches!(result, Err(AppendError::StreamNotFound(_))));
     assert_stream_count(&backend, &basin_name, 0).await;
@@ -94,18 +98,16 @@ async fn test_backend_read_auto_creates_stream() {
         from: ReadFrom::SeqNum(0),
         clamp: false,
     };
-    let _session = backend
-        .read(
-            basin_name.clone(),
-            stream_name.clone(),
-            start,
-            ReadEnd::default(),
-        )
-        .await
-        .expect("Failed to open read session on auto-created stream");
+    let _session = open_read_session(
+        &backend,
+        &basin_name,
+        &stream_name,
+        start,
+        ReadEnd::default(),
+    )
+    .await;
     assert_stream_count(&backend, &basin_name, 1).await;
-    let tail = backend
-        .check_tail(basin_name, stream_name)
+    let tail = check_tail(&backend, basin_name, stream_name)
         .await
         .expect("Failed to check tail on auto-created read stream");
     assert_eq!(tail.seq_num, 0);
@@ -126,9 +128,14 @@ async fn test_backend_read_without_auto_create_returns_not_found() {
         from: ReadFrom::SeqNum(0),
         clamp: false,
     };
-    let result = backend
-        .read(basin_name.clone(), stream_name, start, ReadEnd::default())
-        .await;
+    let result = try_open_read_session(
+        &backend,
+        &basin_name,
+        &stream_name,
+        start,
+        ReadEnd::default(),
+    )
+    .await;
 
     assert!(matches!(result, Err(ReadError::StreamNotFound(_))));
     assert_stream_count(&backend, &basin_name, 0).await;
@@ -144,8 +151,7 @@ async fn test_backend_check_tail_auto_creates_stream() {
     let basin_name = create_test_basin(&backend, "backend-auto-create-tail", basin_config).await;
     let stream_name = test_stream_name("missing");
 
-    let tail = backend
-        .check_tail(basin_name.clone(), stream_name)
+    let tail = check_tail(&backend, basin_name.clone(), stream_name)
         .await
         .expect("Failed to check tail on auto-created stream");
 
@@ -164,7 +170,7 @@ async fn test_backend_check_tail_without_auto_create_returns_not_found() {
     .await;
     let stream_name = test_stream_name("missing");
 
-    let result = backend.check_tail(basin_name.clone(), stream_name).await;
+    let result = check_tail(&backend, basin_name.clone(), stream_name).await;
 
     assert!(matches!(result, Err(CheckTailError::StreamNotFound(_))));
     assert_stream_count(&backend, &basin_name, 0).await;
@@ -198,9 +204,14 @@ async fn test_backend_append_auto_create_is_race_safe() {
                 fencing_token: None,
             };
             for _ in 0..MAX_AUTO_CREATE_ATTEMPTS {
-                match backend
-                    .append(basin_name.clone(), stream_name.clone(), input.clone())
-                    .await
+                match append(
+                    &backend,
+                    basin_name.clone(),
+                    stream_name.clone(),
+                    input.clone(),
+                    None,
+                )
+                .await
                 {
                     Ok(ack) => return Ok(ack),
                     Err(AppendError::TransactionConflict(_))
@@ -210,7 +221,7 @@ async fn test_backend_append_auto_create_is_race_safe() {
                     Err(err) => return Err(err),
                 }
             }
-            backend.append(basin_name, stream_name, input).await
+            append(&backend, basin_name, stream_name, input, None).await
         }));
     }
 
@@ -221,8 +232,7 @@ async fn test_backend_append_auto_create_is_race_safe() {
             .expect("auto-create append racer should succeed");
     }
 
-    let tail = backend
-        .check_tail(basin_name.clone(), stream_name.clone())
+    let tail = check_tail(&backend, basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to check tail");
     assert_eq!(tail.seq_num, 10);
@@ -267,10 +277,7 @@ async fn test_backend_read_auto_create_is_race_safe() {
                 wait: Some(Duration::ZERO),
             };
             for _ in 0..MAX_AUTO_CREATE_ATTEMPTS {
-                match backend
-                    .read(basin_name.clone(), stream_name.clone(), start, end)
-                    .await
-                {
+                match try_open_read_session(&backend, &basin_name, &stream_name, start, end).await {
                     Ok(session) => {
                         drop(session);
                         return Ok::<(), ReadError>(());
@@ -281,7 +288,7 @@ async fn test_backend_read_auto_create_is_race_safe() {
                     Err(err) => return Err(err),
                 }
             }
-            match backend.read(basin_name, stream_name, start, end).await {
+            match try_open_read_session(&backend, &basin_name, &stream_name, start, end).await {
                 Ok(session) => {
                     drop(session);
                     Ok::<(), ReadError>(())
@@ -298,8 +305,7 @@ async fn test_backend_read_auto_create_is_race_safe() {
             .expect("auto-create read racer should succeed");
     }
 
-    let tail = backend
-        .check_tail(basin_name.clone(), stream_name.clone())
+    let tail = check_tail(&backend, basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to check tail after auto-create reads");
     assert_eq!(tail, StreamPosition::MIN);

--- a/lite/tests/backend/data_plane/auto_create.rs
+++ b/lite/tests/backend/data_plane/auto_create.rs
@@ -1,10 +1,19 @@
+use std::time::Duration;
+
 use bytes::Bytes;
-use s2_common::types::{
-    config::BasinConfig,
-    stream::{AppendInput, ListStreamsRequest, ReadEnd, ReadFrom, ReadStart},
+use s2_common::{
+    read_extent::{ReadLimit, ReadUntil},
+    record::StreamPosition,
+    types::{
+        config::BasinConfig,
+        stream::{AppendInput, ListStreamsRequest, ReadEnd, ReadFrom, ReadStart},
+    },
 };
+use s2_lite::backend::error::{AppendError, CheckTailError, ReadError};
 
 use super::common::*;
+
+const MAX_AUTO_CREATE_ATTEMPTS: usize = 50;
 
 async fn assert_stream_count(
     backend: &s2_lite::backend::Backend,
@@ -49,6 +58,29 @@ async fn test_backend_append_auto_creates_stream() {
 }
 
 #[tokio::test]
+async fn test_backend_append_without_auto_create_returns_not_found() {
+    let backend = create_backend().await;
+    let basin_name = create_test_basin(
+        &backend,
+        "backend-no-auto-create-append",
+        BasinConfig::default(),
+    )
+    .await;
+    let stream_name = test_stream_name("missing");
+
+    let input = AppendInput {
+        records: create_test_record_batch(vec![Bytes::from_static(b"should fail")]),
+        match_seq_num: None,
+        fencing_token: None,
+    };
+
+    let result = backend.append(basin_name.clone(), stream_name, input).await;
+
+    assert!(matches!(result, Err(AppendError::StreamNotFound(_))));
+    assert_stream_count(&backend, &basin_name, 0).await;
+}
+
+#[tokio::test]
 async fn test_backend_read_auto_creates_stream() {
     let backend = create_backend().await;
     let basin_config = BasinConfig {
@@ -80,6 +112,29 @@ async fn test_backend_read_auto_creates_stream() {
 }
 
 #[tokio::test]
+async fn test_backend_read_without_auto_create_returns_not_found() {
+    let backend = create_backend().await;
+    let basin_name = create_test_basin(
+        &backend,
+        "backend-no-auto-create-read",
+        BasinConfig::default(),
+    )
+    .await;
+    let stream_name = test_stream_name("missing");
+
+    let start = ReadStart {
+        from: ReadFrom::SeqNum(0),
+        clamp: false,
+    };
+    let result = backend
+        .read(basin_name.clone(), stream_name, start, ReadEnd::default())
+        .await;
+
+    assert!(matches!(result, Err(ReadError::StreamNotFound(_))));
+    assert_stream_count(&backend, &basin_name, 0).await;
+}
+
+#[tokio::test]
 async fn test_backend_check_tail_auto_creates_stream() {
     let backend = create_backend().await;
     let basin_config = BasinConfig {
@@ -96,4 +151,161 @@ async fn test_backend_check_tail_auto_creates_stream() {
 
     assert_eq!(tail.seq_num, 0);
     assert_stream_count(&backend, &basin_name, 1).await;
+}
+
+#[tokio::test]
+async fn test_backend_check_tail_without_auto_create_returns_not_found() {
+    let backend = create_backend().await;
+    let basin_name = create_test_basin(
+        &backend,
+        "backend-no-auto-create-tail",
+        BasinConfig::default(),
+    )
+    .await;
+    let stream_name = test_stream_name("missing");
+
+    let result = backend.check_tail(basin_name.clone(), stream_name).await;
+
+    assert!(matches!(result, Err(CheckTailError::StreamNotFound(_))));
+    assert_stream_count(&backend, &basin_name, 0).await;
+}
+
+#[tokio::test]
+async fn test_backend_append_auto_create_is_race_safe() {
+    let backend = create_backend().await;
+    let basin_name = create_test_basin(
+        &backend,
+        "backend-auto-create-append-race",
+        BasinConfig {
+            create_stream_on_append: true,
+            ..Default::default()
+        },
+    )
+    .await;
+    let stream_name = test_stream_name("missing");
+    let expected_bodies: Vec<_> = (0..10).map(|i| format!("racer-{i}").into_bytes()).collect();
+    let mut handles = Vec::new();
+
+    for body in &expected_bodies {
+        let backend = backend.clone();
+        let basin_name = basin_name.clone();
+        let stream_name = stream_name.clone();
+        let body = body.clone();
+        handles.push(tokio::spawn(async move {
+            let input = AppendInput {
+                records: create_test_record_batch(vec![Bytes::from(body)]),
+                match_seq_num: None,
+                fencing_token: None,
+            };
+            for _ in 0..MAX_AUTO_CREATE_ATTEMPTS {
+                match backend
+                    .append(basin_name.clone(), stream_name.clone(), input.clone())
+                    .await
+                {
+                    Ok(ack) => return Ok(ack),
+                    Err(AppendError::TransactionConflict(_))
+                    | Err(AppendError::StreamNotFound(_)) => {
+                        tokio::task::yield_now().await;
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+            backend.append(basin_name, stream_name, input).await
+        }));
+    }
+
+    for handle in handles {
+        handle
+            .await
+            .unwrap()
+            .expect("auto-create append racer should succeed");
+    }
+
+    let tail = backend
+        .check_tail(basin_name.clone(), stream_name.clone())
+        .await
+        .expect("Failed to check tail");
+    assert_eq!(tail.seq_num, 10);
+    assert_stream_count(&backend, &basin_name, 1).await;
+
+    let (start, end) = read_all_bounds();
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
+    let mut actual_bodies = envelope_bodies(&records);
+    let mut expected_bodies = expected_bodies;
+    actual_bodies.sort();
+    expected_bodies.sort();
+    assert_eq!(actual_bodies, expected_bodies);
+}
+
+#[tokio::test]
+async fn test_backend_read_auto_create_is_race_safe() {
+    let backend = create_backend().await;
+    let basin_name = create_test_basin(
+        &backend,
+        "backend-auto-create-read-race",
+        BasinConfig {
+            create_stream_on_read: true,
+            ..Default::default()
+        },
+    )
+    .await;
+    let stream_name = test_stream_name("missing");
+    let mut handles = Vec::new();
+
+    for _ in 0..10 {
+        let backend = backend.clone();
+        let basin_name = basin_name.clone();
+        let stream_name = stream_name.clone();
+        handles.push(tokio::spawn(async move {
+            let start = ReadStart {
+                from: ReadFrom::SeqNum(0),
+                clamp: false,
+            };
+            let end = ReadEnd {
+                limit: ReadLimit::Unbounded,
+                until: ReadUntil::Unbounded,
+                wait: Some(Duration::ZERO),
+            };
+            for _ in 0..MAX_AUTO_CREATE_ATTEMPTS {
+                match backend
+                    .read(basin_name.clone(), stream_name.clone(), start, end)
+                    .await
+                {
+                    Ok(session) => {
+                        drop(session);
+                        return Ok::<(), ReadError>(());
+                    }
+                    Err(ReadError::TransactionConflict(_)) | Err(ReadError::StreamNotFound(_)) => {
+                        tokio::task::yield_now().await;
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+            match backend.read(basin_name, stream_name, start, end).await {
+                Ok(session) => {
+                    drop(session);
+                    Ok::<(), ReadError>(())
+                }
+                Err(err) => Err(err),
+            }
+        }));
+    }
+
+    for handle in handles {
+        handle
+            .await
+            .unwrap()
+            .expect("auto-create read racer should succeed");
+    }
+
+    let tail = backend
+        .check_tail(basin_name.clone(), stream_name.clone())
+        .await
+        .expect("Failed to check tail after auto-create reads");
+    assert_eq!(tail, StreamPosition::MIN);
+    assert_stream_count(&backend, &basin_name, 1).await;
+
+    let (start, end) = read_all_bounds();
+    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
+    assert!(records.is_empty());
 }

--- a/lite/tests/backend/data_plane/auto_create.rs
+++ b/lite/tests/backend/data_plane/auto_create.rs
@@ -1,97 +1,31 @@
-use std::time::Duration;
-
 use bytes::Bytes;
-use s2_common::{
-    read_extent::{ReadLimit, ReadUntil},
-    record::StreamPosition,
-    types::{
-        config::BasinConfig,
-        stream::{AppendInput, ListStreamsRequest, ReadEnd, ReadFrom, ReadStart},
-    },
+use s2_common::types::{
+    config::BasinConfig,
+    stream::{AppendInput, ListStreamsRequest, ReadEnd, ReadFrom, ReadStart},
 };
-use s2_lite::backend::error::{AppendError, CheckTailError, ReadError};
 
 use super::common::*;
 
-const MAX_AUTO_CREATE_ATTEMPTS: usize = 50;
+async fn assert_stream_count(
+    backend: &s2_lite::backend::Backend,
+    basin_name: &s2_common::types::basin::BasinName,
+    expected: usize,
+) {
+    let stream_list = backend
+        .list_streams(basin_name.clone(), ListStreamsRequest::default())
+        .await
+        .expect("Failed to list streams");
+    assert_eq!(stream_list.values.len(), expected);
+}
 
 #[tokio::test]
-async fn test_auto_create_stream_on_append() {
+async fn test_backend_append_auto_creates_stream() {
     let backend = create_backend().await;
     let basin_config = BasinConfig {
         create_stream_on_append: true,
         ..Default::default()
     };
-    let basin_name = create_test_basin(&backend, "auto-create-append", basin_config).await;
-    let stream_name = test_stream_name("auto");
-
-    let stream_list = backend
-        .list_streams(basin_name.clone(), ListStreamsRequest::default())
-        .await
-        .expect("Failed to list streams");
-    assert!(stream_list.values.is_empty());
-
-    let ack = append_payloads(&backend, &basin_name, &stream_name, &[b"auto created"]).await;
-    assert_eq!(ack.start.seq_num, 0);
-
-    let stream_list = backend
-        .list_streams(basin_name.clone(), ListStreamsRequest::default())
-        .await
-        .expect("Failed to list streams");
-    let stream_names: Vec<_> = stream_list
-        .values
-        .iter()
-        .map(|info| info.name.as_ref())
-        .collect();
-    assert_eq!(stream_names, vec![stream_name.as_ref()]);
-
-    let config = backend
-        .get_stream_config(basin_name, stream_name)
-        .await
-        .expect("Failed to get stream config");
-    assert!(config.storage_class.is_some());
-}
-
-#[tokio::test]
-async fn test_auto_create_stream_on_read() {
-    let backend = create_backend().await;
-    let basin_config = BasinConfig {
-        create_stream_on_read: true,
-        ..Default::default()
-    };
-    let basin_name = create_test_basin(&backend, "auto-create-read", basin_config).await;
-    let stream_name = test_stream_name("auto");
-
-    let stream_list = backend
-        .list_streams(basin_name.clone(), ListStreamsRequest::default())
-        .await
-        .expect("Failed to list streams");
-    assert!(stream_list.values.is_empty());
-
-    let (start, end) = read_all_bounds();
-    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
-    assert!(records.is_empty());
-
-    let stream_list = backend
-        .list_streams(basin_name.clone(), ListStreamsRequest::default())
-        .await
-        .expect("Failed to list streams");
-    let stream_names: Vec<_> = stream_list
-        .values
-        .iter()
-        .map(|info| info.name.as_ref())
-        .collect();
-    assert_eq!(stream_names, vec![stream_name.as_ref()]);
-}
-
-#[tokio::test]
-async fn test_auto_create_disabled_append_fails() {
-    let backend = create_backend().await;
-    let basin_config = BasinConfig {
-        create_stream_on_append: false,
-        ..Default::default()
-    };
-    let basin_name = create_test_basin(&backend, "no-auto-create-append", basin_config).await;
+    let basin_name = create_test_basin(&backend, "backend-auto-create-append", basin_config).await;
     let stream_name = test_stream_name("missing");
 
     let input = AppendInput {
@@ -100,227 +34,66 @@ async fn test_auto_create_disabled_append_fails() {
         fencing_token: None,
     };
 
-    let result = backend.append(basin_name, stream_name, input).await;
+    let ack = backend
+        .append(basin_name.clone(), stream_name.clone(), input)
+        .await
+        .expect("Failed to append to auto-created stream");
 
-    assert!(matches!(result, Err(AppendError::StreamNotFound(_))));
+    assert_eq!(ack.end.seq_num, 1);
+    assert_stream_count(&backend, &basin_name, 1).await;
+    let tail = backend
+        .check_tail(basin_name, stream_name)
+        .await
+        .expect("Failed to check tail on auto-created stream");
+    assert_eq!(tail.seq_num, 1);
 }
 
 #[tokio::test]
-async fn test_auto_create_disabled_read_fails() {
+async fn test_backend_read_auto_creates_stream() {
     let backend = create_backend().await;
     let basin_config = BasinConfig {
-        create_stream_on_read: false,
+        create_stream_on_read: true,
         ..Default::default()
     };
-    let basin_name = create_test_basin(&backend, "no-auto-create-read", basin_config).await;
+    let basin_name = create_test_basin(&backend, "backend-auto-create-read", basin_config).await;
     let stream_name = test_stream_name("missing");
 
     let start = ReadStart {
         from: ReadFrom::SeqNum(0),
         clamp: false,
     };
-    let end = ReadEnd::default();
-
-    let result = backend.read(basin_name, stream_name, start, end).await;
-
-    assert!(matches!(result, Err(ReadError::StreamNotFound(_))));
+    let _session = backend
+        .read(
+            basin_name.clone(),
+            stream_name.clone(),
+            start,
+            ReadEnd::default(),
+        )
+        .await
+        .expect("Failed to open read session on auto-created stream");
+    assert_stream_count(&backend, &basin_name, 1).await;
+    let tail = backend
+        .check_tail(basin_name, stream_name)
+        .await
+        .expect("Failed to check tail on auto-created read stream");
+    assert_eq!(tail.seq_num, 0);
 }
 
 #[tokio::test]
-async fn test_auto_create_disabled_check_tail_fails() {
+async fn test_backend_check_tail_auto_creates_stream() {
     let backend = create_backend().await;
     let basin_config = BasinConfig {
-        create_stream_on_read: false,
+        create_stream_on_read: true,
         ..Default::default()
     };
-    let basin_name = create_test_basin(&backend, "no-auto-create-tail", basin_config).await;
+    let basin_name = create_test_basin(&backend, "backend-auto-create-tail", basin_config).await;
     let stream_name = test_stream_name("missing");
 
-    let result = backend.check_tail(basin_name, stream_name).await;
-
-    assert!(matches!(result, Err(CheckTailError::StreamNotFound(_))));
-}
-
-#[tokio::test]
-async fn test_auto_create_check_tail() {
-    let backend = create_backend().await;
-    let basin_config = BasinConfig {
-        create_stream_on_read: true,
-        ..Default::default()
-    };
-    let basin_name = create_test_basin(&backend, "auto-create-tail", basin_config).await;
-    let stream_name = test_stream_name("auto");
-
     let tail = backend
-        .check_tail(basin_name.clone(), stream_name.clone())
+        .check_tail(basin_name.clone(), stream_name)
         .await
-        .expect("check_tail should auto-create stream");
-    assert_eq!(tail, StreamPosition::MIN);
+        .expect("Failed to check tail on auto-created stream");
 
-    let stream_list = backend
-        .list_streams(basin_name.clone(), ListStreamsRequest::default())
-        .await
-        .expect("Failed to list streams");
-    let stream_names: Vec<_> = stream_list
-        .values
-        .iter()
-        .map(|info| info.name.as_ref())
-        .collect();
-    assert_eq!(stream_names, vec![stream_name.as_ref()]);
-}
-
-#[tokio::test]
-async fn test_auto_create_race_condition_append() {
-    let backend = create_backend().await;
-    let basin_config = BasinConfig {
-        create_stream_on_append: true,
-        ..Default::default()
-    };
-    let basin_name = create_test_basin(&backend, "auto-race-append", basin_config).await;
-    let stream_name = test_stream_name("racing");
-
-    let expected_bodies: Vec<_> = (0..10).map(|i| format!("racer-{i}").into_bytes()).collect();
-    let mut handles = vec![];
-    for body in &expected_bodies {
-        let backend = backend.clone();
-        let basin_name = basin_name.clone();
-        let stream_name = stream_name.clone();
-        let body = body.clone();
-        let handle = tokio::spawn(async move {
-            let input = AppendInput {
-                records: create_test_record_batch(vec![Bytes::from(body)]),
-                match_seq_num: None,
-                fencing_token: None,
-            };
-            for _ in 0..MAX_AUTO_CREATE_ATTEMPTS {
-                match backend
-                    .append(basin_name.clone(), stream_name.clone(), input.clone())
-                    .await
-                {
-                    Ok(ack) => return Ok(ack),
-                    Err(AppendError::TransactionConflict(_))
-                    | Err(AppendError::StreamNotFound(_)) => {
-                        tokio::task::yield_now().await;
-                        continue;
-                    }
-                    Err(e) => return Err(e),
-                }
-            }
-            backend.append(basin_name, stream_name, input).await
-        });
-        handles.push(handle);
-    }
-
-    for handle in handles {
-        handle
-            .await
-            .unwrap()
-            .expect("Auto-create append racer should succeed");
-    }
-
-    let tail = backend
-        .check_tail(basin_name.clone(), stream_name.clone())
-        .await
-        .expect("Failed to check tail");
-    assert_eq!(tail.seq_num, 10);
-
-    let stream_list = backend
-        .list_streams(basin_name.clone(), ListStreamsRequest::default())
-        .await
-        .expect("Failed to list streams");
-    let stream_names: Vec<_> = stream_list
-        .values
-        .iter()
-        .map(|info| info.name.as_ref())
-        .collect();
-    assert_eq!(stream_names, vec![stream_name.as_ref()]);
-
-    let (start, end) = read_all_bounds();
-    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
-    let mut actual_bodies = envelope_bodies(&records);
-    let mut expected_bodies = expected_bodies;
-    actual_bodies.sort();
-    expected_bodies.sort();
-    assert_eq!(actual_bodies, expected_bodies);
-}
-
-#[tokio::test]
-async fn test_auto_create_race_condition_read() {
-    let backend = create_backend().await;
-    let basin_config = BasinConfig {
-        create_stream_on_read: true,
-        ..Default::default()
-    };
-    let basin_name = create_test_basin(&backend, "auto-race-read", basin_config).await;
-    let stream_name = test_stream_name("racing");
-
-    let mut handles = vec![];
-    for _ in 0..10 {
-        let backend = backend.clone();
-        let basin_name = basin_name.clone();
-        let stream_name = stream_name.clone();
-        let handle = tokio::spawn(async move {
-            let start = ReadStart {
-                from: ReadFrom::SeqNum(0),
-                clamp: false,
-            };
-            let end = ReadEnd {
-                limit: ReadLimit::Unbounded,
-                until: ReadUntil::Unbounded,
-                wait: Some(Duration::ZERO),
-            };
-            for _ in 0..MAX_AUTO_CREATE_ATTEMPTS {
-                match backend
-                    .read(basin_name.clone(), stream_name.clone(), start, end)
-                    .await
-                {
-                    Ok(session) => {
-                        drop(session);
-                        return Ok::<(), ReadError>(());
-                    }
-                    Err(ReadError::TransactionConflict(_)) | Err(ReadError::StreamNotFound(_)) => {
-                        tokio::task::yield_now().await;
-                        continue;
-                    }
-                    Err(e) => return Err(e),
-                }
-            }
-            match backend.read(basin_name, stream_name, start, end).await {
-                Ok(session) => {
-                    drop(session);
-                    Ok::<(), ReadError>(())
-                }
-                Err(e) => Err(e),
-            }
-        });
-        handles.push(handle);
-    }
-
-    for handle in handles {
-        handle
-            .await
-            .unwrap()
-            .expect("Auto-create read racer should succeed");
-    }
-
-    let stream_list = backend
-        .list_streams(basin_name.clone(), ListStreamsRequest::default())
-        .await
-        .expect("Failed to list streams");
-    let stream_names: Vec<_> = stream_list
-        .values
-        .iter()
-        .map(|info| info.name.as_ref())
-        .collect();
-    assert_eq!(stream_names, vec![stream_name.as_ref()]);
-
-    let tail = backend
-        .check_tail(basin_name.clone(), stream_name.clone())
-        .await
-        .expect("Failed to check tail after auto-create reads");
-    assert_eq!(tail, StreamPosition::MIN);
-
-    let (start, end) = read_all_bounds();
-    let records = read_records(&backend, &basin_name, &stream_name, start, end).await;
-    assert!(records.is_empty());
+    assert_eq!(tail.seq_num, 0);
+    assert_stream_count(&backend, &basin_name, 1).await;
 }

--- a/lite/tests/backend/data_plane/mixed.rs
+++ b/lite/tests/backend/data_plane/mixed.rs
@@ -154,7 +154,6 @@ async fn test_concurrent_reconfigure_during_append() {
         retention_policy: s2_common::maybe::Maybe::from(Some(RetentionPolicy::Infinite())),
         timestamping: s2_common::maybe::Maybe::default(),
         delete_on_empty: s2_common::maybe::Maybe::default(),
-        encryption: s2_common::maybe::Maybe::default(),
     };
 
     let updated_config = backend

--- a/lite/tests/backend/data_plane/mixed.rs
+++ b/lite/tests/backend/data_plane/mixed.rs
@@ -29,9 +29,7 @@ async fn test_operations_on_nonexistent_basin() {
         wait: None,
     };
 
-    let read_result = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await;
+    let read_result = try_open_read_session(&backend, &basin_name, &stream_name, start, end).await;
     assert!(matches!(read_result, Err(ReadError::BasinNotFound(_))));
 
     let input = AppendInput {
@@ -39,12 +37,17 @@ async fn test_operations_on_nonexistent_basin() {
         match_seq_num: None,
         fencing_token: None,
     };
-    let append_result = backend
-        .append(basin_name.clone(), stream_name.clone(), input)
-        .await;
+    let append_result = append(
+        &backend,
+        basin_name.clone(),
+        stream_name.clone(),
+        input,
+        None,
+    )
+    .await;
     assert!(matches!(append_result, Err(AppendError::BasinNotFound(_))));
 
-    let check_tail_result = backend.check_tail(basin_name, stream_name).await;
+    let check_tail_result = check_tail(&backend, basin_name, stream_name).await;
     assert!(matches!(
         check_tail_result,
         Err(CheckTailError::BasinNotFound(_))
@@ -75,7 +78,7 @@ async fn test_concurrent_appends_to_same_stream() {
                 match_seq_num: None,
                 fencing_token: None,
             };
-            backend.append(basin_name, stream_name, input).await
+            append(&backend, basin_name, stream_name, input, None).await
         });
         handles.push(handle);
     }
@@ -87,8 +90,7 @@ async fn test_concurrent_appends_to_same_stream() {
             .expect("Concurrent append should succeed");
     }
 
-    let tail = backend
-        .check_tail(basin_name.clone(), stream_name.clone())
+    let tail = check_tail(&backend, basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to check tail");
     assert_eq!(tail.seq_num, 20);
@@ -103,10 +105,7 @@ async fn test_concurrent_appends_to_same_stream() {
         wait: Some(Duration::ZERO),
     };
 
-    let session = backend
-        .read(basin_name, stream_name, start, end)
-        .await
-        .expect("Failed to create read session");
+    let session = open_read_session(&backend, &basin_name, &stream_name, start, end).await;
     let mut session = Box::pin(session);
     let records = collect_records(&mut session).await;
     let mut actual_bodies = envelope_bodies(&records);
@@ -164,8 +163,7 @@ async fn test_concurrent_reconfigure_during_append() {
 
     append_handle.await.unwrap();
 
-    let tail = backend
-        .check_tail(basin_name.clone(), stream_name.clone())
+    let tail = check_tail(&backend, basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to check tail");
     assert_eq!(tail.seq_num, 10);
@@ -214,7 +212,8 @@ async fn test_concurrent_reads_same_stream() {
                 until: ReadUntil::Unbounded,
                 wait: Some(Duration::ZERO),
             };
-            let session = backend.read(basin_name, stream_name, start, end).await?;
+            let session =
+                try_open_read_session(&backend, &basin_name, &stream_name, start, end).await?;
             let mut session = Box::pin(session);
             let records = collect_records(&mut session).await;
             Ok::<Vec<Vec<u8>>, ReadError>(envelope_bodies(&records))

--- a/lite/tests/backend/data_plane/read.rs
+++ b/lite/tests/backend/data_plane/read.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use rstest::rstest;
 use s2_common::{
-    encryption::{Encryption, EncryptionMode},
+    encryption::{Encryption, EncryptionAlgorithm},
     read_extent::{ReadLimit, ReadUntil},
     record::{MeteredSize, RecordDecryptionError, StreamPosition},
     types::{
@@ -204,10 +204,10 @@ async fn test_read_encrypted_batch_rejects_plaintext_decryption() {
     let batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
     assert!(matches!(
         batch.decrypt(&Encryption::Plain, &[]),
-        Err(RecordDecryptionError::ModeMismatch {
-            expected: EncryptionMode::Plain,
+        Err(RecordDecryptionError::AlgorithmMismatch {
+            expected: None,
             actual,
-        }) if actual == EncryptionMode::Aegis256
+        }) if actual == Some(EncryptionAlgorithm::Aegis256)
     ));
 }
 

--- a/lite/tests/backend/data_plane/read.rs
+++ b/lite/tests/backend/data_plane/read.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use rstest::rstest;
 use s2_common::{
-    encryption::{EncryptionMode, EncryptionSpec},
+    encryption::{Encryption, EncryptionMode},
     read_extent::{ReadLimit, ReadUntil},
     record::{MeteredSize, RecordDecryptionError, StreamPosition},
     types::{
@@ -203,7 +203,7 @@ async fn test_read_encrypted_batch_rejects_plaintext_decryption() {
 
     let batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
     assert!(matches!(
-        batch.decrypt(&EncryptionSpec::Plain, &[]),
+        batch.decrypt(&Encryption::Plain, &[]),
         Err(RecordDecryptionError::ModeMismatch {
             expected: EncryptionMode::Plain,
             actual,

--- a/lite/tests/backend/data_plane/read.rs
+++ b/lite/tests/backend/data_plane/read.rs
@@ -4,13 +4,13 @@ use bytes::Bytes;
 use futures::StreamExt;
 use rstest::rstest;
 use s2_common::{
-    encryption::{EncryptionAlgorithm, EncryptionSpec},
+    encryption::EncryptionAlgorithm,
     read_extent::{ReadLimit, ReadUntil},
-    record::{MeteredSize, RecordDecryptionError, StreamPosition},
+    record::{MeteredSize, StreamPosition},
     types::{
         basin::BasinName,
         config::{OptionalStreamConfig, OptionalTimestampingConfig, TimestampingMode},
-        stream::{ReadEnd, ReadFrom, ReadStart, StoredReadSessionOutput, StreamName},
+        stream::{ReadEnd, ReadFrom, ReadSessionOutput, ReadStart, StreamName},
     },
 };
 use s2_lite::backend::{
@@ -106,27 +106,25 @@ async fn test_check_tail_scenarios() {
     let (backend, basin_name, stream_name) =
         setup_backend_with_stream("check-tail", "stream", OptionalStreamConfig::default()).await;
 
-    let empty_tail = backend
-        .check_tail(basin_name.clone(), stream_name.clone())
+    let empty_tail = check_tail(&backend, basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to check tail on empty stream");
     assert_eq!(empty_tail, StreamPosition::MIN);
 
     let ack = append_payloads(&backend, &basin_name, &stream_name, &[b"test data"]).await;
 
-    let tail_after_append = backend
-        .check_tail(basin_name.clone(), stream_name.clone())
+    let tail_after_append = check_tail(&backend, basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to check tail after append");
     assert_eq!(tail_after_append, ack.end);
 
     let missing_backend = create_backend().await;
-    let missing_result = missing_backend
-        .check_tail(
-            test_basin_name("check-tail-missing"),
-            test_stream_name("missing"),
-        )
-        .await;
+    let missing_result = check_tail(
+        &missing_backend,
+        test_basin_name("check-tail-missing"),
+        test_stream_name("missing"),
+    )
+    .await;
 
     assert!(matches!(
         missing_result,
@@ -182,36 +180,6 @@ async fn test_read_encrypted_roundtrip() {
 }
 
 #[tokio::test]
-async fn test_read_encrypted_batch_rejects_plaintext_decryption() {
-    let encryption = aegis256_encryption_spec();
-    let (backend, basin_name, stream_name) = setup_backend_with_basin_and_stream(
-        "read-enc-plain-mismatch",
-        "stream",
-        basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256),
-        OptionalStreamConfig::default(),
-    )
-    .await;
-
-    append_payloads_with_encryption(
-        &backend,
-        &basin_name,
-        &stream_name,
-        &[b"secret-1", b"secret-2"],
-        &encryption,
-    )
-    .await;
-
-    let batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
-    assert!(matches!(
-        batch.decrypt(&EncryptionSpec::Plain, &[]),
-        Err(RecordDecryptionError::AlgorithmMismatch {
-            expected: None,
-            actual,
-        }) if actual == Some(EncryptionAlgorithm::Aegis256)
-    ));
-}
-
-#[tokio::test]
 async fn test_read_with_limit() {
     let (backend, basin_name, stream_name) =
         setup_backend_with_stream("read-with-limit", "limit", OptionalStreamConfig::default())
@@ -258,14 +226,14 @@ async fn test_read_unwritten_clamp_behavior() {
         from: ReadFrom::SeqNum(100),
         clamp: false,
     };
-    let result = backend
-        .read(
-            basin_name.clone(),
-            stream_name.clone(),
-            start,
-            ReadEnd::default(),
-        )
-        .await;
+    let result = try_open_read_session(
+        &backend,
+        &basin_name,
+        &stream_name,
+        start,
+        ReadEnd::default(),
+    )
+    .await;
     assert!(matches!(result, Err(ReadError::Unwritten(_))));
 
     // With clamp: succeeds with empty result
@@ -320,9 +288,7 @@ async fn test_read_at_tail_without_follow_returns_unwritten(
         clamp,
     };
     let end = tail_read_end(end_case);
-    let result = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await;
+    let result = try_open_read_session(&backend, &basin_name, &stream_name, start, end).await;
 
     match result {
         Err(ReadError::Unwritten(UnwrittenError(tail))) => {
@@ -429,7 +395,7 @@ async fn test_read_from_tail_times_out_without_new_data() {
         outputs
             .outputs
             .iter()
-            .all(|output| matches!(output, StoredReadSessionOutput::Heartbeat(_)))
+            .all(|output| matches!(output, ReadSessionOutput::Heartbeat(_)))
     );
     let wait = Duration::from_millis(100);
     assert!(outputs.closed_at >= started + wait);
@@ -465,7 +431,7 @@ async fn test_read_from_tail_wait_is_reset_by_new_data() {
         .await
         .expect("session should enter follow mode")
         .expect("session should not error");
-    assert!(matches!(first, StoredReadSessionOutput::Heartbeat(_)));
+    assert!(matches!(first, ReadSessionOutput::Heartbeat(_)));
 
     advance_time(follow_delay).await;
 
@@ -478,10 +444,9 @@ async fn test_read_from_tail_wait_is_reset_by_new_data() {
         .expect("session should yield the live tail batch")
         .expect("session should not error");
     let reset_at = tokio::time::Instant::now();
-    let StoredReadSessionOutput::Batch(batch) = follow else {
+    let ReadSessionOutput::Batch(batch) = follow else {
         panic!("expected a batch after appending past tail");
     };
-    let batch = decrypt_plain_batch(batch);
     assert_eq!(
         envelope_bodies(&batch.records),
         vec![b"follow data".to_vec()]
@@ -515,9 +480,11 @@ async fn test_read_with_bytes_limit_exact_fit() {
     )
     .await;
 
-    let stored_batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
-    let exact_limit =
-        stored_batch.records[0].metered_size() + stored_batch.records[1].metered_size();
+    let expected_batch = create_test_record_batch(vec![
+        Bytes::from_static(b"record-1"),
+        Bytes::from_static(b"record-2"),
+    ]);
+    let exact_limit = expected_batch[0].metered_size() + expected_batch[1].metered_size();
 
     let start = ReadStart {
         from: ReadFrom::SeqNum(0),
@@ -547,8 +514,8 @@ async fn test_read_with_bytes_limit_smaller_than_first_record_returns_empty() {
 
     append_payloads(&backend, &basin_name, &stream_name, &[b"oversized"]).await;
 
-    let stored_batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
-    let first_size = stored_batch.records[0].metered_size();
+    let first_size =
+        create_test_record_batch(vec![Bytes::from_static(b"oversized")])[0].metered_size();
     assert!(first_size > 0);
 
     let start = ReadStart {
@@ -614,8 +581,8 @@ async fn test_read_with_count_or_bytes_limit_bytes_wins() {
     )
     .await;
 
-    let stored_batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
-    let per_record_bytes = stored_batch.records[0].metered_size();
+    let per_record_bytes =
+        create_test_record_batch(vec![Bytes::from_static(b"slot-0")])[0].metered_size();
 
     let start = ReadStart {
         from: ReadFrom::SeqNum(0),
@@ -714,8 +681,8 @@ async fn test_read_until_with_additional_limits() {
     )
     .await;
 
-    let stored_batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
-    let per_record_bytes = stored_batch.records[0].metered_size();
+    let per_record_bytes =
+        create_test_record_batch(vec![Bytes::from_static(b"ts-1000")])[0].metered_size();
     let cases = vec![
         (
             "count wins",

--- a/lite/tests/backend/data_plane/read.rs
+++ b/lite/tests/backend/data_plane/read.rs
@@ -203,7 +203,7 @@ async fn test_read_encrypted_batch_rejects_plaintext_decryption() {
 
     let batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
     assert!(matches!(
-        batch.decrypt(&EncryptionSpec::plain(), &[]),
+        batch.decrypt(&EncryptionSpec::Plaintext, &[]),
         Err(RecordDecryptionError::AlgorithmMismatch {
             expected: None,
             actual,

--- a/lite/tests/backend/data_plane/read.rs
+++ b/lite/tests/backend/data_plane/read.rs
@@ -203,7 +203,7 @@ async fn test_read_encrypted_batch_rejects_plaintext_decryption() {
 
     let batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
     assert!(matches!(
-        batch.decrypt(&EncryptionSpec::Plaintext, &[]),
+        batch.decrypt(&EncryptionSpec::Plain, &[]),
         Err(RecordDecryptionError::AlgorithmMismatch {
             expected: None,
             actual,

--- a/lite/tests/backend/data_plane/read.rs
+++ b/lite/tests/backend/data_plane/read.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use rstest::rstest;
 use s2_common::{
-    encryption::{Encryption, EncryptionAlgorithm},
+    encryption::{EncryptionAlgorithm, EncryptionSpec},
     read_extent::{ReadLimit, ReadUntil},
     record::{MeteredSize, RecordDecryptionError, StreamPosition},
     types::{
@@ -203,7 +203,7 @@ async fn test_read_encrypted_batch_rejects_plaintext_decryption() {
 
     let batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
     assert!(matches!(
-        batch.decrypt(&Encryption::Plain, &[]),
+        batch.decrypt(&EncryptionSpec::plain(), &[]),
         Err(RecordDecryptionError::AlgorithmMismatch {
             expected: None,
             actual,

--- a/lite/tests/backend/data_plane/read.rs
+++ b/lite/tests/backend/data_plane/read.rs
@@ -157,8 +157,8 @@ async fn test_read_encrypted_roundtrip() {
     let (backend, basin_name, stream_name) = setup_backend_with_basin_and_stream(
         "read-enc",
         "stream",
-        all_encryption_modes_basin_config(),
-        all_encryption_modes_stream_config(),
+        basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256),
+        OptionalStreamConfig::default(),
     )
     .await;
 
@@ -187,8 +187,8 @@ async fn test_read_encrypted_batch_rejects_plaintext_decryption() {
     let (backend, basin_name, stream_name) = setup_backend_with_basin_and_stream(
         "read-enc-plain-mismatch",
         "stream",
-        all_encryption_modes_basin_config(),
-        all_encryption_modes_stream_config(),
+        basin_config_with_stream_cipher(EncryptionAlgorithm::Aegis256),
+        OptionalStreamConfig::default(),
     )
     .await;
 

--- a/lite/tests/backend/data_plane/read_follow.rs
+++ b/lite/tests/backend/data_plane/read_follow.rs
@@ -9,7 +9,7 @@ use s2_common::{
     record::MeteredSize,
     types::{
         config::{OptionalStreamConfig, OptionalTimestampingConfig, TimestampingMode},
-        stream::{AppendInput, ReadEnd, ReadFrom, ReadStart, StoredReadSessionOutput},
+        stream::{AppendInput, ReadEnd, ReadFrom, ReadSessionOutput, ReadStart},
     },
 };
 use s2_lite::backend::FOLLOWER_MAX_LAG;
@@ -44,10 +44,15 @@ async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &
         wait: Some(wait_duration),
     };
 
-    let session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
+    let session = open_read_session_with_encryption(
+        &backend,
+        &basin_name,
+        &stream_name,
+        start,
+        end,
+        encryption,
+    )
+    .await;
     let mut session = Box::pin(session);
 
     let backend_clone = backend.clone();
@@ -87,7 +92,7 @@ async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &
     let closed_at = loop {
         match poll_session_with_deadline(&mut session, deadline, Some(probe_step)).await {
             SessionPoll::Output(output) => {
-                if matches!(output, StoredReadSessionOutput::Batch(_)) {
+                if matches!(output, ReadSessionOutput::Batch(_)) {
                     final_delivery_at = Some(tokio::time::Instant::now());
                 }
                 outputs.push(output);
@@ -102,14 +107,10 @@ async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &
     let all_records = outputs
         .into_iter()
         .filter_map(|output| match output {
-            StoredReadSessionOutput::Batch(batch) => Some(batch),
-            StoredReadSessionOutput::Heartbeat(_) => None,
+            ReadSessionOutput::Batch(batch) => Some(batch),
+            ReadSessionOutput::Heartbeat(_) => None,
         })
-        .flat_map(|batch| {
-            decrypt_batch_for_stream(batch, &basin_name, &stream_name, encryption)
-                .records
-                .into_iter()
-        })
+        .flat_map(|batch| batch.records.into_iter())
         .collect::<Vec<_>>();
     let bodies = envelope_bodies(&all_records);
     assert_eq!(
@@ -150,10 +151,7 @@ async fn test_follow_mode_broadcast_lag_resets_wait_after_db_catchup() {
         wait: Some(wait_duration),
     };
 
-    let session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
+    let session = open_read_session(&backend, &basin_name, &stream_name, start, end).await;
     let mut session = Box::pin(session);
 
     expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
@@ -173,10 +171,9 @@ async fn test_follow_mode_broadcast_lag_resets_wait_after_db_catchup() {
         .expect("session should deliver the lagged catchup batch")
         .expect("session should not error");
     let reset_at = tokio::time::Instant::now();
-    let StoredReadSessionOutput::Batch(batch) = follow else {
+    let ReadSessionOutput::Batch(batch) = follow else {
         panic!("expected catchup batch after lagged follow");
     };
-    let batch = decrypt_plain_batch(batch);
     assert_eq!(envelope_bodies(&batch.records), expected);
 
     let outputs = collect_outputs_until_closed_advanced(
@@ -212,10 +209,7 @@ async fn test_follow_mode_broadcast_lag_respects_count_limit() {
         wait: Some(Duration::from_secs(3)),
     };
 
-    let session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
+    let session = open_read_session(&backend, &basin_name, &stream_name, start, end).await;
     let mut session = Box::pin(session);
 
     expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
@@ -251,27 +245,26 @@ async fn test_follow_mode_broadcast_lag_respects_bytes_limit() {
 
     append_payloads(&backend, &basin_name, &stream_name, &[b"item-00"]).await;
 
-    let stored_batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
-    let per_record_bytes = stored_batch.records[0].metered_size();
+    let per_record_bytes =
+        create_test_record_batch(vec![Bytes::from_static(b"item-00")])[0].metered_size();
     let message_count = FOLLOWER_MAX_LAG + 25;
     let bytes_limit = per_record_bytes * 3;
 
-    let session = backend
-        .read(
-            basin_name.clone(),
-            stream_name.clone(),
-            ReadStart {
-                from: ReadFrom::TailOffset(0),
-                clamp: false,
-            },
-            ReadEnd {
-                limit: ReadLimit::Bytes(bytes_limit),
-                until: ReadUntil::Unbounded,
-                wait: Some(Duration::from_secs(3)),
-            },
-        )
-        .await
-        .expect("Failed to create read session");
+    let session = open_read_session(
+        &backend,
+        &basin_name,
+        &stream_name,
+        ReadStart {
+            from: ReadFrom::TailOffset(0),
+            clamp: false,
+        },
+        ReadEnd {
+            limit: ReadLimit::Bytes(bytes_limit),
+            until: ReadUntil::Unbounded,
+            wait: Some(Duration::from_secs(3)),
+        },
+    )
+    .await;
     let mut session = Box::pin(session);
 
     expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
@@ -312,22 +305,21 @@ async fn test_follow_mode_broadcast_lag_respects_timestamp_until() {
     let message_count = FOLLOWER_MAX_LAG + 25;
     let cutoff = 4_000;
 
-    let session = backend
-        .read(
-            basin_name.clone(),
-            stream_name.clone(),
-            ReadStart {
-                from: ReadFrom::SeqNum(0),
-                clamp: false,
-            },
-            ReadEnd {
-                limit: ReadLimit::Unbounded,
-                until: ReadUntil::Timestamp(cutoff),
-                wait: Some(Duration::from_secs(3)),
-            },
-        )
-        .await
-        .expect("Failed to create read session");
+    let session = open_read_session(
+        &backend,
+        &basin_name,
+        &stream_name,
+        ReadStart {
+            from: ReadFrom::SeqNum(0),
+            clamp: false,
+        },
+        ReadEnd {
+            limit: ReadLimit::Unbounded,
+            until: ReadUntil::Timestamp(cutoff),
+            wait: Some(Duration::from_secs(3)),
+        },
+    )
+    .await;
     let mut session = Box::pin(session);
 
     expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
@@ -352,10 +344,9 @@ async fn test_follow_mode_broadcast_lag_respects_timestamp_until() {
         .await
         .expect("session should deliver the lagged catchup batch")
         .expect("session should not error");
-    let StoredReadSessionOutput::Batch(batch) = catchup else {
+    let ReadSessionOutput::Batch(batch) = catchup else {
         panic!("expected lagged catchup batch");
     };
-    let batch = decrypt_plain_batch(batch);
     assert_eq!(
         envelope_bodies(&batch.records),
         expected
@@ -400,10 +391,7 @@ async fn test_follow_mode_broadcast_lag_resumes_live_follow_after_catchup() {
         wait: Some(Duration::from_millis(300)),
     };
 
-    let session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
+    let session = open_read_session(&backend, &basin_name, &stream_name, start, end).await;
     let mut session = Box::pin(session);
 
     expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
@@ -422,10 +410,9 @@ async fn test_follow_mode_broadcast_lag_resumes_live_follow_after_catchup() {
         .await
         .expect("session should deliver the lagged catchup batch")
         .expect("session should not error");
-    let StoredReadSessionOutput::Batch(batch) = catchup else {
+    let ReadSessionOutput::Batch(batch) = catchup else {
         panic!("expected catchup batch after lagged follow");
     };
-    let batch = decrypt_plain_batch(batch);
     assert_eq!(envelope_bodies(&batch.records), expected_catchup);
 
     let backend_clone = backend.clone();
@@ -492,10 +479,7 @@ async fn test_transition_from_catchup_to_follow() {
         wait: Some(Duration::from_secs(3)),
     };
 
-    let session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
+    let session = open_read_session(&backend, &basin_name, &stream_name, start, end).await;
     let mut session = Box::pin(session);
 
     let backend_clone = backend.clone();
@@ -549,10 +533,7 @@ async fn test_follow_mode_with_count_limit() {
         wait: Some(Duration::from_secs(3)),
     };
 
-    let session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
+    let session = open_read_session(&backend, &basin_name, &stream_name, start, end).await;
     let mut session = Box::pin(session);
 
     let backend_clone = backend.clone();
@@ -609,10 +590,7 @@ async fn test_follow_mode_with_exact_count_limit() {
         wait: Some(Duration::from_secs(2)),
     };
 
-    let session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
+    let session = open_read_session(&backend, &basin_name, &stream_name, start, end).await;
     let mut session = Box::pin(session);
 
     let backend_clone = backend.clone();
@@ -654,22 +632,21 @@ async fn test_collect_records_until_advanced_stops_at_target_count_with_multi_re
 
     append_payloads(&backend, &basin_name, &stream_name, &[b"seed"]).await;
 
-    let session = backend
-        .read(
-            basin_name.clone(),
-            stream_name.clone(),
-            ReadStart {
-                from: ReadFrom::TailOffset(0),
-                clamp: false,
-            },
-            ReadEnd {
-                limit: ReadLimit::Unbounded,
-                until: ReadUntil::Unbounded,
-                wait: Some(Duration::from_secs(2)),
-            },
-        )
-        .await
-        .expect("Failed to create follow read session");
+    let session = open_read_session(
+        &backend,
+        &basin_name,
+        &stream_name,
+        ReadStart {
+            from: ReadFrom::TailOffset(0),
+            clamp: false,
+        },
+        ReadEnd {
+            limit: ReadLimit::Unbounded,
+            until: ReadUntil::Unbounded,
+            wait: Some(Duration::from_secs(2)),
+        },
+    )
+    .await;
     let mut session = Box::pin(session);
 
     expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
@@ -711,25 +688,24 @@ async fn test_follow_mode_with_bytes_limit_truncates_live_batch() {
 
     append_payloads(&backend, &basin_name, &stream_name, &[b"item-00"]).await;
 
-    let stored_batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
-    let per_record_bytes = stored_batch.records[0].metered_size();
+    let per_record_bytes =
+        create_test_record_batch(vec![Bytes::from_static(b"item-00")])[0].metered_size();
 
-    let session = backend
-        .read(
-            basin_name.clone(),
-            stream_name.clone(),
-            ReadStart {
-                from: ReadFrom::TailOffset(0),
-                clamp: false,
-            },
-            ReadEnd {
-                limit: ReadLimit::Bytes(per_record_bytes * 2),
-                until: ReadUntil::Unbounded,
-                wait: Some(Duration::from_secs(2)),
-            },
-        )
-        .await
-        .expect("Failed to create follow read session");
+    let session = open_read_session(
+        &backend,
+        &basin_name,
+        &stream_name,
+        ReadStart {
+            from: ReadFrom::TailOffset(0),
+            clamp: false,
+        },
+        ReadEnd {
+            limit: ReadLimit::Bytes(per_record_bytes * 2),
+            until: ReadUntil::Unbounded,
+            wait: Some(Duration::from_secs(2)),
+        },
+    )
+    .await;
     let mut session = Box::pin(session);
 
     expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
@@ -748,8 +724,7 @@ async fn test_follow_mode_with_bytes_limit_truncates_live_batch() {
             match_seq_num: None,
             fencing_token: None,
         };
-        backend_clone
-            .append(basin_clone, stream_clone, input)
+        append(&backend_clone, basin_clone, stream_clone, input, None)
             .await
             .expect("live append should succeed");
     });
@@ -780,25 +755,24 @@ async fn test_follow_mode_with_bytes_limit_smaller_than_first_live_record_closes
 
     append_payloads(&backend, &basin_name, &stream_name, &[b"item-00"]).await;
 
-    let stored_batch = first_stored_batch(&backend, &basin_name, &stream_name).await;
-    let per_record_bytes = stored_batch.records[0].metered_size();
+    let per_record_bytes =
+        create_test_record_batch(vec![Bytes::from_static(b"item-00")])[0].metered_size();
 
-    let session = backend
-        .read(
-            basin_name.clone(),
-            stream_name.clone(),
-            ReadStart {
-                from: ReadFrom::TailOffset(0),
-                clamp: false,
-            },
-            ReadEnd {
-                limit: ReadLimit::Bytes(per_record_bytes - 1),
-                until: ReadUntil::Unbounded,
-                wait: Some(Duration::from_secs(2)),
-            },
-        )
-        .await
-        .expect("Failed to create follow read session");
+    let session = open_read_session(
+        &backend,
+        &basin_name,
+        &stream_name,
+        ReadStart {
+            from: ReadFrom::TailOffset(0),
+            clamp: false,
+        },
+        ReadEnd {
+            limit: ReadLimit::Bytes(per_record_bytes - 1),
+            until: ReadUntil::Unbounded,
+            wait: Some(Duration::from_secs(2)),
+        },
+    )
+    .await;
     let mut session = Box::pin(session);
 
     expect_heartbeat_advanced(&mut session, Duration::from_secs(1), VIRTUAL_TIME_STEP).await;
@@ -824,7 +798,7 @@ async fn test_follow_mode_with_bytes_limit_smaller_than_first_live_record_closes
         outputs
             .outputs
             .iter()
-            .all(|output| matches!(output, StoredReadSessionOutput::Heartbeat(_))),
+            .all(|output| matches!(output, ReadSessionOutput::Heartbeat(_))),
         "live oversize record should close the session without yielding a batch"
     );
 }
@@ -856,10 +830,7 @@ async fn test_follow_mode_with_timestamp_until() {
         wait: Some(Duration::from_secs(2)),
     };
 
-    let session = backend
-        .read(basin_name.clone(), stream_name.clone(), start, end)
-        .await
-        .expect("Failed to create read session");
+    let session = open_read_session(&backend, &basin_name, &stream_name, start, end).await;
     let mut session = Box::pin(session);
 
     let backend_clone = backend.clone();

--- a/lite/tests/backend/data_plane/read_follow.rs
+++ b/lite/tests/backend/data_plane/read_follow.rs
@@ -19,20 +19,8 @@ use super::common::*;
 const VIRTUAL_TIME_STEP: Duration = Duration::from_millis(50);
 
 async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &EncryptionSpec) {
-    let (backend, basin_name, stream_name) = match encryption {
-        EncryptionSpec::Plain => {
-            setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await
-        }
-        EncryptionSpec::Aegis256(_) | EncryptionSpec::Aes256Gcm(_) => {
-            setup_backend_with_basin_and_stream(
-                test_suffix,
-                "stream",
-                all_encryption_modes_basin_config(),
-                all_encryption_modes_stream_config(),
-            )
-            .await
-        }
-    };
+    let (backend, basin_name, stream_name) =
+        setup_backend_for_encryption_spec(test_suffix, "stream", encryption).await;
 
     append_payloads_with_encryption(
         &backend,

--- a/lite/tests/backend/data_plane/read_follow.rs
+++ b/lite/tests/backend/data_plane/read_follow.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use rstest::rstest;
 use s2_common::{
-    encryption::EncryptionSpec,
+    encryption::Encryption,
     read_extent::{ReadLimit, ReadUntil},
     record::MeteredSize,
     types::{
@@ -18,14 +18,18 @@ use super::common::*;
 
 const VIRTUAL_TIME_STEP: Duration = Duration::from_millis(50);
 
-async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &EncryptionSpec) {
-    let (backend, basin_name, stream_name) = setup_backend_with_basin_and_stream(
-        test_suffix,
-        "stream",
-        all_encryption_modes_basin_config(),
-        all_encryption_modes_stream_config(),
-    )
-    .await;
+async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &Encryption) {
+    let (backend, basin_name, stream_name) = if matches!(encryption, Encryption::Plain) {
+        setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await
+    } else {
+        setup_backend_with_basin_and_stream(
+            test_suffix,
+            "stream",
+            all_encryption_modes_basin_config(),
+            all_encryption_modes_stream_config(),
+        )
+        .await
+    };
 
     append_payloads_with_encryption(
         &backend,
@@ -460,12 +464,12 @@ async fn test_follow_mode_broadcast_lag_resumes_live_follow_after_catchup() {
 }
 
 #[rstest]
-#[case::plaintext("follow-new-data", EncryptionSpec::Plain)]
+#[case::plaintext("follow-new-data", Encryption::Plain)]
 #[case::encrypted("follow-enc", aegis256_encryption_spec())]
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_follow_mode_receives_new_data(
     #[case] test_suffix: &str,
-    #[case] encryption: EncryptionSpec,
+    #[case] encryption: Encryption,
 ) {
     run_follow_mode_receives_new_data_case(test_suffix, &encryption).await;
 }

--- a/lite/tests/backend/data_plane/read_follow.rs
+++ b/lite/tests/backend/data_plane/read_follow.rs
@@ -19,16 +19,19 @@ use super::common::*;
 const VIRTUAL_TIME_STEP: Duration = Duration::from_millis(50);
 
 async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &EncryptionSpec) {
-    let (backend, basin_name, stream_name) = if encryption.is_plain() {
-        setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await
-    } else {
-        setup_backend_with_basin_and_stream(
-            test_suffix,
-            "stream",
-            all_encryption_modes_basin_config(),
-            all_encryption_modes_stream_config(),
-        )
-        .await
+    let (backend, basin_name, stream_name) = match encryption {
+        EncryptionSpec::Plaintext => {
+            setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await
+        }
+        EncryptionSpec::Aegis256(_) | EncryptionSpec::Aes256Gcm(_) => {
+            setup_backend_with_basin_and_stream(
+                test_suffix,
+                "stream",
+                all_encryption_modes_basin_config(),
+                all_encryption_modes_stream_config(),
+            )
+            .await
+        }
     };
 
     append_payloads_with_encryption(
@@ -464,7 +467,7 @@ async fn test_follow_mode_broadcast_lag_resumes_live_follow_after_catchup() {
 }
 
 #[rstest]
-#[case::plaintext("follow-new-data", EncryptionSpec::plain())]
+#[case::plaintext("follow-new-data", EncryptionSpec::Plaintext)]
 #[case::encrypted("follow-enc", aegis256_encryption_spec())]
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_follow_mode_receives_new_data(

--- a/lite/tests/backend/data_plane/read_follow.rs
+++ b/lite/tests/backend/data_plane/read_follow.rs
@@ -20,7 +20,7 @@ const VIRTUAL_TIME_STEP: Duration = Duration::from_millis(50);
 
 async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &EncryptionSpec) {
     let (backend, basin_name, stream_name) = match encryption {
-        EncryptionSpec::Plaintext => {
+        EncryptionSpec::Plain => {
             setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await
         }
         EncryptionSpec::Aegis256(_) | EncryptionSpec::Aes256Gcm(_) => {
@@ -467,7 +467,7 @@ async fn test_follow_mode_broadcast_lag_resumes_live_follow_after_catchup() {
 }
 
 #[rstest]
-#[case::plaintext("follow-new-data", EncryptionSpec::Plaintext)]
+#[case::plaintext("follow-new-data", EncryptionSpec::Plain)]
 #[case::encrypted("follow-enc", aegis256_encryption_spec())]
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_follow_mode_receives_new_data(

--- a/lite/tests/backend/data_plane/read_follow.rs
+++ b/lite/tests/backend/data_plane/read_follow.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use rstest::rstest;
 use s2_common::{
-    encryption::Encryption,
+    encryption::EncryptionSpec,
     read_extent::{ReadLimit, ReadUntil},
     record::MeteredSize,
     types::{
@@ -18,8 +18,8 @@ use super::common::*;
 
 const VIRTUAL_TIME_STEP: Duration = Duration::from_millis(50);
 
-async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &Encryption) {
-    let (backend, basin_name, stream_name) = if matches!(encryption, Encryption::Plain) {
+async fn run_follow_mode_receives_new_data_case(test_suffix: &str, encryption: &EncryptionSpec) {
+    let (backend, basin_name, stream_name) = if encryption.is_plain() {
         setup_backend_with_stream(test_suffix, "stream", OptionalStreamConfig::default()).await
     } else {
         setup_backend_with_basin_and_stream(
@@ -464,12 +464,12 @@ async fn test_follow_mode_broadcast_lag_resumes_live_follow_after_catchup() {
 }
 
 #[rstest]
-#[case::plaintext("follow-new-data", Encryption::Plain)]
+#[case::plaintext("follow-new-data", EncryptionSpec::plain())]
 #[case::encrypted("follow-enc", aegis256_encryption_spec())]
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_follow_mode_receives_new_data(
     #[case] test_suffix: &str,
-    #[case] encryption: Encryption,
+    #[case] encryption: EncryptionSpec,
 ) {
     run_follow_mode_receives_new_data_case(test_suffix, &encryption).await;
 }

--- a/sdk/src/api.rs
+++ b/sdk/src/api.rs
@@ -28,7 +28,7 @@ use s2_api::v1::{
         s2s::{self, FrameDecoder, SessionMessage, TerminalMessage},
     },
 };
-use s2_common::encryption::S2_ENCRYPTION_HEADER;
+use s2_common::encryption::S2_ENCRYPTION_KEY_HEADER;
 use secrecy::ExposeSecret;
 use tokio_util::codec::Decoder;
 use tracing::{debug, warn};
@@ -39,7 +39,7 @@ use crate::{
     frame_signal::FrameSignal,
     retry::{RetryBackoff, RetryBackoffBuilder},
     types::{
-        AccessTokenId, AppendRetryPolicy, BasinAuthority, BasinName, Compression, EncryptionSpec,
+        AccessTokenId, AppendRetryPolicy, BasinAuthority, BasinName, Compression, EncryptionKey,
         RetryConfig, S2Config, S2Endpoints, StreamName,
     },
 };
@@ -346,7 +346,7 @@ impl BasinClient {
         &self,
         name: &StreamName,
         input: AppendInput,
-        encryption: Option<&EncryptionSpec>,
+        encryption: Option<&EncryptionKey>,
         append_retry_policy: AppendRetryPolicy,
     ) -> Result<AppendAck, ApiError> {
         let url = self
@@ -384,7 +384,7 @@ impl BasinClient {
         name: &StreamName,
         start: ReadStart,
         end: ReadEnd,
-        encryption: Option<&EncryptionSpec>,
+        encryption: Option<&EncryptionKey>,
     ) -> Result<ReadBatch, ApiError> {
         let url = self
             .base_url
@@ -412,7 +412,7 @@ impl BasinClient {
         &self,
         name: &StreamName,
         inputs: I,
-        encryption: Option<&EncryptionSpec>,
+        encryption: Option<&EncryptionKey>,
         frame_signal: Option<FrameSignal>,
     ) -> Result<Streaming<AppendAck>, ApiError>
     where
@@ -486,7 +486,7 @@ impl BasinClient {
         name: &StreamName,
         start: ReadStart,
         end: ReadEnd,
-        encryption: Option<&EncryptionSpec>,
+        encryption: Option<&EncryptionKey>,
     ) -> Result<Streaming<ReadBatch>, ApiError> {
         let url = self
             .base_url
@@ -919,11 +919,11 @@ impl BaseClient {
     }
 }
 
-fn set_encryption_header(request: &mut client::Request, encryption: Option<&EncryptionSpec>) {
+fn set_encryption_header(request: &mut client::Request, encryption: Option<&EncryptionKey>) {
     if let Some(encryption) = encryption {
         request
             .headers_mut()
-            .insert(S2_ENCRYPTION_HEADER.clone(), encryption.to_header_value());
+            .insert(S2_ENCRYPTION_KEY_HEADER.clone(), encryption.to_header_value());
     }
 }
 

--- a/sdk/src/api.rs
+++ b/sdk/src/api.rs
@@ -921,9 +921,10 @@ impl BaseClient {
 
 fn set_encryption_header(request: &mut client::Request, encryption: Option<&EncryptionKey>) {
     if let Some(encryption) = encryption {
-        request
-            .headers_mut()
-            .insert(S2_ENCRYPTION_KEY_HEADER.clone(), encryption.to_header_value());
+        request.headers_mut().insert(
+            S2_ENCRYPTION_KEY_HEADER.clone(),
+            encryption.to_header_value(),
+        );
     }
 }
 

--- a/sdk/src/ops.rs
+++ b/sdk/src/ops.rs
@@ -12,7 +12,7 @@ use crate::{
     session::{self, AppendSession, AppendSessionConfig},
     types::{
         AccessTokenId, AccessTokenInfo, AppendAck, AppendInput, BasinConfig, BasinInfo, BasinName,
-        CreateBasinInput, CreateStreamInput, DeleteBasinInput, DeleteStreamInput, EncryptionSpec,
+        CreateBasinInput, CreateStreamInput, DeleteBasinInput, DeleteStreamInput, EncryptionKey,
         GetAccountMetricsInput, GetBasinMetricsInput, GetStreamMetricsInput, IssueAccessTokenInput,
         ListAccessTokensInput, ListAllAccessTokensInput, ListAllBasinsInput, ListAllStreamsInput,
         ListBasinsInput, ListStreamsInput, Metric, Page, ReadBatch, ReadInput,
@@ -386,12 +386,12 @@ impl S2Basin {
 pub struct S2Stream {
     client: BasinClient,
     name: StreamName,
-    encryption: Option<EncryptionSpec>,
+    encryption: Option<EncryptionKey>,
 }
 
 impl S2Stream {
-    /// Set the encryption spec for this stream handle.
-    pub fn with_encryption(self, encryption: EncryptionSpec) -> Self {
+    /// Set the encryption key for this stream handle.
+    pub fn with_encryption_key(self, encryption: EncryptionKey) -> Self {
         Self {
             encryption: Some(encryption),
             ..self

--- a/sdk/src/producer.rs
+++ b/sdk/src/producer.rs
@@ -21,7 +21,7 @@ use crate::{
     batching::{AppendInputs, AppendRecordBatches, BatchingConfig},
     session::{AppendPermit, AppendPermits, AppendSessionInternal, BatchSubmitTicket},
     types::{
-        AppendAck, AppendRecord, EncryptionSpec, FencingToken, MeteredBytes, ONE_MIB, S2Error,
+        AppendAck, AppendRecord, EncryptionKey, FencingToken, MeteredBytes, ONE_MIB, S2Error,
         StreamName, ValidationError,
     },
 };
@@ -144,7 +144,7 @@ impl Producer {
     pub(crate) fn new(
         client: BasinClient,
         stream: StreamName,
-        encryption: Option<EncryptionSpec>,
+        encryption: Option<EncryptionKey>,
         config: ProducerConfig,
     ) -> Self {
         let (cmd_tx, cmd_rx) = mpsc::channel::<Command>(RECORD_BATCH_MAX.count);

--- a/sdk/src/session/append.rs
+++ b/sdk/src/session/append.rs
@@ -23,7 +23,7 @@ use crate::{
     frame_signal::FrameSignal,
     retry::RetryBackoffBuilder,
     types::{
-        AppendAck, AppendInput, AppendRetryPolicy, EncryptionSpec, MeteredBytes, ONE_MIB, S2Error,
+        AppendAck, AppendInput, AppendRetryPolicy, EncryptionKey, MeteredBytes, ONE_MIB, S2Error,
         StreamName, StreamPosition, ValidationError,
     },
 };
@@ -171,7 +171,7 @@ impl AppendSession {
     pub(crate) fn new(
         client: BasinClient,
         stream: StreamName,
-        encryption: Option<EncryptionSpec>,
+        encryption: Option<EncryptionKey>,
         config: AppendSessionConfig,
     ) -> Self {
         let buffer_size = config
@@ -296,7 +296,7 @@ impl AppendSessionInternal {
     pub(crate) fn new(
         client: BasinClient,
         stream: StreamName,
-        encryption: Option<EncryptionSpec>,
+        encryption: Option<EncryptionKey>,
     ) -> Self {
         let buffer_size = DEFAULT_CHANNEL_BUFFER_SIZE;
         let (cmd_tx, cmd_rx) = mpsc::channel(buffer_size);
@@ -410,7 +410,7 @@ impl AppendPermits {
 async fn run_session_with_retry(
     client: BasinClient,
     stream: StreamName,
-    encryption: Option<EncryptionSpec>,
+    encryption: Option<EncryptionKey>,
     cmd_rx: mpsc::Receiver<Command>,
     retry_builder: RetryBackoffBuilder,
     buffer_size: usize,
@@ -510,7 +510,7 @@ async fn run_session_with_retry(
 async fn run_session(
     client: &BasinClient,
     stream: &StreamName,
-    encryption: Option<&EncryptionSpec>,
+    encryption: Option<&EncryptionKey>,
     state: &mut SessionState,
     buffer_size: usize,
     frame_signal: &Option<FrameSignal>,
@@ -719,7 +719,7 @@ async fn resend(
 async fn connect(
     client: &BasinClient,
     stream: &StreamName,
-    encryption: Option<&EncryptionSpec>,
+    encryption: Option<&EncryptionKey>,
     buffer_size: usize,
     frame_signal: Option<FrameSignal>,
 ) -> Result<(mpsc::Sender<AppendInput>, Streaming<AppendAck>), AppendSessionError> {

--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 use crate::{
     api::{ApiError, BasinClient, retry_builder},
     retry::RetryBackoff,
-    types::{EncryptionSpec, MeteredBytes, ReadBatch, S2Error, StreamName},
+    types::{EncryptionKey, MeteredBytes, ReadBatch, S2Error, StreamName},
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -43,7 +43,7 @@ pub type Streaming<R> = Pin<Box<dyn Send + futures::Stream<Item = Result<R, Read
 pub async fn read_session(
     client: BasinClient,
     name: StreamName,
-    encryption: Option<EncryptionSpec>,
+    encryption: Option<EncryptionKey>,
     mut start: ReadStart,
     mut end: ReadEnd,
     ignore_command_records: bool,
@@ -157,7 +157,7 @@ pub async fn read_session(
 async fn session_inner(
     client: BasinClient,
     name: StreamName,
-    encryption: Option<EncryptionSpec>,
+    encryption: Option<EncryptionKey>,
     start: ReadStart,
     end: ReadEnd,
 ) -> Result<Streaming<ReadBatch>, ReadSessionError> {

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -2625,7 +2625,7 @@ pub struct StreamInfo {
     /// Deletion time if the stream is being deleted.
     pub deleted_at: Option<S2DateTime>,
     /// Encryption algorithm for this stream, if encryption is enabled.
-    pub encryption_algorithm: Option<EncryptionAlgorithm>,
+    pub cipher: Option<EncryptionAlgorithm>,
 }
 
 impl TryFrom<api::stream::StreamInfo> for StreamInfo {
@@ -2636,7 +2636,7 @@ impl TryFrom<api::stream::StreamInfo> for StreamInfo {
             name: value.name,
             created_at: value.created_at.try_into()?,
             deleted_at: value.deleted_at.map(S2DateTime::try_from).transpose()?,
-            encryption_algorithm: value.encryption_algorithm.map(Into::into),
+            cipher: value.cipher.map(Into::into),
         })
     }
 }

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -781,7 +781,7 @@ pub struct BasinConfig {
     /// See [`StreamConfig`] for defaults.
     pub default_stream_config: Option<StreamConfig>,
     /// Encryption algorithm to apply to newly created streams in the basin.
-    pub stream_encryption_algorithm: Option<EncryptionAlgorithm>,
+    pub stream_cipher: Option<EncryptionAlgorithm>,
     /// Whether to create stream on append if it doesn't exist using default stream configuration.
     ///
     /// Defaults to `false`.
@@ -807,12 +807,9 @@ impl BasinConfig {
     }
 
     /// Set the encryption algorithm to apply to newly created streams in the basin.
-    pub fn with_stream_encryption_algorithm(
-        self,
-        stream_encryption_algorithm: EncryptionAlgorithm,
-    ) -> Self {
+    pub fn with_stream_cipher(self, stream_cipher: EncryptionAlgorithm) -> Self {
         Self {
-            stream_encryption_algorithm: Some(stream_encryption_algorithm),
+            stream_cipher: Some(stream_cipher),
             ..self
         }
     }
@@ -839,7 +836,7 @@ impl From<api::config::BasinConfig> for BasinConfig {
     fn from(value: api::config::BasinConfig) -> Self {
         Self {
             default_stream_config: value.default_stream_config.map(Into::into),
-            stream_encryption_algorithm: value.stream_encryption_algorithm.map(Into::into),
+            stream_cipher: value.stream_cipher.map(Into::into),
             create_stream_on_append: value.create_stream_on_append,
             create_stream_on_read: value.create_stream_on_read,
         }
@@ -850,7 +847,7 @@ impl From<BasinConfig> for api::config::BasinConfig {
     fn from(value: BasinConfig) -> Self {
         Self {
             default_stream_config: value.default_stream_config.map(Into::into),
-            stream_encryption_algorithm: value.stream_encryption_algorithm.map(Into::into),
+            stream_cipher: value.stream_cipher.map(Into::into),
             create_stream_on_append: value.create_stream_on_append,
             create_stream_on_read: value.create_stream_on_read,
         }
@@ -1337,9 +1334,8 @@ impl From<StreamReconfiguration> for api::config::StreamReconfiguration {
 pub struct BasinReconfiguration {
     /// Override for the existing [`default_stream_config`](BasinConfig::default_stream_config).
     pub default_stream_config: Maybe<Option<StreamReconfiguration>>,
-    /// Override for the existing
-    /// [`stream_encryption_algorithm`](BasinConfig::stream_encryption_algorithm).
-    pub stream_encryption_algorithm: Maybe<Option<EncryptionAlgorithm>>,
+    /// Override for the existing [`stream_cipher`](BasinConfig::stream_cipher).
+    pub stream_cipher: Maybe<Option<EncryptionAlgorithm>>,
     /// Override for the existing
     /// [`create_stream_on_append`](BasinConfig::create_stream_on_append).
     pub create_stream_on_append: Maybe<bool>,
@@ -1362,14 +1358,10 @@ impl BasinReconfiguration {
         }
     }
 
-    /// Set the override for the existing
-    /// [`stream_encryption_algorithm`](BasinConfig::stream_encryption_algorithm).
-    pub fn with_stream_encryption_algorithm(
-        self,
-        stream_encryption_algorithm: EncryptionAlgorithm,
-    ) -> Self {
+    /// Set the override for the existing [`stream_cipher`](BasinConfig::stream_cipher).
+    pub fn with_stream_cipher(self, stream_cipher: EncryptionAlgorithm) -> Self {
         Self {
-            stream_encryption_algorithm: Maybe::Specified(Some(stream_encryption_algorithm)),
+            stream_cipher: Maybe::Specified(Some(stream_cipher)),
             ..self
         }
     }
@@ -1397,9 +1389,7 @@ impl From<BasinReconfiguration> for api::config::BasinReconfiguration {
     fn from(value: BasinReconfiguration) -> Self {
         Self {
             default_stream_config: value.default_stream_config.map(|m| m.map(Into::into)),
-            stream_encryption_algorithm: value
-                .stream_encryption_algorithm
-                .map(|m| m.map(Into::into)),
+            stream_cipher: value.stream_cipher.map(|m| m.map(Into::into)),
             create_stream_on_append: value.create_stream_on_append,
             create_stream_on_read: value.create_stream_on_read,
         }

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -780,7 +780,7 @@ pub struct BasinConfig {
     ///
     /// See [`StreamConfig`] for defaults.
     pub default_stream_config: Option<StreamConfig>,
-    /// Cipher to apply to newly created streams in the basin.
+    /// Encryption algorithm to apply to newly created streams in the basin.
     pub stream_cipher: Option<EncryptionAlgorithm>,
     /// Whether to create stream on append if it doesn't exist using default stream configuration.
     ///
@@ -806,7 +806,7 @@ impl BasinConfig {
         }
     }
 
-    /// Set the cipher to apply to newly created streams in the basin.
+    /// Set the encryption algorithm to apply to newly created streams in the basin.
     pub fn with_stream_cipher(self, stream_cipher: EncryptionAlgorithm) -> Self {
         Self {
             stream_cipher: Some(stream_cipher),
@@ -2624,7 +2624,7 @@ pub struct StreamInfo {
     pub created_at: S2DateTime,
     /// Deletion time if the stream is being deleted.
     pub deleted_at: Option<S2DateTime>,
-    /// Cipher for this stream, if encryption is enabled.
+    /// Encryption algorithm for this stream, if encryption is enabled.
     pub cipher: Option<EncryptionAlgorithm>,
 }
 

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -21,10 +21,10 @@ use s2_api::{v1 as api, v1::stream::s2s::CompressionAlgorithm};
 pub use s2_common::caps::RECORD_BATCH_MAX;
 /// Encryption algorithm.
 pub use s2_common::encryption::EncryptionAlgorithm;
+/// Encryption key for stream operations.
+pub use s2_common::encryption::EncryptionKey;
 /// Encryption mode, including plaintext.
 pub use s2_common::encryption::EncryptionMode;
-/// Encryption spec for stream operations.
-pub use s2_common::encryption::EncryptionSpec;
 /// Validation error.
 pub use s2_common::types::ValidationError;
 /// Access token ID.
@@ -691,44 +691,6 @@ impl From<DeleteOnEmptyConfig> for api::config::DeleteOnEmptyConfig {
     }
 }
 
-/// Encryption configuration for a stream.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct EncryptionConfig {
-    /// Allowed encryption modes for the stream.
-    ///
-    /// If empty, use defaults. If no default is configured, only plaintext is allowed.
-    pub allowed_modes: Vec<EncryptionMode>,
-}
-
-impl EncryptionConfig {
-    /// Create a new [`EncryptionConfig`] with default settings.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Set the allowed encryption modes.
-    pub fn with_allowed_modes(self, allowed_modes: Vec<EncryptionMode>) -> Self {
-        Self { allowed_modes }
-    }
-}
-
-impl From<api::config::EncryptionConfig> for EncryptionConfig {
-    fn from(value: api::config::EncryptionConfig) -> Self {
-        Self {
-            allowed_modes: value.allowed_modes.into_iter().map(Into::into).collect(),
-        }
-    }
-}
-
-impl From<EncryptionConfig> for api::config::EncryptionConfig {
-    fn from(value: EncryptionConfig) -> Self {
-        Self {
-            allowed_modes: value.allowed_modes.into_iter().map(Into::into).collect(),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[non_exhaustive]
 /// Configuration for a stream.
@@ -749,10 +711,6 @@ pub struct StreamConfig {
     ///
     /// See [`DeleteOnEmptyConfig`] for defaults.
     pub delete_on_empty: Option<DeleteOnEmptyConfig>,
-    /// Encryption configuration.
-    ///
-    /// See [`EncryptionConfig`] for defaults.
-    pub encryption: Option<EncryptionConfig>,
 }
 
 impl StreamConfig {
@@ -792,14 +750,6 @@ impl StreamConfig {
             ..self
         }
     }
-
-    /// Set the encryption configuration.
-    pub fn with_encryption(self, encryption: EncryptionConfig) -> Self {
-        Self {
-            encryption: Some(encryption),
-            ..self
-        }
-    }
 }
 
 impl From<api::config::StreamConfig> for StreamConfig {
@@ -809,7 +759,6 @@ impl From<api::config::StreamConfig> for StreamConfig {
             retention_policy: value.retention_policy.map(Into::into),
             timestamping: value.timestamping.map(Into::into),
             delete_on_empty: value.delete_on_empty.map(Into::into),
-            encryption: value.encryption.map(Into::into),
         }
     }
 }
@@ -821,7 +770,6 @@ impl From<StreamConfig> for api::config::StreamConfig {
             retention_policy: value.retention_policy.map(Into::into),
             timestamping: value.timestamping.map(Into::into),
             delete_on_empty: value.delete_on_empty.map(Into::into),
-            encryption: value.encryption.map(Into::into),
         }
     }
 }
@@ -834,6 +782,8 @@ pub struct BasinConfig {
     ///
     /// See [`StreamConfig`] for defaults.
     pub default_stream_config: Option<StreamConfig>,
+    /// Encryption algorithm materialized into streams created in the basin.
+    pub stream_encryption_algorithm: Option<EncryptionAlgorithm>,
     /// Whether to create stream on append if it doesn't exist using default stream configuration.
     ///
     /// Defaults to `false`.
@@ -854,6 +804,17 @@ impl BasinConfig {
     pub fn with_default_stream_config(self, config: StreamConfig) -> Self {
         Self {
             default_stream_config: Some(config),
+            ..self
+        }
+    }
+
+    /// Set the encryption algorithm materialized into streams created in the basin.
+    pub fn with_stream_encryption_algorithm(
+        self,
+        stream_encryption_algorithm: EncryptionAlgorithm,
+    ) -> Self {
+        Self {
+            stream_encryption_algorithm: Some(stream_encryption_algorithm),
             ..self
         }
     }
@@ -880,6 +841,7 @@ impl From<api::config::BasinConfig> for BasinConfig {
     fn from(value: api::config::BasinConfig) -> Self {
         Self {
             default_stream_config: value.default_stream_config.map(Into::into),
+            stream_encryption_algorithm: value.stream_encryption_algorithm.map(Into::into),
             create_stream_on_append: value.create_stream_on_append,
             create_stream_on_read: value.create_stream_on_read,
         }
@@ -890,6 +852,7 @@ impl From<BasinConfig> for api::config::BasinConfig {
     fn from(value: BasinConfig) -> Self {
         Self {
             default_stream_config: value.default_stream_config.map(Into::into),
+            stream_encryption_algorithm: value.stream_encryption_algorithm.map(Into::into),
             create_stream_on_append: value.create_stream_on_append,
             create_stream_on_read: value.create_stream_on_read,
         }
@@ -1306,40 +1269,6 @@ impl From<DeleteOnEmptyReconfiguration> for api::config::DeleteOnEmptyReconfigur
     }
 }
 
-/// Encryption reconfiguration for a stream.
-#[derive(Debug, Clone, Default)]
-#[non_exhaustive]
-pub struct EncryptionReconfiguration {
-    /// Override for the existing [`allowed_modes`](EncryptionConfig::allowed_modes).
-    ///
-    /// Specify an empty list to reset to defaults.
-    pub allowed_modes: Maybe<Vec<EncryptionMode>>,
-}
-
-impl EncryptionReconfiguration {
-    /// Create a new [`EncryptionReconfiguration`] with default settings.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Set the allowed encryption modes.
-    pub fn with_allowed_modes(self, allowed_modes: Vec<EncryptionMode>) -> Self {
-        Self {
-            allowed_modes: Maybe::Specified(allowed_modes),
-        }
-    }
-}
-
-impl From<EncryptionReconfiguration> for api::config::EncryptionReconfiguration {
-    fn from(value: EncryptionReconfiguration) -> Self {
-        Self {
-            allowed_modes: value
-                .allowed_modes
-                .map(|modes| modes.into_iter().map(Into::into).collect()),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 /// Reconfiguration for [`StreamConfig`].
@@ -1352,8 +1281,6 @@ pub struct StreamReconfiguration {
     pub timestamping: Maybe<Option<TimestampingReconfiguration>>,
     /// Override for the existing [`delete_on_empty`](StreamConfig::delete_on_empty).
     pub delete_on_empty: Maybe<Option<DeleteOnEmptyReconfiguration>>,
-    /// Override for the existing [`encryption`](StreamConfig::encryption).
-    pub encryption: Maybe<Option<EncryptionReconfiguration>>,
 }
 
 impl StreamReconfiguration {
@@ -1393,14 +1320,6 @@ impl StreamReconfiguration {
             ..self
         }
     }
-
-    /// Set the encryption reconfiguration.
-    pub fn with_encryption(self, encryption: EncryptionReconfiguration) -> Self {
-        Self {
-            encryption: Maybe::Specified(Some(encryption)),
-            ..self
-        }
-    }
 }
 
 impl From<StreamReconfiguration> for api::config::StreamReconfiguration {
@@ -1410,7 +1329,6 @@ impl From<StreamReconfiguration> for api::config::StreamReconfiguration {
             retention_policy: value.retention_policy.map(|m| m.map(Into::into)),
             timestamping: value.timestamping.map(|m| m.map(Into::into)),
             delete_on_empty: value.delete_on_empty.map(|m| m.map(Into::into)),
-            encryption: value.encryption.map(|m| m.map(Into::into)),
         }
     }
 }
@@ -1421,6 +1339,9 @@ impl From<StreamReconfiguration> for api::config::StreamReconfiguration {
 pub struct BasinReconfiguration {
     /// Override for the existing [`default_stream_config`](BasinConfig::default_stream_config).
     pub default_stream_config: Maybe<Option<StreamReconfiguration>>,
+    /// Override for the existing
+    /// [`stream_encryption_algorithm`](BasinConfig::stream_encryption_algorithm).
+    pub stream_encryption_algorithm: Maybe<Option<EncryptionAlgorithm>>,
     /// Override for the existing
     /// [`create_stream_on_append`](BasinConfig::create_stream_on_append).
     pub create_stream_on_append: Maybe<bool>,
@@ -1439,6 +1360,18 @@ impl BasinReconfiguration {
     pub fn with_default_stream_config(self, config: StreamReconfiguration) -> Self {
         Self {
             default_stream_config: Maybe::Specified(Some(config)),
+            ..self
+        }
+    }
+
+    /// Set the override for the existing
+    /// [`stream_encryption_algorithm`](BasinConfig::stream_encryption_algorithm).
+    pub fn with_stream_encryption_algorithm(
+        self,
+        stream_encryption_algorithm: EncryptionAlgorithm,
+    ) -> Self {
+        Self {
+            stream_encryption_algorithm: Maybe::Specified(Some(stream_encryption_algorithm)),
             ..self
         }
     }
@@ -1466,6 +1399,9 @@ impl From<BasinReconfiguration> for api::config::BasinReconfiguration {
     fn from(value: BasinReconfiguration) -> Self {
         Self {
             default_stream_config: value.default_stream_config.map(|m| m.map(Into::into)),
+            stream_encryption_algorithm: value
+                .stream_encryption_algorithm
+                .map(|m| m.map(Into::into)),
             create_stream_on_append: value.create_stream_on_append,
             create_stream_on_read: value.create_stream_on_read,
         }
@@ -2700,6 +2636,8 @@ pub struct StreamInfo {
     pub created_at: S2DateTime,
     /// Deletion time if the stream is being deleted.
     pub deleted_at: Option<S2DateTime>,
+    /// Encryption algorithm materialized at stream creation time, if encryption is enabled.
+    pub encryption_algorithm: Option<EncryptionAlgorithm>,
 }
 
 impl TryFrom<api::stream::StreamInfo> for StreamInfo {
@@ -2710,6 +2648,7 @@ impl TryFrom<api::stream::StreamInfo> for StreamInfo {
             name: value.name,
             created_at: value.created_at.try_into()?,
             deleted_at: value.deleted_at.map(S2DateTime::try_from).transpose()?,
+            encryption_algorithm: value.encryption_algorithm.map(Into::into),
         })
     }
 }

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -780,7 +780,7 @@ pub struct BasinConfig {
     ///
     /// See [`StreamConfig`] for defaults.
     pub default_stream_config: Option<StreamConfig>,
-    /// Encryption algorithm to apply to newly created streams in the basin.
+    /// Cipher to apply to newly created streams in the basin.
     pub stream_cipher: Option<EncryptionAlgorithm>,
     /// Whether to create stream on append if it doesn't exist using default stream configuration.
     ///
@@ -806,7 +806,7 @@ impl BasinConfig {
         }
     }
 
-    /// Set the encryption algorithm to apply to newly created streams in the basin.
+    /// Set the cipher to apply to newly created streams in the basin.
     pub fn with_stream_cipher(self, stream_cipher: EncryptionAlgorithm) -> Self {
         Self {
             stream_cipher: Some(stream_cipher),
@@ -2624,7 +2624,7 @@ pub struct StreamInfo {
     pub created_at: S2DateTime,
     /// Deletion time if the stream is being deleted.
     pub deleted_at: Option<S2DateTime>,
-    /// Encryption algorithm for this stream, if encryption is enabled.
+    /// Cipher for this stream, if encryption is enabled.
     pub cipher: Option<EncryptionAlgorithm>,
 }
 

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -23,8 +23,6 @@ pub use s2_common::caps::RECORD_BATCH_MAX;
 pub use s2_common::encryption::EncryptionAlgorithm;
 /// Encryption key for stream operations.
 pub use s2_common::encryption::EncryptionKey;
-/// Encryption mode, including plaintext.
-pub use s2_common::encryption::EncryptionMode;
 /// Validation error.
 pub use s2_common::types::ValidationError;
 /// Access token ID.

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -780,7 +780,7 @@ pub struct BasinConfig {
     ///
     /// See [`StreamConfig`] for defaults.
     pub default_stream_config: Option<StreamConfig>,
-    /// Encryption algorithm materialized into streams created in the basin.
+    /// Encryption algorithm to apply to newly created streams in the basin.
     pub stream_encryption_algorithm: Option<EncryptionAlgorithm>,
     /// Whether to create stream on append if it doesn't exist using default stream configuration.
     ///
@@ -806,7 +806,7 @@ impl BasinConfig {
         }
     }
 
-    /// Set the encryption algorithm materialized into streams created in the basin.
+    /// Set the encryption algorithm to apply to newly created streams in the basin.
     pub fn with_stream_encryption_algorithm(
         self,
         stream_encryption_algorithm: EncryptionAlgorithm,
@@ -2634,7 +2634,7 @@ pub struct StreamInfo {
     pub created_at: S2DateTime,
     /// Deletion time if the stream is being deleted.
     pub deleted_at: Option<S2DateTime>,
-    /// Encryption algorithm materialized at stream creation time, if encryption is enabled.
+    /// Encryption algorithm for this stream, if encryption is enabled.
     pub encryption_algorithm: Option<EncryptionAlgorithm>,
 }
 


### PR DESCRIPTION
Replace per-request encryption modes with basin `stream_cipher`, immutable stream `cipher` metadata, and key-only request handling.

- move stream encryption selection to basin config and persist the resolved cipher in stream metadata
- replace `s2-encryption` / `EncryptionSpec` request handling with `s2-encryption-key`
- remove stream-level encryption config and reconfiguration surfaces from API, SDK, CLI, and init schema
- expose stream cipher in stream listings and `StreamInfo`
- update lite read/append flows and tests to the new CSEK model

Known gap:
- existing encrypted streams do not yet have a compatibility or migration path from legacy `config.encryption` metadata to the new top-level `cipher` field

Testing:
- just test -p s2-common -p s2-api -p s2-lite -p s2-sdk -p s2-cli
- cargo test -p s2-lite --lib rejected_before_stream_starts

BREAKING CHANGE: replace stream-level allowed encryption modes and the `s2-encryption` header with basin `stream_cipher` metadata and the `s2-encryption-key` header.
