### PR TITLE
feat: add aws:us-west-2 and aws:eu-north-1 basin scopes

### DIFF
--- a/api/src/v1/basin.rs
+++ b/api/src/v1/basin.rs
@@ -127,12 +127,20 @@ pub enum BasinScope {
     /// AWS `us-east-1` region.
     #[serde(rename = "aws:us-east-1")]
     AwsUsEast1,
+    /// AWS `us-west-2` region.
+    #[serde(rename = "aws:us-west-2")]
+    AwsUsWest2,
+    /// AWS `eu-north-1` region.
+    #[serde(rename = "aws:eu-north-1")]
+    AwsEuNorth1,
 }
 
 impl From<BasinScope> for types::basin::BasinScope {
     fn from(value: BasinScope) -> Self {
         match value {
             BasinScope::AwsUsEast1 => Self::AwsUsEast1,
+            BasinScope::AwsUsWest2 => Self::AwsUsWest2,
+            BasinScope::AwsEuNorth1 => Self::AwsEuNorth1,
         }
     }
 }
@@ -141,6 +149,8 @@ impl From<types::basin::BasinScope> for BasinScope {
     fn from(value: types::basin::BasinScope) -> Self {
         match value {
             types::basin::BasinScope::AwsUsEast1 => Self::AwsUsEast1,
+            types::basin::BasinScope::AwsUsWest2 => Self::AwsUsWest2,
+            types::basin::BasinScope::AwsEuNorth1 => Self::AwsEuNorth1,
         }
     }
 }
@@ -163,6 +173,7 @@ pub struct CreateOrReconfigureBasinRequest {
     /// Basin reconfiguration.
     pub config: Option<BasinReconfiguration>,
     /// Basin scope.
+    /// If omitted, defaults to `aws:us-east-1`.
     /// This cannot be reconfigured.
     pub scope: Option<BasinScope>,
 }
@@ -178,5 +189,6 @@ pub struct CreateBasinRequest {
     /// Basin configuration.
     pub config: Option<BasinConfig>,
     /// Basin scope.
+    /// If omitted, defaults to `aws:us-east-1`.
     pub scope: Option<BasinScope>,
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -13,7 +13,7 @@ use crate::{
         parse_records_output_source,
     },
     types::{
-        AccessTokenMatcher, BasinConfig, BasinMatcher, Interval, Operation,
+        AccessTokenMatcher, BasinConfig, BasinMatcher, BasinScope, Interval, Operation,
         PermittedOperationGroups, S2BasinAndMaybeStreamUri, S2BasinAndStreamUri, S2BasinUri,
         StorageClass, StreamConfig, StreamMatcher,
     },
@@ -264,6 +264,10 @@ pub struct ListBasinsArgs {
 pub struct CreateBasinArgs {
     /// Name of the basin to create.
     pub basin: S2BasinUri,
+
+    /// Cloud provider and region for the basin.
+    #[arg(long)]
+    pub scope: Option<BasinScope>,
 
     #[command(flatten)]
     pub config: BasinConfig,

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -94,7 +94,10 @@ pub async fn list_basins(
 }
 
 pub async fn create_basin(s2: &S2, args: CreateBasinArgs) -> Result<BasinInfo, CliError> {
-    let input = CreateBasinInput::new(args.basin.into()).with_config(args.config.into());
+    let mut input = CreateBasinInput::new(args.basin.into()).with_config(args.config.into());
+    if let Some(scope) = args.scope {
+        input = input.with_scope(scope.into());
+    }
     s2.create_basin(input)
         .await
         .map_err(|e| CliError::op(OpKind::CreateBasin, e))

--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -824,6 +824,26 @@ fn timestamping_mode_prev(tm: &Option<TimestampingMode>) -> Option<TimestampingM
 pub enum BasinScopeOption {
     #[default]
     AwsUsEast1,
+    AwsUsWest2,
+    AwsEuNorth1,
+}
+
+impl BasinScopeOption {
+    pub fn next(self) -> Self {
+        match self {
+            Self::AwsUsEast1 => Self::AwsUsWest2,
+            Self::AwsUsWest2 => Self::AwsEuNorth1,
+            Self::AwsEuNorth1 => Self::AwsUsEast1,
+        }
+    }
+
+    pub fn prev(self) -> Self {
+        match self {
+            Self::AwsUsEast1 => Self::AwsEuNorth1,
+            Self::AwsUsWest2 => Self::AwsUsEast1,
+            Self::AwsEuNorth1 => Self::AwsUsWest2,
+        }
+    }
 }
 
 /// Expiry options for access tokens
@@ -2435,6 +2455,7 @@ impl App {
                             _ => {}
                         },
                         KeyCode::Left | KeyCode::Char('h') => match *selected {
+                            1 => *scope = scope.prev(),
                             2 => *storage_class = storage_class_prev(storage_class),
                             3 => *retention_policy = retention_policy.toggle(),
                             5 => *timestamping_mode = timestamping_mode_prev(timestamping_mode),
@@ -2442,6 +2463,7 @@ impl App {
                             _ => {}
                         },
                         KeyCode::Right | KeyCode::Char('l') => match *selected {
+                            1 => *scope = scope.next(),
                             2 => *storage_class = storage_class_next(storage_class),
                             3 => *retention_policy = retention_policy.toggle(),
                             5 => *timestamping_mode = timestamping_mode_next(timestamping_mode),
@@ -4306,6 +4328,8 @@ impl App {
             };
             let sdk_scope = match scope {
                 BasinScopeOption::AwsUsEast1 => s2_sdk::types::BasinScope::AwsUsEast1,
+                BasinScopeOption::AwsUsWest2 => s2_sdk::types::BasinScope::AwsUsWest2,
+                BasinScopeOption::AwsEuNorth1 => s2_sdk::types::BasinScope::AwsEuNorth1,
             };
             let input = s2_sdk::types::CreateBasinInput::new(basin_name)
                 .with_config(config.into())

--- a/cli/src/tui/ui.rs
+++ b/cli/src/tui/ui.rs
@@ -2478,6 +2478,8 @@ fn draw_basins(f: &mut Frame, area: Rect, state: &BasinsState) {
             .as_ref()
             .map(|s| match s {
                 s2_sdk::types::BasinScope::AwsUsEast1 => "aws:us-east-1",
+                s2_sdk::types::BasinScope::AwsUsWest2 => "aws:us-west-2",
+                s2_sdk::types::BasinScope::AwsEuNorth1 => "aws:eu-north-1",
             })
             .unwrap_or("—");
 
@@ -4530,7 +4532,11 @@ fn draw_input_dialog(f: &mut Frame, mode: &InputMode) {
             let name_valid = name.len() >= 8 && name.len() <= 48;
 
             // Scope options
-            let scope_opts = [("AWS us-east-1", *scope == BasinScopeOption::AwsUsEast1)];
+            let scope_opts = [
+                ("AWS us-east-1", *scope == BasinScopeOption::AwsUsEast1),
+                ("AWS us-west-2", *scope == BasinScopeOption::AwsUsWest2),
+                ("AWS eu-north-1", *scope == BasinScopeOption::AwsEuNorth1),
+            ];
 
             // Storage class options
             let storage_opts = [

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -173,6 +173,19 @@ impl StreamConfig {
 }
 
 #[derive(ValueEnum, Debug, Clone, Serialize)]
+pub enum BasinScope {
+    #[value(name = "aws:us-east-1")]
+    #[serde(rename = "aws:us-east-1")]
+    AwsUsEast1,
+    #[value(name = "aws:us-west-2")]
+    #[serde(rename = "aws:us-west-2")]
+    AwsUsWest2,
+    #[value(name = "aws:eu-north-1")]
+    #[serde(rename = "aws:eu-north-1")]
+    AwsEuNorth1,
+}
+
+#[derive(ValueEnum, Debug, Clone, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum StorageClass {
     Standard,
@@ -284,6 +297,26 @@ impl From<StreamConfig> for sdk::types::StreamConfig {
             stream_config = stream_config.with_delete_on_empty(delete_on_empty.into());
         }
         stream_config
+    }
+}
+
+impl From<BasinScope> for sdk::types::BasinScope {
+    fn from(scope: BasinScope) -> Self {
+        match scope {
+            BasinScope::AwsUsEast1 => sdk::types::BasinScope::AwsUsEast1,
+            BasinScope::AwsUsWest2 => sdk::types::BasinScope::AwsUsWest2,
+            BasinScope::AwsEuNorth1 => sdk::types::BasinScope::AwsEuNorth1,
+        }
+    }
+}
+
+impl From<sdk::types::BasinScope> for BasinScope {
+    fn from(scope: sdk::types::BasinScope) -> Self {
+        match scope {
+            sdk::types::BasinScope::AwsUsEast1 => BasinScope::AwsUsEast1,
+            sdk::types::BasinScope::AwsUsWest2 => BasinScope::AwsUsWest2,
+            sdk::types::BasinScope::AwsEuNorth1 => BasinScope::AwsEuNorth1,
+        }
     }
 }
 

--- a/common/src/types/basin.rs
+++ b/common/src/types/basin.rs
@@ -206,6 +206,10 @@ pub type ListBasinsRequest = ListItemsRequest<BasinNamePrefix, BasinNameStartAft
 pub enum BasinScope {
     #[strum(serialize = "aws:us-east-1")]
     AwsUsEast1,
+    #[strum(serialize = "aws:us-west-2")]
+    AwsUsWest2,
+    #[strum(serialize = "aws:eu-north-1")]
+    AwsEuNorth1,
 }
 
 #[derive(Debug, Clone)]

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -859,12 +859,18 @@ impl From<BasinConfig> for api::config::BasinConfig {
 pub enum BasinScope {
     /// AWS `us-east-1` region.
     AwsUsEast1,
+    /// AWS `us-west-2` region.
+    AwsUsWest2,
+    /// AWS `eu-north-1` region.
+    AwsEuNorth1,
 }
 
 impl From<api::basin::BasinScope> for BasinScope {
     fn from(value: api::basin::BasinScope) -> Self {
         match value {
             api::basin::BasinScope::AwsUsEast1 => BasinScope::AwsUsEast1,
+            api::basin::BasinScope::AwsUsWest2 => BasinScope::AwsUsWest2,
+            api::basin::BasinScope::AwsEuNorth1 => BasinScope::AwsEuNorth1,
         }
     }
 }
@@ -873,6 +879,8 @@ impl From<BasinScope> for api::basin::BasinScope {
     fn from(value: BasinScope) -> Self {
         match value {
             BasinScope::AwsUsEast1 => api::basin::BasinScope::AwsUsEast1,
+            BasinScope::AwsUsWest2 => api::basin::BasinScope::AwsUsWest2,
+            BasinScope::AwsEuNorth1 => api::basin::BasinScope::AwsEuNorth1,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds two new \`BasinScope\` variants (\`aws:us-west-2\`, \`aws:eu-north-1\`) alongside the existing \`aws:us-east-1\`.
- Touches every layer that mirrors the enum: internal types in \`common\`, HTTP API + \`From\` impls, public SDK + \`From\` impls, CLI clap \`ValueEnum\` + new \`--scope\` flag on \`s2 create-basin\`, and the TUI with prev/next cycling on the Region row.
- Documents the unset-scope default (\`aws:us-east-1\`) on \`CreateBasinRequest.scope\` and \`CreateOrReconfigureBasinRequest.scope\` so it surfaces in the regenerated \`openapi.json\` (utoipa picks up doc comments on schema fields). Previously the default was only documented in the SDK rustdoc.

## Notes

- Background: ties into the us-west-2 cell standup planned in s2-cloud (\`new_us_west_2_cell.md\`). \`eu-north-1\` is added now to avoid a second pass; customer-facing exposure is gated server-side.
- With \`v1alpha\` sunset in s2-specs (\`a47ed3e\`), the Rust types in \`s2/common/src/types/basin.rs\` are now the **single** source of truth for \`BasinScope\` — no proto change needed.
- \`openapi.json\` regen in s2-specs will follow after merge, per the existing manual regen flow.

## Test plan

- [x] \`just fmt\`
- [x] \`cargo check --all-targets --all-features\` clean
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\` clean
- [x] \`just test\` — 470/470 pass
- [x] Verified regenerated \`openapi.json\` (via \`cargo run --bin openapi -p s2-lite --features utoipa\`) lists all 3 enum variants and includes the \"defaults to \`aws:us-east-1\`\" description on the \`scope\` field.
- [x] Manual TUI smoke: cycle Region pills with ←/→ on the create-basin form
- [ ] Manual CLI smoke: \`s2 create-basin <name> --scope aws:us-west-2\` against a sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)