### PR TITLE
fix(lite): treat encryption algorithm mismatch as storage error

### DIFF
--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -257,13 +257,11 @@ impl ServiceError {
                     standard(ErrorCode::Invalid, e.to_string())
                 }
                 ReadError::RecordDecryption(e) => match e {
-                    RecordDecryptionError::AlgorithmMismatch { .. } => {
-                        standard(ErrorCode::Invalid, e.to_string())
-                    }
                     RecordDecryptionError::AuthenticationFailed => {
                         standard(ErrorCode::DecryptionFailed, e.to_string())
                     }
-                    RecordDecryptionError::MalformedEncryptedRecord
+                    RecordDecryptionError::AlgorithmMismatch { .. }
+                    | RecordDecryptionError::MalformedEncryptedRecord
                     | RecordDecryptionError::MeteredSizeMismatch { .. }
                     | RecordDecryptionError::MalformedDecryptedRecord(_) => {
                         standard(ErrorCode::Storage, e.to_string())


### PR DESCRIPTION
## Summary
- Reclassify `RecordDecryptionError::AlgorithmMismatch` from `Invalid` to `Storage`, grouping it with the other decryption errors that indicate on-disk/data-level problems rather than caller input issues.

## Test plan
- [x] `just fmt`
- [x] `just test`