### PR TITLE
feat!: mark s2_sdk::BasinScope as #[non_exhaustive]

### DIFF
--- a/api/src/v1/basin.rs
+++ b/api/src/v1/basin.rs
@@ -173,7 +173,7 @@ pub struct CreateOrReconfigureBasinRequest {
     /// Basin reconfiguration.
     pub config: Option<BasinReconfiguration>,
     /// Basin scope.
-    /// If omitted, defaults to `aws:us-east-1`.
+    /// If omitted when creating, defaults to `aws:us-east-1`.
     /// This cannot be reconfigured.
     pub scope: Option<BasinScope>,
 }
@@ -189,6 +189,6 @@ pub struct CreateBasinRequest {
     /// Basin configuration.
     pub config: Option<BasinConfig>,
     /// Basin scope.
-    /// If omitted, defaults to `aws:us-east-1`.
+    /// If omitted when creating, defaults to `aws:us-east-1`.
     pub scope: Option<BasinScope>,
 }

--- a/cli/src/tui/ui.rs
+++ b/cli/src/tui/ui.rs
@@ -2480,6 +2480,7 @@ fn draw_basins(f: &mut Frame, area: Rect, state: &BasinsState) {
                 s2_sdk::types::BasinScope::AwsUsEast1 => "aws:us-east-1",
                 s2_sdk::types::BasinScope::AwsUsWest2 => "aws:us-west-2",
                 s2_sdk::types::BasinScope::AwsEuNorth1 => "aws:eu-north-1",
+                _ => "unknown",
             })
             .unwrap_or("—");
 

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -316,6 +316,9 @@ impl From<sdk::types::BasinScope> for BasinScope {
             sdk::types::BasinScope::AwsUsEast1 => BasinScope::AwsUsEast1,
             sdk::types::BasinScope::AwsUsWest2 => BasinScope::AwsUsWest2,
             sdk::types::BasinScope::AwsEuNorth1 => BasinScope::AwsEuNorth1,
+            _ => unreachable!(
+                "s2-cli is released together with s2-sdk; new BasinScope variants are added to both"
+            ),
         }
     }
 }

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -856,6 +856,7 @@ impl From<BasinConfig> for api::config::BasinConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Scope of a basin.
+#[non_exhaustive]
 pub enum BasinScope {
     /// AWS `us-east-1` region.
     AwsUsEast1,


### PR DESCRIPTION
## Summary
Adding new variants to \`s2_sdk::types::BasinScope\` is currently semver-major because the enum is exhaustive. This bit us with #430: bumping \`s2-api 0.28.4 → 0.28.5\` added enum variants in a patch release, which broke \`s2-sdk 0.27.1\`'s exhaustive match (39 errors when s2-verification tried to compile against the new s2-api).

Marks **only** \`s2_sdk::types::BasinScope\` \`#[non_exhaustive]\` so future variant additions on the public SDK surface don't break downstream consumers.

## Scope of the change
- \`s2_sdk::types::BasinScope\`: \`#[non_exhaustive]\` ← the public API surface, this is the one that matters
- \`cli/src/types.rs\` and \`cli/src/tui/ui.rs\`: gain \`_\` arms (cli matches across the crate boundary on the now-non_exhaustive sdk enum)
- \`s2_api::v1::basin::BasinScope\` and \`s2_common::types::basin::BasinScope\`: **left exhaustive**. Marking them non_exhaustive would only force \`unreachable!()\` arms in the workspace-internal \`From\` impls (api ← common, sdk ← api) — converting a compile error into a runtime panic, which is worse. The api↔sdk semver-skew that triggered #430's downstream break is a release-coordination problem (put api/common/sdk in the same release-plz \`version_group\`), not an enum-attribute one.
- Doc tweak: \"If omitted **when creating**, defaults to \`aws:us-east-1\`\" — the default only applies at create, not reconfigure.

## Test plan
- [x] \`just fmt\`
- [x] \`cargo check --workspace --all-features\` clean
- [x] \`just test\` — 470/470 pass