### PR TITLE
build: abort on panic in workspace profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,5 +80,9 @@ zstd = "0.13"
 [patch.crates-io]
 utoipa = { git = "https://github.com/infiniteregrets/utoipa", rev = "9cd181d40ac0a50551ebe1995a4d73e8685890d6" }
 
+[profile.dev]
+panic = "abort"
+
 [profile.release]
+panic = "abort"
 lto = true


### PR DESCRIPTION
## Summary
- set `panic = "abort"` in the workspace `dev` and `release` profiles
- make the panic strategy apply consistently to all workspace binary targets via the root manifest

## Verification
- `cargo rustc -p s2-cli --bin s2 -- --print=cfg | rg ^panic=
- `cargo rustc -p s2-lite --bin server -- --print=cfg | rg ^panic=
- `cargo rustc -p s2-lite --bin openapi --features utoipa -- --print=cfg | rg ^panic=
- `cargo rustc -p s2-cli --bin s2 --release -- --print=cfg | rg ^panic=
- `just test -p s2-lite`