### PR TITLE
fix(lite): cap random-nonce encrypted stream messages

### DIFF
--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -33,7 +33,7 @@ use aes_gcm::{Aes256Gcm, KeyInit, aead::AeadInPlace};
 use bytes::{BufMut, Bytes, BytesMut};
 use rand::random;
 
-use super::{Encodable, Metered, MeteredSize, Record, RecordDecodeError, StoredRecord};
+use super::{Encodable, Metered, MeteredSize, Record, RecordDecodeError, SeqNum, StoredRecord};
 use crate::{
     deep_size::DeepSize,
     encryption::{EncryptionAlgorithm, EncryptionSpec},
@@ -97,6 +97,13 @@ impl EncryptedRecordFormat {
             Self::Aes256GcmV1 => buf.put_slice(&random::<[u8; 12]>()),
         }
     }
+
+    const fn stream_message_limit(self) -> Option<SeqNum> {
+        match self {
+            Self::Aegis256V1 => None,
+            Self::Aes256GcmV1 => Some(1u64 << 32),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -132,6 +139,10 @@ impl EncryptedRecord {
 
     pub fn algorithm(&self) -> EncryptionAlgorithm {
         self.format.algorithm()
+    }
+
+    pub fn stream_message_limit(&self) -> Option<SeqNum> {
+        self.format.stream_message_limit()
     }
 
     pub(crate) fn nonce(&self) -> &[u8] {

--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -98,7 +98,7 @@ impl EncryptedRecordFormat {
         }
     }
 
-    const fn stream_message_limit(self) -> Option<SeqNum> {
+    const fn stream_encrypted_record_limit(self) -> Option<SeqNum> {
         match self {
             Self::Aegis256V1 => None,
             Self::Aes256GcmV1 => Some(1u64 << 32),
@@ -141,8 +141,8 @@ impl EncryptedRecord {
         self.format.algorithm()
     }
 
-    pub fn stream_message_limit(&self) -> Option<SeqNum> {
-        self.format.stream_message_limit()
+    pub fn stream_encrypted_record_limit(&self) -> Option<SeqNum> {
+        self.format.stream_encrypted_record_limit()
     }
 
     pub(crate) fn nonce(&self) -> &[u8] {

--- a/common/src/record/mod.rs
+++ b/common/src/record/mod.rs
@@ -247,6 +247,13 @@ impl StoredRecord {
             Self::Encrypted { record, .. } => Some(record.algorithm()),
         }
     }
+
+    pub fn stream_message_limit(&self) -> Option<SeqNum> {
+        match self {
+            Self::Plaintext(_) => None,
+            Self::Encrypted { record, .. } => record.stream_message_limit(),
+        }
+    }
 }
 
 impl DeepSize for StoredRecord {

--- a/common/src/record/mod.rs
+++ b/common/src/record/mod.rs
@@ -248,10 +248,10 @@ impl StoredRecord {
         }
     }
 
-    pub fn stream_message_limit(&self) -> Option<SeqNum> {
+    pub fn stream_encrypted_record_limit(&self) -> Option<SeqNum> {
         match self {
             Self::Plaintext(_) => None,
-            Self::Encrypted { record, .. } => record.stream_message_limit(),
+            Self::Encrypted { record, .. } => record.stream_encrypted_record_limit(),
         }
     }
 }

--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -79,7 +79,7 @@ pub struct AppendTimestampRequiredError;
 
 #[derive(Debug, Clone, thiserror::Error)]
 #[error(
-    "stream encrypted message limit exceeded: records must use sequence numbers below {limit}; attempted {assigned_seq_num}"
+    "stream encrypted message limit exceeded: records must be assigned sequence numbers below {limit}; attempted {assigned_seq_num}"
 )]
 pub struct EncryptedMessageLimitExceededError {
     pub assigned_seq_num: SeqNum,

--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -79,9 +79,9 @@ pub struct AppendTimestampRequiredError;
 
 #[derive(Debug, Clone, thiserror::Error)]
 #[error(
-    "stream encrypted message limit exceeded: records must be assigned sequence numbers below {limit}; attempted {assigned_seq_num}"
+    "stream encrypted record limit exceeded: records must be assigned sequence numbers below {limit}; attempted {assigned_seq_num}"
 )]
-pub struct EncryptedMessageLimitExceededError {
+pub struct StreamEncryptedRecordLimitExceededError {
     pub assigned_seq_num: SeqNum,
     pub limit: SeqNum,
 }
@@ -113,7 +113,7 @@ pub(super) enum AppendErrorInternal {
     #[error(transparent)]
     TimestampMissing(#[from] AppendTimestampRequiredError),
     #[error(transparent)]
-    EncryptedMessageLimitExceeded(#[from] EncryptedMessageLimitExceededError),
+    StreamEncryptedRecordLimitExceeded(#[from] StreamEncryptedRecordLimitExceededError),
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -169,7 +169,7 @@ pub enum AppendError {
     #[error(transparent)]
     TimestampMissing(#[from] AppendTimestampRequiredError),
     #[error(transparent)]
-    StreamMessageLimitExceeded(#[from] EncryptedMessageLimitExceededError),
+    StreamEncryptedRecordLimitExceeded(#[from] StreamEncryptedRecordLimitExceededError),
 }
 
 impl From<AppendErrorInternal> for AppendError {
@@ -182,8 +182,8 @@ impl From<AppendErrorInternal> for AppendError {
             AppendErrorInternal::RequestDroppedError(e) => AppendError::RequestDroppedError(e),
             AppendErrorInternal::ConditionFailed(e) => AppendError::ConditionFailed(e),
             AppendErrorInternal::TimestampMissing(e) => AppendError::TimestampMissing(e),
-            AppendErrorInternal::EncryptedMessageLimitExceeded(e) => {
-                AppendError::StreamMessageLimitExceeded(e)
+            AppendErrorInternal::StreamEncryptedRecordLimitExceeded(e) => {
+                AppendError::StreamEncryptedRecordLimitExceeded(e)
             }
         }
     }

--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -79,9 +79,9 @@ pub struct AppendTimestampRequiredError;
 
 #[derive(Debug, Clone, thiserror::Error)]
 #[error(
-    "stream message limit exceeded: records must use sequence numbers below {limit} (max {limit} messages per stream); attempted {assigned_seq_num}"
+    "stream encrypted message limit exceeded: records must use sequence numbers below {limit}; attempted {assigned_seq_num}"
 )]
-pub struct StreamMessageLimitExceededError {
+pub struct EncryptedMessageLimitExceededError {
     pub assigned_seq_num: SeqNum,
     pub limit: SeqNum,
 }
@@ -113,7 +113,7 @@ pub(super) enum AppendErrorInternal {
     #[error(transparent)]
     TimestampMissing(#[from] AppendTimestampRequiredError),
     #[error(transparent)]
-    StreamMessageLimitExceeded(#[from] StreamMessageLimitExceededError),
+    EncryptedMessageLimitExceeded(#[from] EncryptedMessageLimitExceededError),
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -169,7 +169,7 @@ pub enum AppendError {
     #[error(transparent)]
     TimestampMissing(#[from] AppendTimestampRequiredError),
     #[error(transparent)]
-    StreamMessageLimitExceeded(#[from] StreamMessageLimitExceededError),
+    StreamMessageLimitExceeded(#[from] EncryptedMessageLimitExceededError),
 }
 
 impl From<AppendErrorInternal> for AppendError {
@@ -182,7 +182,7 @@ impl From<AppendErrorInternal> for AppendError {
             AppendErrorInternal::RequestDroppedError(e) => AppendError::RequestDroppedError(e),
             AppendErrorInternal::ConditionFailed(e) => AppendError::ConditionFailed(e),
             AppendErrorInternal::TimestampMissing(e) => AppendError::TimestampMissing(e),
-            AppendErrorInternal::StreamMessageLimitExceeded(e) => {
+            AppendErrorInternal::EncryptedMessageLimitExceeded(e) => {
                 AppendError::StreamMessageLimitExceeded(e)
             }
         }

--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -1,7 +1,7 @@
 use std::{ops::RangeTo, sync::Arc};
 
 use s2_common::{
-    encryption::{EncryptionAlgorithm, EncryptionSpecResolutionError},
+    encryption::EncryptionSpecResolutionError,
     record::{FencingToken, RecordDecryptionError, SeqNum, StreamPosition},
     types::{basin::BasinName, stream::StreamName},
 };
@@ -78,10 +78,12 @@ pub struct RequestDroppedError;
 pub struct AppendTimestampRequiredError;
 
 #[derive(Debug, Clone, thiserror::Error)]
-#[error("record encryption algorithm mismatch")]
-pub struct EncryptionAlgorithmMismatchError {
-    pub expected: Option<EncryptionAlgorithm>,
-    pub actual: Option<EncryptionAlgorithm>,
+#[error(
+    "stream message limit exceeded: records must use sequence numbers below {limit} (max {limit} messages per stream); attempted {assigned_seq_num}"
+)]
+pub struct StreamMessageLimitExceededError {
+    pub assigned_seq_num: SeqNum,
+    pub limit: SeqNum,
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -111,7 +113,7 @@ pub(super) enum AppendErrorInternal {
     #[error(transparent)]
     TimestampMissing(#[from] AppendTimestampRequiredError),
     #[error(transparent)]
-    EncryptionAlgorithmMismatch(#[from] EncryptionAlgorithmMismatchError),
+    StreamMessageLimitExceeded(#[from] StreamMessageLimitExceededError),
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -167,7 +169,7 @@ pub enum AppendError {
     #[error(transparent)]
     TimestampMissing(#[from] AppendTimestampRequiredError),
     #[error(transparent)]
-    EncryptionAlgorithmMismatch(#[from] EncryptionAlgorithmMismatchError),
+    StreamMessageLimitExceeded(#[from] StreamMessageLimitExceededError),
 }
 
 impl From<AppendErrorInternal> for AppendError {
@@ -180,8 +182,8 @@ impl From<AppendErrorInternal> for AppendError {
             AppendErrorInternal::RequestDroppedError(e) => AppendError::RequestDroppedError(e),
             AppendErrorInternal::ConditionFailed(e) => AppendError::ConditionFailed(e),
             AppendErrorInternal::TimestampMissing(e) => AppendError::TimestampMissing(e),
-            AppendErrorInternal::EncryptionAlgorithmMismatch(e) => {
-                AppendError::EncryptionAlgorithmMismatch(e)
+            AppendErrorInternal::StreamMessageLimitExceeded(e) => {
+                AppendError::StreamMessageLimitExceeded(e)
             }
         }
     }

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -45,7 +45,7 @@ use crate::{
         durability_notifier::DurabilityNotifier,
         error::{
             AppendConditionFailedError, AppendErrorInternal, AppendTimestampRequiredError,
-            DeleteStreamError, EncryptedMessageLimitExceededError, RequestDroppedError,
+            DeleteStreamError, RequestDroppedError, StreamEncryptedRecordLimitExceededError,
             StreamerMissingInActionError,
         },
         kv,
@@ -732,7 +732,7 @@ impl StreamerClient {
                 }
                 AppendErrorInternal::ConditionFailed(_) => unreachable!("unconditional write"),
                 AppendErrorInternal::TimestampMissing(_) => unreachable!("Timestamp::MAX used"),
-                AppendErrorInternal::EncryptedMessageLimitExceeded(_) => {
+                AppendErrorInternal::StreamEncryptedRecordLimitExceeded(_) => {
                     unreachable!("terminal append is plaintext command record")
                 }
             }),
@@ -828,10 +828,10 @@ fn sequenced_records(
         .enumerate()
     {
         let assigned_seq_num = first_seq_num + i as u64;
-        if let Some(limit) = record.as_ref().into_inner().stream_message_limit()
+        if let Some(limit) = record.as_ref().into_inner().stream_encrypted_record_limit()
             && assigned_seq_num >= limit
         {
-            Err(EncryptedMessageLimitExceededError {
+            Err(StreamEncryptedRecordLimitExceededError {
                 assigned_seq_num,
                 limit,
             })?;
@@ -1190,7 +1190,7 @@ mod tests {
         let limit = first_record
             .parts()
             .record
-            .stream_message_limit()
+            .stream_encrypted_record_limit()
             .expect("aes-256-gcm record has stream message limit");
         let records: StoredAppendRecordBatch = vec![
             first_record,
@@ -1207,8 +1207,8 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(AppendErrorInternal::EncryptedMessageLimitExceeded(
-                EncryptedMessageLimitExceededError {
+            Err(AppendErrorInternal::StreamEncryptedRecordLimitExceeded(
+                StreamEncryptedRecordLimitExceededError {
                     assigned_seq_num: seq_num,
                     limit: err_limit,
                 }
@@ -1227,7 +1227,7 @@ mod tests {
         )
         .parts()
         .record
-        .stream_message_limit()
+        .stream_encrypted_record_limit()
         .expect("aes-256-gcm record has stream message limit");
 
         let records: StoredAppendRecordBatch =

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -45,7 +45,7 @@ use crate::{
         durability_notifier::DurabilityNotifier,
         error::{
             AppendConditionFailedError, AppendErrorInternal, AppendTimestampRequiredError,
-            DeleteStreamError, RequestDroppedError, StreamMessageLimitExceededError,
+            DeleteStreamError, EncryptedMessageLimitExceededError, RequestDroppedError,
             StreamerMissingInActionError,
         },
         kv,
@@ -732,7 +732,7 @@ impl StreamerClient {
                 }
                 AppendErrorInternal::ConditionFailed(_) => unreachable!("unconditional write"),
                 AppendErrorInternal::TimestampMissing(_) => unreachable!("Timestamp::MAX used"),
-                AppendErrorInternal::StreamMessageLimitExceeded(_) => {
+                AppendErrorInternal::EncryptedMessageLimitExceeded(_) => {
                     unreachable!("terminal append is plaintext command record")
                 }
             }),
@@ -828,18 +828,13 @@ fn sequenced_records(
         .enumerate()
     {
         let assigned_seq_num = first_seq_num + i as u64;
-        match record.as_ref().into_inner() {
-            StoredRecord::Plaintext(Record::Command(_)) => {}
-            sr @ StoredRecord::Plaintext(_) | sr @ StoredRecord::Encrypted { .. } => {
-                if let Some(limit) = sr.stream_message_limit()
-                    && assigned_seq_num >= limit
-                {
-                    Err(StreamMessageLimitExceededError {
-                        assigned_seq_num,
-                        limit,
-                    })?;
-                }
-            }
+        if let Some(limit) = record.as_ref().into_inner().stream_message_limit()
+            && assigned_seq_num >= limit
+        {
+            Err(EncryptedMessageLimitExceededError {
+                assigned_seq_num,
+                limit,
+            })?;
         }
         let mut timestamp = match mode {
             TimestampingMode::ClientPrefer => timestamp.unwrap_or(now),
@@ -1212,13 +1207,13 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(AppendErrorInternal::StreamMessageLimitExceeded(
-                StreamMessageLimitExceededError {
+            Err(AppendErrorInternal::EncryptedMessageLimitExceeded(
+                EncryptedMessageLimitExceededError {
                     assigned_seq_num: seq_num,
                     limit: err_limit,
                 }
             ))
-            if seq_num == limit && err_limit == limit
+            if seq_num == limit && err_limit == limit,
         ));
     }
 

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -45,7 +45,7 @@ use crate::{
         durability_notifier::DurabilityNotifier,
         error::{
             AppendConditionFailedError, AppendErrorInternal, AppendTimestampRequiredError,
-            DeleteStreamError, EncryptionAlgorithmMismatchError, RequestDroppedError,
+            DeleteStreamError, RequestDroppedError, StreamMessageLimitExceededError,
             StreamerMissingInActionError,
         },
         kv,
@@ -252,7 +252,6 @@ impl Spawner {
             stream_id,
             msg_tx: msg_tx.clone(),
             config,
-            cipher,
             fencing_token: CommandState {
                 state: fencing_token,
                 applied_point: ..tail_pos.seq_num,
@@ -312,7 +311,6 @@ struct Streamer {
     stream_id: StreamId,
     msg_tx: mpsc::UnboundedSender<Message>,
     config: OptionalStreamConfig,
-    cipher: Option<EncryptionAlgorithm>,
     fencing_token: CommandState<FencingToken>,
     trim_point: CommandState<RangeTo<SeqNum>>,
     last_doe_deadline_at: Option<Instant>,
@@ -366,7 +364,6 @@ impl Streamer {
             first_seq_num,
             next_assignable_pos.timestamp,
             &self.config.timestamping,
-            self.cipher,
         )
     }
 
@@ -735,7 +732,7 @@ impl StreamerClient {
                 }
                 AppendErrorInternal::ConditionFailed(_) => unreachable!("unconditional write"),
                 AppendErrorInternal::TimestampMissing(_) => unreachable!("Timestamp::MAX used"),
-                AppendErrorInternal::EncryptionAlgorithmMismatch(_) => {
+                AppendErrorInternal::StreamMessageLimitExceeded(_) => {
                     unreachable!("terminal append is plaintext command record")
                 }
             }),
@@ -819,7 +816,6 @@ fn sequenced_records(
     first_seq_num: SeqNum,
     prev_max_timestamp: Timestamp,
     config: &OptionalTimestampingConfig,
-    expected_encryption_algorithm: Option<EncryptionAlgorithm>,
 ) -> Result<Vec<Metered<StoredSequencedRecord>>, AppendErrorInternal> {
     let mode = config.mode.unwrap_or_default();
     let uncapped = config.uncapped.unwrap_or_default();
@@ -831,13 +827,16 @@ fn sequenced_records(
         .map(|record| record.into_parts())
         .enumerate()
     {
+        let assigned_seq_num = first_seq_num + i as u64;
         match record.as_ref().into_inner() {
             StoredRecord::Plaintext(Record::Command(_)) => {}
             sr @ StoredRecord::Plaintext(_) | sr @ StoredRecord::Encrypted { .. } => {
-                if expected_encryption_algorithm != sr.encryption_algorithm() {
-                    Err(EncryptionAlgorithmMismatchError {
-                        expected: expected_encryption_algorithm,
-                        actual: sr.encryption_algorithm(),
+                if let Some(limit) = sr.stream_message_limit()
+                    && assigned_seq_num >= limit
+                {
+                    Err(StreamMessageLimitExceededError {
+                        assigned_seq_num,
+                        limit,
                     })?;
                 }
             }
@@ -857,7 +856,7 @@ fn sequenced_records(
         }
 
         sequenced_records.push(record.sequenced(StreamPosition {
-            seq_num: first_seq_num + i as u64,
+            seq_num: assigned_seq_num,
             timestamp,
         }));
     }
@@ -930,7 +929,7 @@ mod tests {
 
     use bytes::Bytes;
     use s2_common::{
-        encryption::{EncryptionAlgorithm, EncryptionSpec},
+        encryption::EncryptionSpec,
         record::{EnvelopeRecord, Metered, Record, StoredRecord},
         types::stream::{
             StoredAppendInput, StoredAppendRecord, StoredAppendRecordBatch, StoredAppendRecordParts,
@@ -957,11 +956,15 @@ mod tests {
         parts.try_into().unwrap()
     }
 
-    fn test_encrypted_record(body: Bytes, timestamp: Option<Timestamp>) -> StoredAppendRecord {
+    fn test_encrypted_record(
+        body: Bytes,
+        timestamp: Option<Timestamp>,
+        encryption: &EncryptionSpec,
+    ) -> StoredAppendRecord {
         let envelope = EnvelopeRecord::try_from_parts(vec![], body).unwrap();
         let record = s2_common::record::encrypt_record(
             Metered::from(Record::Envelope(envelope)),
-            &EncryptionSpec::aegis256([0x42; 32]),
+            encryption,
             b"test-streamer",
         );
         let parts = StoredAppendRecordParts { timestamp, record };
@@ -982,7 +985,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, None).unwrap();
+        let result = sequenced_records(records, 100, 0, &config).unwrap();
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].position().seq_num, 100);
@@ -1006,7 +1009,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, None).unwrap();
+        let result = sequenced_records(records, 100, 0, &config).unwrap();
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].position().seq_num, 100);
@@ -1026,7 +1029,7 @@ mod tests {
             .try_into()
             .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, None);
+        let result = sequenced_records(records, 100, 0, &config);
 
         assert!(matches!(
             result,
@@ -1048,7 +1051,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, None).unwrap();
+        let result = sequenced_records(records, 100, 0, &config).unwrap();
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].position().timestamp, 900);
@@ -1070,7 +1073,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, None).unwrap();
+        let result = sequenced_records(records, 100, 0, &config).unwrap();
 
         assert_eq!(result.len(), 2);
         assert!(result[0].position().timestamp >= now);
@@ -1092,7 +1095,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, None).unwrap();
+        let result = sequenced_records(records, 100, 0, &config).unwrap();
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].position().timestamp, 1000);
@@ -1114,7 +1117,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, 100, 1000, &config, None).unwrap();
+        let result = sequenced_records(records, 100, 1000, &config).unwrap();
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].position().timestamp, 1000);
@@ -1135,7 +1138,7 @@ mod tests {
                 .try_into()
                 .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, None).unwrap();
+        let result = sequenced_records(records, 100, 0, &config).unwrap();
 
         assert_eq!(result.len(), 1);
         assert!(result[0].position().timestamp <= now + 100);
@@ -1155,7 +1158,7 @@ mod tests {
                 .try_into()
                 .unwrap();
 
-        let result = sequenced_records(records, 100, 0, &config, None).unwrap();
+        let result = sequenced_records(records, 100, 0, &config).unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].position().timestamp, future);
@@ -1173,7 +1176,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, 42, 0, &config, None).unwrap();
+        let result = sequenced_records(records, 42, 0, &config).unwrap();
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].position().seq_num, 42);
@@ -1182,43 +1185,65 @@ mod tests {
     }
 
     #[test]
-    fn sequenced_records_skip_encryption_check_for_command_records() {
+    fn sequenced_records_reject_aes256gcm_records_past_random_nonce_limit() {
         let config = OptionalTimestampingConfig::default();
-        let expected_encryption_algorithm = Some(EncryptionAlgorithm::Aegis256);
+        let first_record = test_encrypted_record(
+            vec![1, 2, 3].into(),
+            None,
+            &EncryptionSpec::aes256_gcm([0x24; 32]),
+        );
+        let limit = first_record
+            .parts()
+            .record
+            .stream_message_limit()
+            .expect("aes-256-gcm record has stream message limit");
+        let records: StoredAppendRecordBatch = vec![
+            first_record,
+            test_encrypted_record(
+                vec![4, 5, 6].into(),
+                None,
+                &EncryptionSpec::aes256_gcm([0x24; 32]),
+            ),
+        ]
+        .try_into()
+        .unwrap();
+
+        let result = sequenced_records(records, limit - 1, 0, &config);
+
+        assert!(matches!(
+            result,
+            Err(AppendErrorInternal::StreamMessageLimitExceeded(
+                StreamMessageLimitExceededError {
+                    assigned_seq_num: seq_num,
+                    limit: err_limit,
+                }
+            ))
+            if seq_num == limit && err_limit == limit
+        ));
+    }
+
+    #[test]
+    fn sequenced_records_allow_aes256gcm_command_records_past_random_nonce_limit() {
+        let config = OptionalTimestampingConfig::default();
+        let limit = test_encrypted_record(
+            vec![1, 2, 3].into(),
+            None,
+            &EncryptionSpec::aes256_gcm([0x24; 32]),
+        )
+        .parts()
+        .record
+        .stream_message_limit()
+        .expect("aes-256-gcm record has stream message limit");
 
         let records: StoredAppendRecordBatch =
             vec![test_command_record(CommandRecord::Trim(42), None)]
                 .try_into()
                 .unwrap();
 
-        let result =
-            sequenced_records(records, 42, 0, &config, expected_encryption_algorithm).unwrap();
+        let result = sequenced_records(records, limit, 0, &config).unwrap();
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].position().seq_num, 42);
-    }
-
-    #[test]
-    fn sequenced_records_reject_disallowed_encrypted_envelope_records() {
-        let config = OptionalTimestampingConfig::default();
-        let expected_encryption_algorithm = Some(EncryptionAlgorithm::Aes256Gcm);
-
-        let records: StoredAppendRecordBatch =
-            vec![test_encrypted_record(vec![1, 2, 3].into(), None)]
-                .try_into()
-                .unwrap();
-
-        let result = sequenced_records(records, 42, 0, &config, expected_encryption_algorithm);
-
-        assert!(matches!(
-            result,
-            Err(AppendErrorInternal::EncryptionAlgorithmMismatch(
-                EncryptionAlgorithmMismatchError {
-                    expected: Some(EncryptionAlgorithm::Aes256Gcm),
-                    actual: Some(EncryptionAlgorithm::Aegis256),
-                }
-            ))
-        ));
+        assert_eq!(result[0].position().seq_num, limit);
     }
 
     #[test]
@@ -1257,7 +1282,6 @@ mod tests {
             stream_id: [3u8; StreamId::LEN].into(),
             msg_tx,
             config: OptionalStreamConfig::default(),
-            cipher: None,
             fencing_token: CommandState {
                 state: FencingToken::default(),
                 applied_point: ..SeqNum::MIN,

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -249,7 +249,7 @@ impl ServiceError {
                     } => v1t::stream::AppendConditionFailed::SeqNumMismatch(*assigned_seq_num),
                 }),
                 AppendError::TimestampMissing(e) => standard(ErrorCode::Invalid, e.to_string()),
-                AppendError::StreamMessageLimitExceeded(e) => {
+                AppendError::StreamEncryptedRecordLimitExceeded(e) => {
                     standard(ErrorCode::Invalid, e.to_string())
                 }
             },

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -249,7 +249,7 @@ impl ServiceError {
                     } => v1t::stream::AppendConditionFailed::SeqNumMismatch(*assigned_seq_num),
                 }),
                 AppendError::TimestampMissing(e) => standard(ErrorCode::Invalid, e.to_string()),
-                AppendError::EncryptionAlgorithmMismatch(e) => {
+                AppendError::StreamMessageLimitExceeded(e) => {
                     standard(ErrorCode::Invalid, e.to_string())
                 }
             },


### PR DESCRIPTION
- enforce per-record stream message limits during sequencing for encrypted records with random nonces
- keep the limit on encrypted record formats and expose it through stored records instead of encryption algorithms
- remove streamer-owned append cipher validation so append handles enforce encryption choice by construction
- keep plaintext command records appendable past the encrypted-record limit

Testing:
- just fmt
- just test