### PR TITLE
fix(lite): model record limits as max assignable sequence numbers

### DIFF
--- a/common/src/record/encryption.rs
+++ b/common/src/record/encryption.rs
@@ -98,10 +98,10 @@ impl EncryptedRecordFormat {
         }
     }
 
-    const fn stream_encrypted_record_limit(self) -> Option<SeqNum> {
+    const fn max_assignable_seq_num(self) -> SeqNum {
         match self {
-            Self::Aegis256V1 => None,
-            Self::Aes256GcmV1 => Some(1u64 << 32),
+            Self::Aegis256V1 => SeqNum::MAX,
+            Self::Aes256GcmV1 => (1u64 << 32) - 1,
         }
     }
 }
@@ -141,8 +141,8 @@ impl EncryptedRecord {
         self.format.algorithm()
     }
 
-    pub fn stream_encrypted_record_limit(&self) -> Option<SeqNum> {
-        self.format.stream_encrypted_record_limit()
+    pub fn max_assignable_seq_num(&self) -> SeqNum {
+        self.format.max_assignable_seq_num()
     }
 
     pub(crate) fn nonce(&self) -> &[u8] {

--- a/common/src/record/mod.rs
+++ b/common/src/record/mod.rs
@@ -248,10 +248,10 @@ impl StoredRecord {
         }
     }
 
-    pub fn stream_encrypted_record_limit(&self) -> Option<SeqNum> {
+    pub fn max_assignable_seq_num(&self) -> SeqNum {
         match self {
-            Self::Plaintext(_) => None,
-            Self::Encrypted { record, .. } => record.stream_encrypted_record_limit(),
+            Self::Plaintext(_) => SeqNum::MAX,
+            Self::Encrypted { record, .. } => record.max_assignable_seq_num(),
         }
     }
 }

--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -118,7 +118,7 @@ pub(super) enum AppendErrorInternal {
 }
 
 impl AppendErrorInternal {
-    pub(crate) fn durability_dependency(&self) -> RangeTo<SeqNum> {
+    pub fn durability_dependency(&self) -> RangeTo<SeqNum> {
         match self {
             Self::ConditionFailed(e) => e.durability_dependency(),
             Self::StreamRecordLimitExceeded(e) => e.durability_dependency(),
@@ -228,7 +228,7 @@ impl AppendConditionFailedError {
 }
 
 impl StreamRecordLimitExceededError {
-    pub(crate) fn durability_dependency(&self) -> RangeTo<SeqNum> {
+    pub fn durability_dependency(&self) -> RangeTo<SeqNum> {
         ..self.first_seq_num
     }
 }

--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -79,12 +79,12 @@ pub struct AppendTimestampRequiredError;
 
 #[derive(Debug, Clone, thiserror::Error)]
 #[error(
-    "stream encrypted record limit exceeded: records must be assigned sequence numbers below {limit}; attempted {attempted}",
-    attempted = self.assigned_seq_num()
+    "stream record limit exceeded: max assignable sequence number is {max_assignable_seq_num}; attempted {assigned_seq_num}"
 )]
-pub struct StreamEncryptedRecordLimitExceededError {
+pub struct StreamRecordLimitExceededError {
     pub first_seq_num: SeqNum,
-    pub limit: SeqNum,
+    pub assigned_seq_num: SeqNum,
+    pub max_assignable_seq_num: SeqNum,
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -114,14 +114,14 @@ pub(super) enum AppendErrorInternal {
     #[error(transparent)]
     TimestampMissing(#[from] AppendTimestampRequiredError),
     #[error(transparent)]
-    StreamEncryptedRecordLimitExceeded(#[from] StreamEncryptedRecordLimitExceededError),
+    StreamRecordLimitExceeded(#[from] StreamRecordLimitExceededError),
 }
 
 impl AppendErrorInternal {
     pub(crate) fn durability_dependency(&self) -> RangeTo<SeqNum> {
         match self {
             Self::ConditionFailed(e) => e.durability_dependency(),
-            Self::StreamEncryptedRecordLimitExceeded(e) => e.durability_dependency(),
+            Self::StreamRecordLimitExceeded(e) => e.durability_dependency(),
             _ => ..0,
         }
     }
@@ -180,7 +180,7 @@ pub enum AppendError {
     #[error(transparent)]
     TimestampMissing(#[from] AppendTimestampRequiredError),
     #[error(transparent)]
-    StreamEncryptedRecordLimitExceeded(#[from] StreamEncryptedRecordLimitExceededError),
+    StreamRecordLimitExceeded(#[from] StreamRecordLimitExceededError),
 }
 
 impl From<AppendErrorInternal> for AppendError {
@@ -193,8 +193,8 @@ impl From<AppendErrorInternal> for AppendError {
             AppendErrorInternal::RequestDroppedError(e) => AppendError::RequestDroppedError(e),
             AppendErrorInternal::ConditionFailed(e) => AppendError::ConditionFailed(e),
             AppendErrorInternal::TimestampMissing(e) => AppendError::TimestampMissing(e),
-            AppendErrorInternal::StreamEncryptedRecordLimitExceeded(e) => {
-                AppendError::StreamEncryptedRecordLimitExceeded(e)
+            AppendErrorInternal::StreamRecordLimitExceeded(e) => {
+                AppendError::StreamRecordLimitExceeded(e)
             }
         }
     }
@@ -227,11 +227,7 @@ impl AppendConditionFailedError {
     }
 }
 
-impl StreamEncryptedRecordLimitExceededError {
-    pub fn assigned_seq_num(&self) -> SeqNum {
-        self.first_seq_num.max(self.limit)
-    }
-
+impl StreamRecordLimitExceededError {
     pub(crate) fn durability_dependency(&self) -> RangeTo<SeqNum> {
         ..self.first_seq_num
     }

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -1188,7 +1188,8 @@ mod tests {
             None,
             &EncryptionSpec::aes256_gcm([0x24; 32]),
         );
-        let limit = first_record.parts().record.max_assignable_seq_num();
+        let max_assignable_seq_num = first_record.parts().record.max_assignable_seq_num();
+        let first_rejected_seq_num = max_assignable_seq_num + 1;
         let records: StoredAppendRecordBatch = vec![
             first_record,
             test_encrypted_record(
@@ -1200,21 +1201,21 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, limit, 0, &config);
+        let result = sequenced_records(records, max_assignable_seq_num, 0, &config);
 
         assert!(matches!(
             result,
             Err(AppendErrorInternal::StreamRecordLimitExceeded(error))
-                if error.first_seq_num == limit
-                    && error.assigned_seq_num == limit + 1
-                    && error.max_assignable_seq_num == limit
+                if error.first_seq_num == max_assignable_seq_num
+                    && error.assigned_seq_num == first_rejected_seq_num
+                    && error.max_assignable_seq_num == max_assignable_seq_num
         ));
     }
 
     #[test]
     fn sequenced_records_allow_aes256gcm_command_records_past_random_nonce_limit() {
         let config = OptionalTimestampingConfig::default();
-        let limit = test_encrypted_record(
+        let max_assignable_seq_num = test_encrypted_record(
             vec![1, 2, 3].into(),
             None,
             &EncryptionSpec::aes256_gcm([0x24; 32]),
@@ -1228,10 +1229,11 @@ mod tests {
                 .try_into()
                 .unwrap();
 
-        let result = sequenced_records(records, limit + 1, 0, &config).unwrap();
+        let first_command_seq_num = max_assignable_seq_num + 1;
+        let result = sequenced_records(records, first_command_seq_num, 0, &config).unwrap();
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].position().seq_num, limit + 1);
+        assert_eq!(result[0].position().seq_num, first_command_seq_num);
     }
 
     #[test]

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -45,7 +45,7 @@ use crate::{
         durability_notifier::DurabilityNotifier,
         error::{
             AppendConditionFailedError, AppendErrorInternal, AppendTimestampRequiredError,
-            DeleteStreamError, RequestDroppedError, StreamEncryptedRecordLimitExceededError,
+            DeleteStreamError, RequestDroppedError, StreamRecordLimitExceededError,
             StreamerMissingInActionError,
         },
         kv,
@@ -732,7 +732,7 @@ impl StreamerClient {
                 }
                 AppendErrorInternal::ConditionFailed(_) => unreachable!("unconditional write"),
                 AppendErrorInternal::TimestampMissing(_) => unreachable!("Timestamp::MAX used"),
-                AppendErrorInternal::StreamEncryptedRecordLimitExceeded(_) => {
+                AppendErrorInternal::StreamRecordLimitExceeded(_) => {
                     unreachable!("terminal append is plaintext command record")
                 }
             }),
@@ -828,12 +828,13 @@ fn sequenced_records(
         .enumerate()
     {
         let assigned_seq_num = first_seq_num + i as u64;
-        if let Some(limit) = record.as_ref().into_inner().stream_encrypted_record_limit()
-            && assigned_seq_num >= limit
-        {
-            Err(StreamEncryptedRecordLimitExceededError {
+
+        let max_assignable_seq_num = record.as_ref().into_inner().max_assignable_seq_num();
+        if assigned_seq_num > max_assignable_seq_num {
+            Err(StreamRecordLimitExceededError {
                 first_seq_num,
-                limit,
+                assigned_seq_num,
+                max_assignable_seq_num,
             })?;
         }
         let mut timestamp = match mode {
@@ -1187,11 +1188,7 @@ mod tests {
             None,
             &EncryptionSpec::aes256_gcm([0x24; 32]),
         );
-        let limit = first_record
-            .parts()
-            .record
-            .stream_encrypted_record_limit()
-            .expect("aes-256-gcm record has stream message limit");
+        let limit = first_record.parts().record.max_assignable_seq_num();
         let records: StoredAppendRecordBatch = vec![
             first_record,
             test_encrypted_record(
@@ -1203,14 +1200,14 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let result = sequenced_records(records, limit - 1, 0, &config);
+        let result = sequenced_records(records, limit, 0, &config);
 
         assert!(matches!(
             result,
-            Err(AppendErrorInternal::StreamEncryptedRecordLimitExceeded(error))
-                if error.first_seq_num == limit - 1
-                    && error.limit == limit
-                    && error.assigned_seq_num() == limit,
+            Err(AppendErrorInternal::StreamRecordLimitExceeded(error))
+                if error.first_seq_num == limit
+                    && error.assigned_seq_num == limit + 1
+                    && error.max_assignable_seq_num == limit
         ));
     }
 
@@ -1224,18 +1221,17 @@ mod tests {
         )
         .parts()
         .record
-        .stream_encrypted_record_limit()
-        .expect("aes-256-gcm record has stream message limit");
+        .max_assignable_seq_num();
 
         let records: StoredAppendRecordBatch =
             vec![test_command_record(CommandRecord::Trim(42), None)]
                 .try_into()
                 .unwrap();
 
-        let result = sequenced_records(records, limit, 0, &config).unwrap();
+        let result = sequenced_records(records, limit + 1, 0, &config).unwrap();
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].position().seq_num, limit);
+        assert_eq!(result[0].position().seq_num, limit + 1);
     }
 
     #[test]

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -249,7 +249,7 @@ impl ServiceError {
                     } => v1t::stream::AppendConditionFailed::SeqNumMismatch(*assigned_seq_num),
                 }),
                 AppendError::TimestampMissing(e) => standard(ErrorCode::Invalid, e.to_string()),
-                AppendError::StreamEncryptedRecordLimitExceeded(e) => {
+                AppendError::StreamRecordLimitExceeded(e) => {
                     standard(ErrorCode::Invalid, e.to_string())
                 }
             },


### PR DESCRIPTION
## Summary
- rename the per-record limit API to max_assignable_seq_num with inclusive semantics
- keep the append failure generic as a stream record limit error while reporting the actual rejected sequence number
- preserve the boundary behavior that still allows plaintext command records past the encrypted-record limit

## Testing
- just fmt
- just test