### PR TITLE
fix(lite): preserve offending seq num in limit error

### DIFF
--- a/lite/src/backend/append.rs
+++ b/lite/src/backend/append.rs
@@ -228,12 +228,7 @@ impl Ticket {
         append_err: AppendErrorInternal,
         stable_pos: StreamPosition,
     ) -> Option<BlockedReplySender> {
-        let mut durability_dependency =
-            if let AppendErrorInternal::ConditionFailed(cond_fail) = &append_err {
-                cond_fail.durability_dependency()
-            } else {
-                ..0
-            };
+        let mut durability_dependency = append_err.durability_dependency();
         if let Some(mut session) = self.session {
             let session = session.deref_mut();
             assert!(!session.poisoned, "thanks to typestate");

--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -79,10 +79,11 @@ pub struct AppendTimestampRequiredError;
 
 #[derive(Debug, Clone, thiserror::Error)]
 #[error(
-    "stream encrypted record limit exceeded: records must be assigned sequence numbers below {limit}; attempted {assigned_seq_num}"
+    "stream encrypted record limit exceeded: records must be assigned sequence numbers below {limit}; attempted {attempted}",
+    attempted = self.assigned_seq_num()
 )]
 pub struct StreamEncryptedRecordLimitExceededError {
-    pub assigned_seq_num: SeqNum,
+    pub first_seq_num: SeqNum,
     pub limit: SeqNum,
 }
 
@@ -114,6 +115,16 @@ pub(super) enum AppendErrorInternal {
     TimestampMissing(#[from] AppendTimestampRequiredError),
     #[error(transparent)]
     StreamEncryptedRecordLimitExceeded(#[from] StreamEncryptedRecordLimitExceededError),
+}
+
+impl AppendErrorInternal {
+    pub(crate) fn durability_dependency(&self) -> RangeTo<SeqNum> {
+        match self {
+            Self::ConditionFailed(e) => e.durability_dependency(),
+            Self::StreamEncryptedRecordLimitExceeded(e) => e.durability_dependency(),
+            _ => ..0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -213,6 +224,16 @@ impl AppendConditionFailedError {
             } => ..*assigned_seq_num,
             FencingTokenMismatch { applied_point, .. } => *applied_point,
         }
+    }
+}
+
+impl StreamEncryptedRecordLimitExceededError {
+    pub fn assigned_seq_num(&self) -> SeqNum {
+        self.first_seq_num.max(self.limit)
+    }
+
+    pub(crate) fn durability_dependency(&self) -> RangeTo<SeqNum> {
+        ..self.first_seq_num
     }
 }
 

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -832,7 +832,7 @@ fn sequenced_records(
             && assigned_seq_num >= limit
         {
             Err(StreamEncryptedRecordLimitExceededError {
-                assigned_seq_num,
+                first_seq_num,
                 limit,
             })?;
         }
@@ -1207,13 +1207,10 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(AppendErrorInternal::StreamEncryptedRecordLimitExceeded(
-                StreamEncryptedRecordLimitExceededError {
-                    assigned_seq_num: seq_num,
-                    limit: err_limit,
-                }
-            ))
-            if seq_num == limit && err_limit == limit,
+            Err(AppendErrorInternal::StreamEncryptedRecordLimitExceeded(error))
+                if error.first_seq_num == limit - 1
+                    && error.limit == limit
+                    && error.assigned_seq_num() == limit,
         ));
     }
 


### PR DESCRIPTION
## Summary
- keep `first_seq_num` on the encrypted-record limit error, but derive the offending assigned seq num for the public message
- use the error itself as the durability dependency source via `AppendErrorInternal::durability_dependency()`
- keep the high-value streamer boundary coverage and drop the low-value append queue test

## Testing
- just fmt
- just test