### PR TITLE
fix: map encryption spec errors to bad header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
           {
             "name": "python",
             "repo": "s2-streamstore/s2-sdk-python",
-            "ref": "devin/1781116554-fix-encryption-error-code",
+            "ref": "main",
             "lang": "python",
             "uv-version": "0.11.6",
             "test_cmd": "uv run pytest tests/ -v -s -m '(account or basin or stream) and not access_tokens'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
           {
             "name": "python",
             "repo": "s2-streamstore/s2-sdk-python",
-            "ref": "main",
+            "ref": "devin/1781116554-fix-encryption-error-code",
             "lang": "python",
             "uv-version": "0.11.6",
             "test_cmd": "uv run pytest tests/ -v -s -m '(account or basin or stream) and not access_tokens'"

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -217,7 +217,7 @@ impl ServiceError {
             ServiceError::Append(e) => match e {
                 AppendError::Storage(e) => standard(ErrorCode::Storage, e.to_string()),
                 AppendError::EncryptionSpecResolution(e) => {
-                    standard(ErrorCode::Invalid, e.to_string())
+                    standard(ErrorCode::BadHeader, e.to_string())
                 }
                 AppendError::TransactionConflict(e) => {
                     standard(ErrorCode::TransactionConflict, e.to_string())
@@ -254,7 +254,7 @@ impl ServiceError {
             ServiceError::Read(e) => match e {
                 ReadError::Storage(e) => standard(ErrorCode::Storage, e.to_string()),
                 ReadError::EncryptionSpecResolution(e) => {
-                    standard(ErrorCode::Invalid, e.to_string())
+                    standard(ErrorCode::BadHeader, e.to_string())
                 }
                 ReadError::RecordDecryption(e) => match e {
                     RecordDecryptionError::AuthenticationFailed => {

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -627,16 +627,6 @@ mod tests {
         frame
     }
 
-    fn assert_invalid_error(info: &serde_json::Value, expected_message: &str) {
-        assert_eq!(info["code"], "invalid");
-        assert!(
-            info["message"]
-                .as_str()
-                .expect("error message string")
-                .contains(expected_message)
-        );
-    }
-
     async fn assert_no_streams(backend: &Backend, basin: &BasinName) {
         let stream_list = backend
             .list_streams(basin.clone(), ListStreamsRequest::default())
@@ -742,7 +732,13 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
         let info = response_json(response, "read error body").await;
-        assert_invalid_error(&info, "start `timestamp` exceeds or equal to `until`");
+        assert_eq!(info["code"], "invalid");
+        assert!(
+            info["message"]
+                .as_str()
+                .expect("error message string")
+                .contains("start `timestamp` exceeds or equal to `until`")
+        );
         assert_no_streams(&backend, &basin).await;
     }
 
@@ -805,9 +801,15 @@ mod tests {
         )
         .await;
 
-        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let info = response_json(response, "sse read error body").await;
-        assert_invalid_error(&info, "missing encryption key");
+        assert_eq!(info["code"], "bad_header");
+        assert!(
+            info["message"]
+                .as_str()
+                .expect("error message string")
+                .contains("missing encryption key")
+        );
     }
 
     #[tokio::test]
@@ -830,9 +832,15 @@ mod tests {
         )
         .await;
 
-        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let info = response_json(response, "s2s read error body").await;
-        assert_invalid_error(&info, "missing encryption key");
+        assert_eq!(info["code"], "bad_header");
+        assert!(
+            info["message"]
+                .as_str()
+                .expect("error message string")
+                .contains("missing encryption key")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Map append/read encryption spec resolution errors to `bad_header`/400.
- Update existing read-handler assertions for missing encryption-key headers.

## Tests
- `just fmt`
- `cargo test -p s2-lite --all-features read_without_key_header_is_rejected_before_stream_starts`
- `just test`