### PR TITLE
refactor: introduce resource-specific create intents

### DIFF
--- a/common/src/types/basin.rs
+++ b/common/src/types/basin.rs
@@ -7,7 +7,13 @@ use super::{
     ValidationError,
     strings::{NameProps, PrefixProps, StartAfterProps, StrProps},
 };
-use crate::{caps, types::resources::ListItemsRequest};
+use crate::{
+    caps,
+    types::{
+        config::{BasinConfig, BasinReconfiguration},
+        resources::{ListItemsRequest, RequestToken},
+    },
+};
 
 pub static BASIN_HEADER: http::HeaderName = http::HeaderName::from_static("s2-basin");
 
@@ -218,6 +224,33 @@ pub struct BasinInfo {
     pub scope: Option<BasinScope>,
     pub created_at: OffsetDateTime,
     pub deleted_at: Option<OffsetDateTime>,
+}
+
+/// Basin creation operation intent.
+///
+/// Separates POST-style create-only requests, which carry a complete creation config and optional
+/// idempotency token, from PUT-style create-or-reconfigure requests, which carry only a
+/// reconfiguration patch.
+#[derive(Debug)]
+pub enum CreateBasinIntent {
+    /// Create a new basin.
+    ///
+    /// HTTP POST semantics: idempotent if a request token is provided and the basin was previously
+    /// created using the same token and config.
+    CreateOnly {
+        /// Complete basin configuration for a new basin.
+        config: BasinConfig,
+        /// Optional request token used to make create retries idempotent.
+        request_token: Option<RequestToken>,
+    },
+    /// Create a new basin or reconfigure it if it already exists.
+    ///
+    /// HTTP PUT semantics: always idempotent. When the basin already exists, unspecified fields in
+    /// the reconfiguration preserve the existing config.
+    CreateOrReconfigure {
+        /// Basin reconfiguration patch to apply on create-or-reconfigure.
+        reconfiguration: BasinReconfiguration,
+    },
 }
 
 #[cfg(test)]

--- a/common/src/types/resources.rs
+++ b/common/src/types/resources.rs
@@ -115,19 +115,6 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CreateMode {
-    /// Create a new resource.
-    ///
-    /// HTTP POST semantics – idempotent if a request token is provided and the resource was
-    /// previously created using the same token.
-    CreateOnly(Option<RequestToken>),
-    /// Create a new resource or reconfigure if the resource already exists.
-    ///
-    /// HTTP PUT semantics – always idempotent.
-    CreateOrReconfigure,
-}
-
 pub static REQUEST_TOKEN_HEADER: http::HeaderName =
     http::HeaderName::from_static("s2-request-token");
 

--- a/common/src/types/stream.rs
+++ b/common/src/types/stream.rs
@@ -15,7 +15,10 @@ use crate::{
         FencingToken, Metered, MeteredExt, MeteredSize, Record, RecordDecryptionError, SeqNum,
         Sequenced, StoredRecord, StreamPosition, Timestamp, decrypt_stored_record, encrypt_record,
     },
-    types::resources::ListItemsRequest,
+    types::{
+        config::{OptionalStreamConfig, StreamReconfiguration},
+        resources::{ListItemsRequest, RequestToken},
+    },
 };
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -170,6 +173,33 @@ pub struct StreamInfo {
     pub created_at: OffsetDateTime,
     pub deleted_at: Option<OffsetDateTime>,
     pub cipher: Option<EncryptionAlgorithm>,
+}
+
+/// Stream creation operation intent.
+///
+/// Separates POST-style create-only requests, which carry a complete creation config and optional
+/// idempotency token, from PUT-style create-or-reconfigure requests, which carry only a
+/// reconfiguration patch.
+#[derive(Debug)]
+pub enum CreateStreamIntent {
+    /// Create a new stream.
+    ///
+    /// HTTP POST semantics: idempotent if a request token is provided and the stream was previously
+    /// created using the same token and config.
+    CreateOnly {
+        /// Complete stream configuration for a new stream.
+        config: OptionalStreamConfig,
+        /// Optional request token used to make create retries idempotent.
+        request_token: Option<RequestToken>,
+    },
+    /// Create a new stream or reconfigure it if it already exists.
+    ///
+    /// HTTP PUT semantics: always idempotent. When the stream already exists, unspecified fields in
+    /// the reconfiguration preserve the existing config.
+    CreateOrReconfigure {
+        /// Stream reconfiguration patch to apply on create-or-reconfigure.
+        reconfiguration: StreamReconfiguration,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/lite/src/backend/basins.rs
+++ b/lite/src/backend/basins.rs
@@ -1,9 +1,9 @@
 use s2_common::{
     bash::Bash,
     types::{
-        basin::{BasinInfo, BasinName, ListBasinsRequest},
+        basin::{BasinInfo, BasinName, CreateBasinIntent, ListBasinsRequest},
         config::{BasinConfig, BasinReconfiguration},
-        resources::{CreateMode, ListItemsRequestParts, Page, RequestToken},
+        resources::{ListItemsRequestParts, Page, RequestToken},
         stream::StreamNameStartAfter,
     },
 };
@@ -72,72 +72,93 @@ impl Backend {
     pub async fn create_basin(
         &self,
         basin: BasinName,
-        config: impl Into<BasinReconfiguration>,
-        mode: CreateMode,
+        intent: CreateBasinIntent,
     ) -> Result<CreatedOrReconfigured<BasinInfo>, CreateBasinError> {
-        let config = config.into();
         let meta_key = kv::basin_meta::ser_key(&basin);
 
         let txn = self.db.begin(IsolationLevel::SerializableSnapshot).await?;
 
-        let new_creation_idempotency_key = match &mode {
-            CreateMode::CreateOnly(Some(req_token)) => {
-                let resolved = BasinConfig::default().reconfigure(config.clone());
-                Some(creation_idempotency_key(req_token, &resolved))
-            }
-            _ => None,
-        };
-
-        let mut existing_meta_opt = None;
-        if let Some(existing_meta) =
-            db_txn_get(&txn, &meta_key, kv::basin_meta::deser_value).await?
+        let existing_meta = db_txn_get(&txn, &meta_key, kv::basin_meta::deser_value).await?;
+        if let Some(existing_meta) = &existing_meta
+            && existing_meta.deleted_at.is_some()
         {
-            if existing_meta.deleted_at.is_some() {
-                return Err(BasinDeletionPendingError { basin }.into());
-            }
-            match mode {
-                CreateMode::CreateOnly(_) => {
-                    return if new_creation_idempotency_key.is_some()
-                        && existing_meta.creation_idempotency_key == new_creation_idempotency_key
-                    {
-                        Ok(CreatedOrReconfigured::Created(BasinInfo {
-                            name: basin,
-                            scope: None,
-                            created_at: existing_meta.created_at,
-                            deleted_at: None,
-                        }))
-                    } else {
-                        Err(BasinAlreadyExistsError { basin }.into())
-                    };
-                }
-                CreateMode::CreateOrReconfigure => {
-                    existing_meta_opt = Some(existing_meta);
-                }
-            }
+            return Err(BasinDeletionPendingError { basin }.into());
         }
 
-        let is_reconfigure = existing_meta_opt.is_some();
-        let (resolved, created_at, creation_idempotency_key) = match existing_meta_opt {
-            Some(existing) => (
-                existing.config.reconfigure(config),
-                existing.created_at,
-                existing.creation_idempotency_key,
-            ),
-            None => (
-                BasinConfig::default().reconfigure(config),
-                OffsetDateTime::now_utc(),
-                new_creation_idempotency_key,
-            ),
+        struct CreateBasinResolution {
+            meta: kv::basin_meta::BasinMeta,
+            is_reconfigure: bool,
+        }
+
+        let resolution = match (existing_meta, intent) {
+            (
+                Some(existing),
+                CreateBasinIntent::CreateOnly {
+                    config,
+                    request_token,
+                },
+            ) => {
+                let new_creation_idempotency_key = request_token
+                    .as_ref()
+                    .map(|req_token| creation_idempotency_key(req_token, &config));
+                return if new_creation_idempotency_key.is_some()
+                    && existing.creation_idempotency_key == new_creation_idempotency_key
+                {
+                    Ok(CreatedOrReconfigured::Created(BasinInfo {
+                        name: basin,
+                        scope: None,
+                        created_at: existing.created_at,
+                        deleted_at: None,
+                    }))
+                } else {
+                    Err(BasinAlreadyExistsError { basin }.into())
+                };
+            }
+            (Some(existing), CreateBasinIntent::CreateOrReconfigure { reconfiguration }) => {
+                CreateBasinResolution {
+                    meta: kv::basin_meta::BasinMeta {
+                        config: existing.config.reconfigure(reconfiguration),
+                        created_at: existing.created_at,
+                        deleted_at: None,
+                        creation_idempotency_key: existing.creation_idempotency_key,
+                    },
+                    is_reconfigure: true,
+                }
+            }
+            (
+                None,
+                CreateBasinIntent::CreateOnly {
+                    config,
+                    request_token,
+                },
+            ) => {
+                let new_creation_idempotency_key = request_token
+                    .as_ref()
+                    .map(|req_token| creation_idempotency_key(req_token, &config));
+                CreateBasinResolution {
+                    meta: kv::basin_meta::BasinMeta {
+                        config,
+                        created_at: OffsetDateTime::now_utc(),
+                        deleted_at: None,
+                        creation_idempotency_key: new_creation_idempotency_key,
+                    },
+                    is_reconfigure: false,
+                }
+            }
+            (None, CreateBasinIntent::CreateOrReconfigure { reconfiguration }) => {
+                CreateBasinResolution {
+                    meta: kv::basin_meta::BasinMeta {
+                        config: BasinConfig::default().reconfigure(reconfiguration),
+                        created_at: OffsetDateTime::now_utc(),
+                        deleted_at: None,
+                        creation_idempotency_key: None,
+                    },
+                    is_reconfigure: false,
+                }
+            }
         };
 
-        let meta = kv::basin_meta::BasinMeta {
-            config: resolved,
-            created_at,
-            deleted_at: None,
-            creation_idempotency_key,
-        };
-
-        txn.put(&meta_key, kv::basin_meta::ser_value(&meta))?;
+        txn.put(&meta_key, kv::basin_meta::ser_value(&resolution.meta))?;
 
         static WRITE_OPTS: WriteOptions = WriteOptions {
             await_durable: true,
@@ -147,11 +168,11 @@ impl Backend {
         let info = BasinInfo {
             name: basin,
             scope: None,
-            created_at,
+            created_at: resolution.meta.created_at,
             deleted_at: None,
         };
 
-        Ok(if is_reconfigure {
+        Ok(if resolution.is_reconfigure {
             CreatedOrReconfigured::Reconfigured(info)
         } else {
             CreatedOrReconfigured::Created(info)

--- a/lite/src/backend/basins.rs
+++ b/lite/src/backend/basins.rs
@@ -85,12 +85,7 @@ impl Backend {
             return Err(BasinDeletionPendingError { basin }.into());
         }
 
-        struct CreateBasinResolution {
-            meta: kv::basin_meta::BasinMeta,
-            is_reconfigure: bool,
-        }
-
-        let resolution = match (existing_meta, intent) {
+        let (meta, is_reconfigure) = match (existing_meta, intent) {
             (
                 Some(existing),
                 CreateBasinIntent::CreateOnly {
@@ -114,17 +109,15 @@ impl Backend {
                     Err(BasinAlreadyExistsError { basin }.into())
                 };
             }
-            (Some(existing), CreateBasinIntent::CreateOrReconfigure { reconfiguration }) => {
-                CreateBasinResolution {
-                    meta: kv::basin_meta::BasinMeta {
-                        config: existing.config.reconfigure(reconfiguration),
-                        created_at: existing.created_at,
-                        deleted_at: None,
-                        creation_idempotency_key: existing.creation_idempotency_key,
-                    },
-                    is_reconfigure: true,
-                }
-            }
+            (Some(existing), CreateBasinIntent::CreateOrReconfigure { reconfiguration }) => (
+                kv::basin_meta::BasinMeta {
+                    config: existing.config.reconfigure(reconfiguration),
+                    created_at: existing.created_at,
+                    deleted_at: None,
+                    creation_idempotency_key: existing.creation_idempotency_key,
+                },
+                true,
+            ),
             (
                 None,
                 CreateBasinIntent::CreateOnly {
@@ -135,30 +128,28 @@ impl Backend {
                 let new_creation_idempotency_key = request_token
                     .as_ref()
                     .map(|req_token| creation_idempotency_key(req_token, &config));
-                CreateBasinResolution {
-                    meta: kv::basin_meta::BasinMeta {
+                (
+                    kv::basin_meta::BasinMeta {
                         config,
                         created_at: OffsetDateTime::now_utc(),
                         deleted_at: None,
                         creation_idempotency_key: new_creation_idempotency_key,
                     },
-                    is_reconfigure: false,
-                }
+                    false,
+                )
             }
-            (None, CreateBasinIntent::CreateOrReconfigure { reconfiguration }) => {
-                CreateBasinResolution {
-                    meta: kv::basin_meta::BasinMeta {
-                        config: BasinConfig::default().reconfigure(reconfiguration),
-                        created_at: OffsetDateTime::now_utc(),
-                        deleted_at: None,
-                        creation_idempotency_key: None,
-                    },
-                    is_reconfigure: false,
-                }
-            }
+            (None, CreateBasinIntent::CreateOrReconfigure { reconfiguration }) => (
+                kv::basin_meta::BasinMeta {
+                    config: BasinConfig::default().reconfigure(reconfiguration),
+                    created_at: OffsetDateTime::now_utc(),
+                    deleted_at: None,
+                    creation_idempotency_key: None,
+                },
+                false,
+            ),
         };
 
-        txn.put(&meta_key, kv::basin_meta::ser_value(&resolution.meta))?;
+        txn.put(&meta_key, kv::basin_meta::ser_value(&meta))?;
 
         static WRITE_OPTS: WriteOptions = WriteOptions {
             await_durable: true,
@@ -168,11 +159,11 @@ impl Backend {
         let info = BasinInfo {
             name: basin,
             scope: None,
-            created_at: resolution.meta.created_at,
+            created_at: meta.created_at,
             deleted_at: None,
         };
 
-        Ok(if resolution.is_reconfigure {
+        Ok(if is_reconfigure {
             CreatedOrReconfigured::Reconfigured(info)
         } else {
             CreatedOrReconfigured::Created(info)

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -12,8 +12,7 @@ use s2_common::{
     types::{
         basin::BasinName,
         config::{BasinConfig, OptionalStreamConfig},
-        resources::CreateMode,
-        stream::StreamName,
+        stream::{CreateStreamIntent, StreamName},
     },
 };
 use slatedb::{
@@ -328,8 +327,10 @@ impl Backend {
                         .create_stream(
                             basin.clone(),
                             stream.clone(),
-                            OptionalStreamConfig::default(),
-                            CreateMode::CreateOnly(None),
+                            CreateStreamIntent::CreateOnly {
+                                config: OptionalStreamConfig::default(),
+                                request_token: None,
+                            },
                         )
                         .await
                     {
@@ -369,8 +370,8 @@ mod tests {
     use s2_common::{
         record::{Metered, Record, StoredRecord, StreamPosition},
         types::{
+            basin::CreateBasinIntent,
             config::{BasinConfig, OptionalStreamConfig},
-            resources::CreateMode,
         },
     };
     use slatedb::{WriteBatch, config::WriteOptions, object_store};
@@ -483,8 +484,10 @@ mod tests {
         backend
             .create_basin(
                 basin.clone(),
-                BasinConfig::default(),
-                CreateMode::CreateOnly(None),
+                CreateBasinIntent::CreateOnly {
+                    config: BasinConfig::default(),
+                    request_token: None,
+                },
             )
             .await
             .unwrap();
@@ -492,8 +495,10 @@ mod tests {
             .create_stream(
                 basin.clone(),
                 stream.clone(),
-                OptionalStreamConfig::default(),
-                CreateMode::CreateOnly(None),
+                CreateStreamIntent::CreateOnly {
+                    config: OptionalStreamConfig::default(),
+                    request_token: None,
+                },
             )
             .await
             .unwrap();

--- a/lite/src/backend/read.rs
+++ b/lite/src/backend/read.rs
@@ -430,12 +430,11 @@ mod tests {
         read_extent::{ReadLimit, ReadUntil},
         record::{Metered, Record},
         types::{
-            basin::BasinName,
+            basin::{BasinName, CreateBasinIntent},
             config::{BasinConfig, OptionalStreamConfig},
-            resources::CreateMode,
             stream::{
-                AppendInput, AppendRecord, AppendRecordBatch, AppendRecordParts, ReadEnd, ReadFrom,
-                ReadSessionOutput, ReadStart,
+                AppendInput, AppendRecord, AppendRecordBatch, AppendRecordParts,
+                CreateStreamIntent, ReadEnd, ReadFrom, ReadSessionOutput, ReadStart,
             },
         },
     };
@@ -563,8 +562,10 @@ mod tests {
         backend
             .create_basin(
                 basin.clone(),
-                BasinConfig::default(),
-                CreateMode::CreateOnly(None),
+                CreateBasinIntent::CreateOnly {
+                    config: BasinConfig::default(),
+                    request_token: None,
+                },
             )
             .await
             .unwrap();
@@ -573,8 +574,10 @@ mod tests {
             .create_stream(
                 basin.clone(),
                 stream.clone(),
-                OptionalStreamConfig::default(),
-                CreateMode::CreateOnly(None),
+                CreateStreamIntent::CreateOnly {
+                    config: OptionalStreamConfig::default(),
+                    request_token: None,
+                },
             )
             .await
             .unwrap();
@@ -636,8 +639,10 @@ mod tests {
         backend
             .create_basin(
                 basin.clone(),
-                BasinConfig::default(),
-                CreateMode::CreateOnly(None),
+                CreateBasinIntent::CreateOnly {
+                    config: BasinConfig::default(),
+                    request_token: None,
+                },
             )
             .await
             .unwrap();
@@ -646,8 +651,10 @@ mod tests {
             .create_stream(
                 basin.clone(),
                 stream.clone(),
-                OptionalStreamConfig::default(),
-                CreateMode::CreateOnly(None),
+                CreateStreamIntent::CreateOnly {
+                    config: OptionalStreamConfig::default(),
+                    request_token: None,
+                },
             )
             .await
             .unwrap();
@@ -715,8 +722,10 @@ mod tests {
         backend
             .create_basin(
                 basin.clone(),
-                BasinConfig::default(),
-                CreateMode::CreateOnly(None),
+                CreateBasinIntent::CreateOnly {
+                    config: BasinConfig::default(),
+                    request_token: None,
+                },
             )
             .await
             .unwrap();
@@ -725,8 +734,10 @@ mod tests {
             .create_stream(
                 basin.clone(),
                 stream.clone(),
-                OptionalStreamConfig::default(),
-                CreateMode::CreateOnly(None),
+                CreateStreamIntent::CreateOnly {
+                    config: OptionalStreamConfig::default(),
+                    request_token: None,
+                },
             )
             .await
             .unwrap();
@@ -868,8 +879,10 @@ mod tests {
         backend
             .create_basin(
                 basin.clone(),
-                BasinConfig::default(),
-                CreateMode::CreateOnly(None),
+                CreateBasinIntent::CreateOnly {
+                    config: BasinConfig::default(),
+                    request_token: None,
+                },
             )
             .await
             .unwrap();
@@ -878,8 +891,10 @@ mod tests {
             .create_stream(
                 basin.clone(),
                 stream.clone(),
-                OptionalStreamConfig::default(),
-                CreateMode::CreateOnly(None),
+                CreateStreamIntent::CreateOnly {
+                    config: OptionalStreamConfig::default(),
+                    request_token: None,
+                },
             )
             .await
             .unwrap();
@@ -958,8 +973,10 @@ mod tests {
         backend
             .create_basin(
                 basin.clone(),
-                BasinConfig::default(),
-                CreateMode::CreateOnly(None),
+                CreateBasinIntent::CreateOnly {
+                    config: BasinConfig::default(),
+                    request_token: None,
+                },
             )
             .await
             .unwrap();
@@ -968,8 +985,10 @@ mod tests {
             .create_stream(
                 basin.clone(),
                 stream.clone(),
-                OptionalStreamConfig::default(),
-                CreateMode::CreateOnly(None),
+                CreateStreamIntent::CreateOnly {
+                    config: OptionalStreamConfig::default(),
+                    request_token: None,
+                },
             )
             .await
             .unwrap();

--- a/lite/src/backend/streams.rs
+++ b/lite/src/backend/streams.rs
@@ -4,8 +4,8 @@ use s2_common::{
     types::{
         basin::BasinName,
         config::{OptionalStreamConfig, StreamReconfiguration},
-        resources::{CreateMode, ListItemsRequestParts, Page, RequestToken},
-        stream::{ListStreamsRequest, StreamInfo, StreamName},
+        resources::{ListItemsRequestParts, Page, RequestToken},
+        stream::{CreateStreamIntent, ListStreamsRequest, StreamInfo, StreamName},
     },
 };
 use slatedb::{
@@ -86,10 +86,8 @@ impl Backend {
         &self,
         basin: BasinName,
         stream: StreamName,
-        config: impl Into<StreamReconfiguration>,
-        mode: CreateMode,
+        intent: CreateStreamIntent,
     ) -> Result<CreatedOrReconfigured<StreamInfo>, CreateStreamError> {
-        let config = config.into();
         let txn = self.db.begin(IsolationLevel::SerializableSnapshot).await?;
 
         let Some(basin_meta) = db_txn_get(
@@ -108,83 +106,114 @@ impl Backend {
 
         let stream_meta_key = kv::stream_meta::ser_key(&basin, &stream);
 
-        let creation_idempotency_key = match &mode {
-            CreateMode::CreateOnly(Some(req_token)) => {
-                let resolved = OptionalStreamConfig::default().reconfigure(config.clone());
-                Some(creation_idempotency_key(req_token, &resolved))
-            }
-            _ => None,
-        };
-
-        let mut existing_meta_opt = None;
-        let mut prior_doe_min_age = None;
-
-        if let Some(existing_meta) =
-            db_txn_get(&txn, &stream_meta_key, kv::stream_meta::deser_value).await?
+        let existing_meta =
+            db_txn_get(&txn, &stream_meta_key, kv::stream_meta::deser_value).await?;
+        if let Some(existing_meta) = &existing_meta
+            && existing_meta.deleted_at.is_some()
         {
-            if existing_meta.deleted_at.is_some() {
-                return Err(CreateStreamError::StreamDeletionPending(
-                    StreamDeletionPendingError { basin, stream },
-                ));
-            }
-            prior_doe_min_age = existing_meta
-                .config
-                .delete_on_empty
-                .min_age
-                .filter(|age| !age.is_zero());
-            match mode {
-                CreateMode::CreateOnly(_) => {
-                    return if creation_idempotency_key.is_some()
-                        && existing_meta.creation_idempotency_key == creation_idempotency_key
-                    {
-                        Ok(CreatedOrReconfigured::Created(StreamInfo {
-                            name: stream,
-                            created_at: existing_meta.created_at,
-                            deleted_at: None,
-                            cipher: existing_meta.cipher,
-                        }))
-                    } else {
-                        Err(StreamAlreadyExistsError { basin, stream }.into())
-                    };
-                }
-                CreateMode::CreateOrReconfigure => {
-                    existing_meta_opt = Some(existing_meta);
-                }
-            }
+            return Err(CreateStreamError::StreamDeletionPending(
+                StreamDeletionPendingError { basin, stream },
+            ));
         }
 
-        let is_reconfigure = existing_meta_opt.is_some();
-        let (resolved, created_at, cipher) = match existing_meta_opt {
-            Some(existing) => (
-                existing.config.reconfigure(config),
-                existing.created_at,
-                existing.cipher,
-            ),
-            None => (
-                OptionalStreamConfig::default().reconfigure(config),
-                OffsetDateTime::now_utc(),
-                basin_meta.config.stream_cipher,
-            ),
-        };
-        let basin_defaults = &basin_meta.config.default_stream_config;
-        let resolved: OptionalStreamConfig = resolved.merge(basin_defaults.clone()).into();
+        struct CreateStreamResolution {
+            meta: kv::stream_meta::StreamMeta,
+            is_reconfigure: bool,
+            prior_doe_min_age: Option<std::time::Duration>,
+        }
 
-        let meta = kv::stream_meta::StreamMeta {
-            config: resolved.clone(),
-            cipher,
-            created_at,
-            deleted_at: None,
-            creation_idempotency_key,
+        let mut resolution = match (existing_meta, intent) {
+            (
+                Some(existing),
+                CreateStreamIntent::CreateOnly {
+                    config,
+                    request_token,
+                },
+            ) => {
+                let new_creation_idempotency_key = request_token
+                    .as_ref()
+                    .map(|req_token| creation_idempotency_key(req_token, &config));
+                return if new_creation_idempotency_key.is_some()
+                    && existing.creation_idempotency_key == new_creation_idempotency_key
+                {
+                    Ok(CreatedOrReconfigured::Created(StreamInfo {
+                        name: stream,
+                        created_at: existing.created_at,
+                        deleted_at: None,
+                        cipher: existing.cipher,
+                    }))
+                } else {
+                    Err(StreamAlreadyExistsError { basin, stream }.into())
+                };
+            }
+            (Some(existing), CreateStreamIntent::CreateOrReconfigure { reconfiguration }) => {
+                let prior_doe_min_age = existing
+                    .config
+                    .delete_on_empty
+                    .min_age
+                    .filter(|age| !age.is_zero());
+                CreateStreamResolution {
+                    meta: kv::stream_meta::StreamMeta {
+                        config: existing.config.reconfigure(reconfiguration),
+                        cipher: existing.cipher,
+                        created_at: existing.created_at,
+                        deleted_at: None,
+                        creation_idempotency_key: existing.creation_idempotency_key,
+                    },
+                    is_reconfigure: true,
+                    prior_doe_min_age,
+                }
+            }
+            (
+                None,
+                CreateStreamIntent::CreateOnly {
+                    config,
+                    request_token,
+                },
+            ) => {
+                let new_creation_idempotency_key = request_token
+                    .as_ref()
+                    .map(|req_token| creation_idempotency_key(req_token, &config));
+                CreateStreamResolution {
+                    meta: kv::stream_meta::StreamMeta {
+                        config,
+                        cipher: basin_meta.config.stream_cipher,
+                        created_at: OffsetDateTime::now_utc(),
+                        deleted_at: None,
+                        creation_idempotency_key: new_creation_idempotency_key,
+                    },
+                    is_reconfigure: false,
+                    prior_doe_min_age: None,
+                }
+            }
+            (None, CreateStreamIntent::CreateOrReconfigure { reconfiguration }) => {
+                CreateStreamResolution {
+                    meta: kv::stream_meta::StreamMeta {
+                        config: OptionalStreamConfig::default().reconfigure(reconfiguration),
+                        cipher: basin_meta.config.stream_cipher,
+                        created_at: OffsetDateTime::now_utc(),
+                        deleted_at: None,
+                        creation_idempotency_key: None,
+                    },
+                    is_reconfigure: false,
+                    prior_doe_min_age: None,
+                }
+            }
         };
+        let basin_defaults = basin_meta.config.default_stream_config;
+        resolution.meta.config = resolution.meta.config.merge(basin_defaults).into();
 
-        txn.put(&stream_meta_key, kv::stream_meta::ser_value(&meta))?;
+        txn.put(
+            &stream_meta_key,
+            kv::stream_meta::ser_value(&resolution.meta),
+        )?;
         let stream_id = StreamId::new(&basin, &stream);
-        if !is_reconfigure {
+        if !resolution.is_reconfigure {
             txn.put(
                 kv::stream_id_mapping::ser_key(stream_id),
                 kv::stream_id_mapping::ser_value(&basin, &stream),
             )?;
-            let created_secs = created_at.unix_timestamp();
+            let created_secs = resolution.meta.created_at.unix_timestamp();
             let created_secs = if created_secs <= 0 {
                 0
             } else if created_secs >= i64::from(u32::MAX) {
@@ -200,17 +229,18 @@ impl Backend {
                 ),
             )?;
         }
-        if let Some(min_age) = meta
+        if let Some(min_age) = resolution
+            .meta
             .config
             .delete_on_empty
             .min_age
             .filter(|age| !age.is_zero())
-            && (!is_reconfigure || prior_doe_min_age.is_none())
+            && (!resolution.is_reconfigure || resolution.prior_doe_min_age.is_none())
         {
             txn.put(
                 kv::stream_doe_deadline::ser_key(
                     kv::timestamp::TimestampSecs::after(doe_arm_delay(
-                        retention_age_or_zero(&meta.config),
+                        retention_age_or_zero(&resolution.meta.config),
                         min_age,
                     )),
                     stream_id,
@@ -224,15 +254,18 @@ impl Backend {
         };
         txn.commit_with_options(&WRITE_OPTS).await?;
 
-        if is_reconfigure && let Some(client) = self.streamer_client_if_active(&basin, &stream) {
-            client.advise_reconfig(resolved);
+        if resolution.is_reconfigure
+            && let Some(client) = self.streamer_client_if_active(&basin, &stream)
+        {
+            client.advise_reconfig(resolution.meta.config.clone());
         }
 
+        let is_reconfigure = resolution.is_reconfigure;
         let info = StreamInfo {
             name: stream,
-            created_at,
+            created_at: resolution.meta.created_at,
             deleted_at: None,
-            cipher,
+            cipher: resolution.meta.cipher,
         };
 
         Ok(if is_reconfigure {

--- a/lite/src/backend/streams.rs
+++ b/lite/src/backend/streams.rs
@@ -116,13 +116,7 @@ impl Backend {
             ));
         }
 
-        struct CreateStreamResolution {
-            meta: kv::stream_meta::StreamMeta,
-            is_reconfigure: bool,
-            prior_doe_min_age: Option<std::time::Duration>,
-        }
-
-        let mut resolution = match (existing_meta, intent) {
+        let (mut meta, is_reconfigure, prior_doe_min_age) = match (existing_meta, intent) {
             (
                 Some(existing),
                 CreateStreamIntent::CreateOnly {
@@ -152,17 +146,17 @@ impl Backend {
                     .delete_on_empty
                     .min_age
                     .filter(|age| !age.is_zero());
-                CreateStreamResolution {
-                    meta: kv::stream_meta::StreamMeta {
+                (
+                    kv::stream_meta::StreamMeta {
                         config: existing.config.reconfigure(reconfiguration),
                         cipher: existing.cipher,
                         created_at: existing.created_at,
                         deleted_at: None,
                         creation_idempotency_key: existing.creation_idempotency_key,
                     },
-                    is_reconfigure: true,
+                    true,
                     prior_doe_min_age,
-                }
+                )
             }
             (
                 None,
@@ -174,46 +168,41 @@ impl Backend {
                 let new_creation_idempotency_key = request_token
                     .as_ref()
                     .map(|req_token| creation_idempotency_key(req_token, &config));
-                CreateStreamResolution {
-                    meta: kv::stream_meta::StreamMeta {
+                (
+                    kv::stream_meta::StreamMeta {
                         config,
                         cipher: basin_meta.config.stream_cipher,
                         created_at: OffsetDateTime::now_utc(),
                         deleted_at: None,
                         creation_idempotency_key: new_creation_idempotency_key,
                     },
-                    is_reconfigure: false,
-                    prior_doe_min_age: None,
-                }
+                    false,
+                    None,
+                )
             }
-            (None, CreateStreamIntent::CreateOrReconfigure { reconfiguration }) => {
-                CreateStreamResolution {
-                    meta: kv::stream_meta::StreamMeta {
-                        config: OptionalStreamConfig::default().reconfigure(reconfiguration),
-                        cipher: basin_meta.config.stream_cipher,
-                        created_at: OffsetDateTime::now_utc(),
-                        deleted_at: None,
-                        creation_idempotency_key: None,
-                    },
-                    is_reconfigure: false,
-                    prior_doe_min_age: None,
-                }
-            }
+            (None, CreateStreamIntent::CreateOrReconfigure { reconfiguration }) => (
+                kv::stream_meta::StreamMeta {
+                    config: OptionalStreamConfig::default().reconfigure(reconfiguration),
+                    cipher: basin_meta.config.stream_cipher,
+                    created_at: OffsetDateTime::now_utc(),
+                    deleted_at: None,
+                    creation_idempotency_key: None,
+                },
+                false,
+                None,
+            ),
         };
         let basin_defaults = basin_meta.config.default_stream_config;
-        resolution.meta.config = resolution.meta.config.merge(basin_defaults).into();
+        meta.config = meta.config.merge(basin_defaults).into();
 
-        txn.put(
-            &stream_meta_key,
-            kv::stream_meta::ser_value(&resolution.meta),
-        )?;
+        txn.put(&stream_meta_key, kv::stream_meta::ser_value(&meta))?;
         let stream_id = StreamId::new(&basin, &stream);
-        if !resolution.is_reconfigure {
+        if !is_reconfigure {
             txn.put(
                 kv::stream_id_mapping::ser_key(stream_id),
                 kv::stream_id_mapping::ser_value(&basin, &stream),
             )?;
-            let created_secs = resolution.meta.created_at.unix_timestamp();
+            let created_secs = meta.created_at.unix_timestamp();
             let created_secs = if created_secs <= 0 {
                 0
             } else if created_secs >= i64::from(u32::MAX) {
@@ -229,18 +218,17 @@ impl Backend {
                 ),
             )?;
         }
-        if let Some(min_age) = resolution
-            .meta
+        if let Some(min_age) = meta
             .config
             .delete_on_empty
             .min_age
             .filter(|age| !age.is_zero())
-            && (!resolution.is_reconfigure || resolution.prior_doe_min_age.is_none())
+            && (!is_reconfigure || prior_doe_min_age.is_none())
         {
             txn.put(
                 kv::stream_doe_deadline::ser_key(
                     kv::timestamp::TimestampSecs::after(doe_arm_delay(
-                        retention_age_or_zero(&resolution.meta.config),
+                        retention_age_or_zero(&meta.config),
                         min_age,
                     )),
                     stream_id,
@@ -254,18 +242,15 @@ impl Backend {
         };
         txn.commit_with_options(&WRITE_OPTS).await?;
 
-        if resolution.is_reconfigure
-            && let Some(client) = self.streamer_client_if_active(&basin, &stream)
-        {
-            client.advise_reconfig(resolution.meta.config.clone());
+        if is_reconfigure && let Some(client) = self.streamer_client_if_active(&basin, &stream) {
+            client.advise_reconfig(meta.config.clone());
         }
 
-        let is_reconfigure = resolution.is_reconfigure;
         let info = StreamInfo {
             name: stream,
-            created_at: resolution.meta.created_at,
+            created_at: meta.created_at,
             deleted_at: None,
-            cipher: resolution.meta.cipher,
+            cipher: meta.cipher,
         };
 
         Ok(if is_reconfigure {

--- a/lite/src/handlers/v1/basins.rs
+++ b/lite/src/handlers/v1/basins.rs
@@ -7,9 +7,9 @@ use s2_api::{
 use s2_common::{
     http::extract::HeaderOpt,
     types::{
-        basin::{BasinName, ListBasinsRequest},
+        basin::{BasinName, CreateBasinIntent, ListBasinsRequest},
         config::{BasinConfig, BasinReconfiguration},
-        resources::{CreateMode, Page, RequestToken},
+        resources::{Page, RequestToken},
     },
 };
 
@@ -98,7 +98,13 @@ pub async fn create_basin(
         .transpose()?
         .unwrap_or_default();
     let info = backend
-        .create_basin(request.basin, config, CreateMode::CreateOnly(request_token))
+        .create_basin(
+            request.basin,
+            CreateBasinIntent::CreateOnly {
+                config,
+                request_token,
+            },
+        )
         .await?;
     Ok((StatusCode::CREATED, Json(info.into_inner().into())))
 }
@@ -161,13 +167,16 @@ pub async fn create_or_reconfigure_basin(
         request: JsonOpt(request),
     }: CreateOrReconfigureArgs,
 ) -> Result<(StatusCode, Json<v1t::basin::BasinInfo>), ServiceError> {
-    let config: BasinReconfiguration = request
+    let reconfiguration: BasinReconfiguration = request
         .and_then(|req| req.config)
         .map(TryInto::try_into)
         .transpose()?
         .unwrap_or_default();
     let info = backend
-        .create_basin(basin, config, CreateMode::CreateOrReconfigure)
+        .create_basin(
+            basin,
+            CreateBasinIntent::CreateOrReconfigure { reconfiguration },
+        )
         .await?;
     let status = if info.is_created() {
         StatusCode::CREATED

--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -468,12 +468,12 @@ mod tests {
         read_extent::{ReadLimit, ReadUntil},
         record::{EnvelopeRecord, Metered, Record},
         types::{
-            basin::{BASIN_HEADER, BasinName},
+            basin::{BASIN_HEADER, BasinName, CreateBasinIntent},
             config::{BasinConfig, OptionalStreamConfig},
-            resources::CreateMode,
             stream::{
                 AppendInput, AppendRecord, AppendRecordBatch, AppendRecordParts,
-                ListStreamsRequest, ReadEnd, ReadFrom, ReadSessionOutput, ReadStart, StreamName,
+                CreateStreamIntent, ListStreamsRequest, ReadEnd, ReadFrom, ReadSessionOutput,
+                ReadStart, StreamName,
             },
         },
     };
@@ -518,7 +518,13 @@ mod tests {
         let backend = create_backend().await;
         let basin: BasinName = format!("test-basin-{test_suffix}").parse().unwrap();
         backend
-            .create_basin(basin.clone(), basin_config, CreateMode::CreateOnly(None))
+            .create_basin(
+                basin.clone(),
+                CreateBasinIntent::CreateOnly {
+                    config: basin_config,
+                    request_token: None,
+                },
+            )
             .await
             .expect("create basin");
         let stream: StreamName = format!("test-stream-{test_suffix}").parse().unwrap();
@@ -526,8 +532,10 @@ mod tests {
             .create_stream(
                 basin.clone(),
                 stream.clone(),
-                stream_config,
-                CreateMode::CreateOnly(None),
+                CreateStreamIntent::CreateOnly {
+                    config: stream_config,
+                    request_token: None,
+                },
             )
             .await
             .expect("create stream");
@@ -542,7 +550,13 @@ mod tests {
         let backend = create_backend().await;
         let basin: BasinName = format!("test-basin-{test_suffix}").parse().unwrap();
         backend
-            .create_basin(basin.clone(), basin_config, CreateMode::CreateOnly(None))
+            .create_basin(
+                basin.clone(),
+                CreateBasinIntent::CreateOnly {
+                    config: basin_config,
+                    request_token: None,
+                },
+            )
             .await
             .expect("create basin");
         let stream: StreamName = format!("test-stream-{test_suffix}").parse().unwrap();

--- a/lite/src/handlers/v1/streams.rs
+++ b/lite/src/handlers/v1/streams.rs
@@ -9,8 +9,8 @@ use s2_common::{
     types::{
         basin::BasinName,
         config::{OptionalStreamConfig, StreamReconfiguration},
-        resources::{CreateMode, Page, RequestToken},
-        stream::{ListStreamsRequest, StreamName},
+        resources::{Page, RequestToken},
+        stream::{CreateStreamIntent, ListStreamsRequest, StreamName},
     },
 };
 
@@ -125,8 +125,10 @@ pub async fn create_stream(
         .create_stream(
             basin,
             request.stream,
-            config,
-            CreateMode::CreateOnly(request_token),
+            CreateStreamIntent::CreateOnly {
+                config,
+                request_token,
+            },
         )
         .await?;
     Ok((StatusCode::CREATED, Json(info.into_inner().into())))
@@ -215,12 +217,16 @@ pub async fn create_or_reconfigure_stream(
         config: JsonOpt(config),
     }: CreateOrReconfigureArgs,
 ) -> Result<(StatusCode, Json<v1t::stream::StreamInfo>), ServiceError> {
-    let config: StreamReconfiguration = config
+    let reconfiguration: StreamReconfiguration = config
         .map(TryInto::try_into)
         .transpose()?
         .unwrap_or_default();
     let info = backend
-        .create_stream(basin, stream, config, CreateMode::CreateOrReconfigure)
+        .create_stream(
+            basin,
+            stream,
+            CreateStreamIntent::CreateOrReconfigure { reconfiguration },
+        )
         .await?;
     let status = if info.is_created() {
         StatusCode::CREATED

--- a/lite/src/init.rs
+++ b/lite/src/init.rs
@@ -7,13 +7,12 @@ use std::{borrow::Cow, path::Path, time::Duration};
 use s2_common::{
     maybe::Maybe,
     types::{
-        basin::BasinName,
+        basin::{BasinName, CreateBasinIntent},
         config::{
             BasinReconfiguration, DeleteOnEmptyReconfiguration, RetentionPolicy, StorageClass,
             StreamReconfiguration, TimestampingMode, TimestampingReconfiguration,
         },
-        resources::CreateMode,
-        stream::StreamName,
+        stream::{CreateStreamIntent, StreamName},
     },
 };
 use serde::{Deserialize, Serialize};
@@ -402,8 +401,7 @@ pub async fn apply(backend: &Backend, spec: ResourcesSpec) -> eyre::Result<()> {
         backend
             .create_basin(
                 basin.clone(),
-                reconfiguration,
-                CreateMode::CreateOrReconfigure,
+                CreateBasinIntent::CreateOrReconfigure { reconfiguration },
             )
             .await
             .map_err(|e| eyre::eyre!("failed to apply basin {:?}: {}", basin.as_ref(), e))?;
@@ -425,8 +423,7 @@ pub async fn apply(backend: &Backend, spec: ResourcesSpec) -> eyre::Result<()> {
                 .create_stream(
                     basin.clone(),
                     stream.clone(),
-                    reconfiguration,
-                    CreateMode::CreateOrReconfigure,
+                    CreateStreamIntent::CreateOrReconfigure { reconfiguration },
                 )
                 .await
                 .map_err(|e| {

--- a/lite/tests/backend/common/setup.rs
+++ b/lite/tests/backend/common/setup.rs
@@ -6,10 +6,12 @@ use s2_common::{
     encryption::{EncryptionAlgorithm, EncryptionKey, EncryptionSpec},
     record::{CommandRecord, FencingToken, Metered, Record, Timestamp},
     types::{
-        basin::BasinName,
+        basin::{BasinName, CreateBasinIntent},
         config::{BasinConfig, OptionalStreamConfig},
-        resources::CreateMode,
-        stream::{AppendInput, AppendRecord, AppendRecordBatch, AppendRecordParts, StreamName},
+        stream::{
+            AppendInput, AppendRecord, AppendRecordBatch, AppendRecordParts, CreateStreamIntent,
+            StreamName,
+        },
     },
 };
 use s2_lite::backend::Backend;
@@ -151,7 +153,13 @@ pub fn create_test_record_batch_with_timestamps(
 pub async fn create_test_basin(backend: &Backend, suffix: &str, config: BasinConfig) -> BasinName {
     let basin_name = test_basin_name(suffix);
     backend
-        .create_basin(basin_name.clone(), config, CreateMode::CreateOnly(None))
+        .create_basin(
+            basin_name.clone(),
+            CreateBasinIntent::CreateOnly {
+                config,
+                request_token: None,
+            },
+        )
         .await
         .expect("Failed to create basin");
     basin_name
@@ -168,8 +176,10 @@ pub async fn create_test_stream(
         .create_stream(
             basin.clone(),
             stream_name.clone(),
-            config,
-            CreateMode::CreateOnly(None),
+            CreateStreamIntent::CreateOnly {
+                config,
+                request_token: None,
+            },
         )
         .await
         .expect("Failed to create stream");

--- a/lite/tests/backend/control_plane/basin.rs
+++ b/lite/tests/backend/control_plane/basin.rs
@@ -1,12 +1,12 @@
 use s2_common::{
     maybe::Maybe,
     types::{
-        basin::{BasinNamePrefix, BasinNameStartAfter, ListBasinsRequest},
+        basin::{BasinNamePrefix, BasinNameStartAfter, CreateBasinIntent, ListBasinsRequest},
         config::{
-            BasinConfig, BasinReconfiguration, RetentionPolicy, StorageClass,
+            BasinConfig, BasinReconfiguration, OptionalStreamConfig, RetentionPolicy, StorageClass,
             StreamReconfiguration, TimestampingMode, TimestampingReconfiguration,
         },
-        resources::{CreateMode, ListItemsRequestParts, RequestToken},
+        resources::{ListItemsRequestParts, RequestToken},
     },
 };
 use s2_lite::backend::{
@@ -30,8 +30,10 @@ async fn test_create_basin_idempotency_respects_request_token() {
     let created = backend
         .create_basin(
             basin_name.clone(),
-            config.clone(),
-            CreateMode::CreateOnly(Some(token1.clone())),
+            CreateBasinIntent::CreateOnly {
+                config: config.clone(),
+                request_token: Some(token1.clone()),
+            },
         )
         .await
         .expect("Failed to create basin");
@@ -44,8 +46,10 @@ async fn test_create_basin_idempotency_respects_request_token() {
     let idempotent = backend
         .create_basin(
             basin_name.clone(),
-            config.clone(),
-            CreateMode::CreateOnly(Some(token1.clone())),
+            CreateBasinIntent::CreateOnly {
+                config: config.clone(),
+                request_token: Some(token1.clone()),
+            },
         )
         .await
         .expect("Idempotent create should succeed with same request token");
@@ -59,8 +63,10 @@ async fn test_create_basin_idempotency_respects_request_token() {
     let different_token_result = backend
         .create_basin(
             basin_name.clone(),
-            config.clone(),
-            CreateMode::CreateOnly(Some(different_token)),
+            CreateBasinIntent::CreateOnly {
+                config: config.clone(),
+                request_token: Some(different_token),
+            },
         )
         .await;
     assert!(matches!(
@@ -73,8 +79,10 @@ async fn test_create_basin_idempotency_respects_request_token() {
     let different_config_result = backend
         .create_basin(
             basin_name,
-            different_config,
-            CreateMode::CreateOnly(Some(token1)),
+            CreateBasinIntent::CreateOnly {
+                config: different_config,
+                request_token: Some(token1),
+            },
         )
         .await;
     assert!(matches!(
@@ -97,8 +105,10 @@ async fn test_create_or_reconfigure_preserves_idempotency_key() {
     backend
         .create_basin(
             basin_name.clone(),
-            config.clone(),
-            CreateMode::CreateOnly(Some(token.clone())),
+            CreateBasinIntent::CreateOnly {
+                config: config.clone(),
+                request_token: Some(token.clone()),
+            },
         )
         .await
         .expect("Failed to create basin");
@@ -106,19 +116,22 @@ async fn test_create_or_reconfigure_preserves_idempotency_key() {
     backend
         .create_basin(
             basin_name.clone(),
-            config.clone(),
-            CreateMode::CreateOnly(Some(token.clone())),
+            CreateBasinIntent::CreateOnly {
+                config: config.clone(),
+                request_token: Some(token.clone()),
+            },
         )
         .await
         .expect("Idempotency should work before CreateOrReconfigure");
 
-    let mut updated_config = config.clone();
-    updated_config.create_stream_on_read = true;
+    let reconfiguration = BasinReconfiguration {
+        create_stream_on_read: Maybe::from(true),
+        ..Default::default()
+    };
     backend
         .create_basin(
             basin_name.clone(),
-            updated_config,
-            CreateMode::CreateOrReconfigure,
+            CreateBasinIntent::CreateOrReconfigure { reconfiguration },
         )
         .await
         .expect("CreateOrReconfigure should succeed");
@@ -126,8 +139,10 @@ async fn test_create_or_reconfigure_preserves_idempotency_key() {
     backend
         .create_basin(
             basin_name.clone(),
-            config.clone(),
-            CreateMode::CreateOnly(Some(token.clone())),
+            CreateBasinIntent::CreateOnly {
+                config: config.clone(),
+                request_token: Some(token.clone()),
+            },
         )
         .await
         .expect("Idempotency should still work after CreateOrReconfigure");
@@ -146,8 +161,10 @@ async fn test_create_basin_create_or_reconfigure_updates_config() {
     backend
         .create_basin(
             basin_name.clone(),
-            initial_config.clone(),
-            CreateMode::CreateOnly(None),
+            CreateBasinIntent::CreateOnly {
+                config: initial_config.clone(),
+                request_token: None,
+            },
         )
         .await
         .expect("Failed to create basin");
@@ -160,8 +177,9 @@ async fn test_create_basin_create_or_reconfigure_updates_config() {
     backend
         .create_basin(
             basin_name.clone(),
-            updated_config.clone(),
-            CreateMode::CreateOrReconfigure,
+            CreateBasinIntent::CreateOrReconfigure {
+                reconfiguration: updated_config.clone().into(),
+            },
         )
         .await
         .expect("CreateOrReconfigure should update basin config");
@@ -180,11 +198,68 @@ async fn test_create_basin_create_or_reconfigure_updates_config() {
     backend
         .create_basin(
             basin_name.clone(),
-            updated_config,
-            CreateMode::CreateOnly(None),
+            CreateBasinIntent::CreateOnly {
+                config: updated_config,
+                request_token: None,
+            },
         )
         .await
         .expect_err("CreateOnly without request token should not be idempotent");
+}
+
+#[tokio::test]
+async fn test_create_basin_create_or_reconfigure_preserves_unspecified_config() {
+    let backend = create_backend().await;
+    let basin_name = test_basin_name("basin-reconfigure-preserve");
+    let initial_config = BasinConfig {
+        create_stream_on_append: true,
+        create_stream_on_read: false,
+        default_stream_config: OptionalStreamConfig {
+            storage_class: Some(StorageClass::Standard),
+            retention_policy: Some(RetentionPolicy::Infinite()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    backend
+        .create_basin(
+            basin_name.clone(),
+            CreateBasinIntent::CreateOnly {
+                config: initial_config,
+                request_token: None,
+            },
+        )
+        .await
+        .expect("Failed to create basin");
+
+    backend
+        .create_basin(
+            basin_name.clone(),
+            CreateBasinIntent::CreateOrReconfigure {
+                reconfiguration: BasinReconfiguration {
+                    create_stream_on_read: Maybe::from(true),
+                    ..Default::default()
+                },
+            },
+        )
+        .await
+        .expect("CreateOrReconfigure should preserve unspecified fields");
+
+    let stored_config = backend
+        .get_basin_config(basin_name)
+        .await
+        .expect("Failed to fetch basin config");
+    assert!(stored_config.create_stream_on_append);
+    assert!(stored_config.create_stream_on_read);
+    assert_eq!(
+        stored_config.default_stream_config.storage_class,
+        Some(StorageClass::Standard)
+    );
+    assert_eq!(
+        stored_config.default_stream_config.retention_policy,
+        Some(RetentionPolicy::Infinite())
+    );
 }
 
 #[tokio::test]
@@ -197,8 +272,10 @@ async fn test_reconfigure_basin_updates_nested_defaults() {
     backend
         .create_basin(
             basin_name.clone(),
-            initial_config.clone(),
-            CreateMode::CreateOnly(None),
+            CreateBasinIntent::CreateOnly {
+                config: initial_config.clone(),
+                request_token: None,
+            },
         )
         .await
         .expect("Failed to create basin");
@@ -269,8 +346,10 @@ async fn test_delete_basin_marks_deleting_and_blocks_create() {
     backend
         .create_basin(
             basin_name.clone(),
-            BasinConfig::default(),
-            CreateMode::CreateOnly(None),
+            CreateBasinIntent::CreateOnly {
+                config: BasinConfig::default(),
+                request_token: None,
+            },
         )
         .await
         .expect("Failed to create basin");
@@ -302,8 +381,10 @@ async fn test_delete_basin_marks_deleting_and_blocks_create() {
     let recreate_result = backend
         .create_basin(
             basin_name.clone(),
-            BasinConfig::default(),
-            CreateMode::CreateOnly(None),
+            CreateBasinIntent::CreateOnly {
+                config: BasinConfig::default(),
+                request_token: None,
+            },
         )
         .await;
     assert!(matches!(

--- a/lite/tests/backend/control_plane/stream.rs
+++ b/lite/tests/backend/control_plane/stream.rs
@@ -5,15 +5,16 @@ use s2_common::{
     encryption::EncryptionAlgorithm,
     maybe::Maybe,
     types::{
+        basin::CreateBasinIntent,
         config::{
             BasinConfig, BasinReconfiguration, OptionalStreamConfig, OptionalTimestampingConfig,
             RetentionPolicy, StorageClass, StreamReconfiguration, TimestampingMode,
             TimestampingReconfiguration,
         },
-        resources::{CreateMode, ListItemsRequestParts, RequestToken},
+        resources::{ListItemsRequestParts, RequestToken},
         stream::{
-            AppendInput, ListStreamsRequest, ReadEnd, ReadFrom, ReadStart, StreamNamePrefix,
-            StreamNameStartAfter,
+            AppendInput, CreateStreamIntent, ListStreamsRequest, ReadEnd, ReadFrom, ReadStart,
+            StreamNamePrefix, StreamNameStartAfter,
         },
     },
 };
@@ -45,8 +46,10 @@ async fn test_create_stream_honors_basin_defaults() {
     backend
         .create_basin(
             basin_name.clone(),
-            basin_config,
-            CreateMode::CreateOnly(None),
+            CreateBasinIntent::CreateOnly {
+                config: basin_config,
+                request_token: None,
+            },
         )
         .await
         .expect("Failed to create basin");
@@ -57,8 +60,10 @@ async fn test_create_stream_honors_basin_defaults() {
         .create_stream(
             basin_name.clone(),
             stream_name.clone(),
-            OptionalStreamConfig::default(),
-            CreateMode::CreateOnly(None),
+            CreateStreamIntent::CreateOnly {
+                config: OptionalStreamConfig::default(),
+                request_token: None,
+            },
         )
         .await
         .expect("Failed to create stream");
@@ -222,8 +227,10 @@ async fn test_create_stream_idempotency_and_request_token() {
         .create_stream(
             basin_name.clone(),
             stream_name.clone(),
-            config.clone(),
-            CreateMode::CreateOnly(Some(token1.clone())),
+            CreateStreamIntent::CreateOnly {
+                config: config.clone(),
+                request_token: Some(token1.clone()),
+            },
         )
         .await
         .expect("Failed to create stream");
@@ -238,8 +245,10 @@ async fn test_create_stream_idempotency_and_request_token() {
         .create_stream(
             basin_name.clone(),
             stream_name.clone(),
-            config.clone(),
-            CreateMode::CreateOnly(Some(token1.clone())),
+            CreateStreamIntent::CreateOnly {
+                config: config.clone(),
+                request_token: Some(token1.clone()),
+            },
         )
         .await
         .expect("Idempotent create should succeed with same request token");
@@ -248,8 +257,10 @@ async fn test_create_stream_idempotency_and_request_token() {
         .create_stream(
             basin_name.clone(),
             stream_name.clone(),
-            config.clone(),
-            CreateMode::CreateOnly(Some("stream-token-2".parse().unwrap())),
+            CreateStreamIntent::CreateOnly {
+                config: config.clone(),
+                request_token: Some("stream-token-2".parse().unwrap()),
+            },
         )
         .await;
     assert!(matches!(
@@ -263,14 +274,97 @@ async fn test_create_stream_idempotency_and_request_token() {
         .create_stream(
             basin_name.clone(),
             stream_name.clone(),
-            different_config,
-            CreateMode::CreateOnly(Some(token1)),
+            CreateStreamIntent::CreateOnly {
+                config: different_config,
+                request_token: Some(token1),
+            },
         )
         .await;
     assert!(matches!(
         different_config_result,
         Err(CreateStreamError::StreamAlreadyExists(_))
     ));
+}
+
+#[tokio::test]
+async fn test_create_stream_create_or_reconfigure_preserves_idempotency_key() {
+    let backend = create_backend().await;
+    let basin_name = create_test_basin(
+        &backend,
+        "stream-idempotency-key-preserve",
+        BasinConfig::default(),
+    )
+    .await;
+    let stream_name = test_stream_name("stream-idempotency-key-preserve");
+
+    let config = OptionalStreamConfig {
+        storage_class: Some(StorageClass::Express),
+        ..Default::default()
+    };
+    let token: RequestToken = "stream-token-preserve".parse().unwrap();
+
+    backend
+        .create_stream(
+            basin_name.clone(),
+            stream_name.clone(),
+            CreateStreamIntent::CreateOnly {
+                config: config.clone(),
+                request_token: Some(token.clone()),
+            },
+        )
+        .await
+        .expect("Failed to create stream");
+
+    backend
+        .create_stream(
+            basin_name.clone(),
+            stream_name.clone(),
+            CreateStreamIntent::CreateOnly {
+                config: config.clone(),
+                request_token: Some(token.clone()),
+            },
+        )
+        .await
+        .expect("Idempotency should work before CreateOrReconfigure");
+
+    backend
+        .create_stream(
+            basin_name.clone(),
+            stream_name.clone(),
+            CreateStreamIntent::CreateOrReconfigure {
+                reconfiguration: StreamReconfiguration {
+                    timestamping: Maybe::from(Some(TimestampingReconfiguration {
+                        mode: Maybe::from(Some(TimestampingMode::Arrival)),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            },
+        )
+        .await
+        .expect("CreateOrReconfigure should succeed");
+
+    let stored_config = backend
+        .get_stream_config(basin_name.clone(), stream_name.clone())
+        .await
+        .expect("Failed to fetch stream config");
+    assert_eq!(stored_config.storage_class, Some(StorageClass::Express));
+    assert_eq!(
+        stored_config.timestamping.mode,
+        Some(TimestampingMode::Arrival)
+    );
+
+    backend
+        .create_stream(
+            basin_name,
+            stream_name,
+            CreateStreamIntent::CreateOnly {
+                config,
+                request_token: Some(token),
+            },
+        )
+        .await
+        .expect("Idempotency should still work after CreateOrReconfigure");
 }
 
 #[tokio::test]
@@ -284,8 +378,10 @@ async fn test_reconfigure_stream_updates_selected_fields() {
     backend
         .create_basin(
             basin_name.clone(),
-            basin_config,
-            CreateMode::CreateOnly(None),
+            CreateBasinIntent::CreateOnly {
+                config: basin_config,
+                request_token: None,
+            },
         )
         .await
         .expect("Failed to create basin");
@@ -304,8 +400,10 @@ async fn test_reconfigure_stream_updates_selected_fields() {
         .create_stream(
             basin_name.clone(),
             stream_name.clone(),
-            initial_config,
-            CreateMode::CreateOnly(None),
+            CreateStreamIntent::CreateOnly {
+                config: initial_config,
+                request_token: None,
+            },
         )
         .await
         .expect("Failed to create stream");
@@ -390,11 +488,11 @@ async fn test_create_stream_create_or_reconfigure_updates_active_streamer() {
 
     append_payloads(&backend, &basin_name, &stream_name, &[b"seed"]).await;
 
-    let config = OptionalStreamConfig {
-        timestamping: OptionalTimestampingConfig {
-            mode: Some(TimestampingMode::ClientRequire),
+    let reconfiguration = StreamReconfiguration {
+        timestamping: Maybe::from(Some(TimestampingReconfiguration {
+            mode: Maybe::from(Some(TimestampingMode::ClientRequire)),
             ..Default::default()
-        },
+        })),
         ..Default::default()
     };
 
@@ -402,8 +500,7 @@ async fn test_create_stream_create_or_reconfigure_updates_active_streamer() {
         .create_stream(
             basin_name.clone(),
             stream_name.clone(),
-            config,
-            CreateMode::CreateOrReconfigure,
+            CreateStreamIntent::CreateOrReconfigure { reconfiguration },
         )
         .await
         .expect("CreateOrReconfigure should succeed for an existing stream");
@@ -437,8 +534,10 @@ async fn test_create_stream_fails_when_basin_deleting() {
         .create_stream(
             basin_name,
             stream_name,
-            OptionalStreamConfig::default(),
-            CreateMode::CreateOnly(None),
+            CreateStreamIntent::CreateOnly {
+                config: OptionalStreamConfig::default(),
+                request_token: None,
+            },
         )
         .await;
 
@@ -482,8 +581,10 @@ async fn test_delete_stream_marks_deleted_and_blocks_recreation() {
         .create_stream(
             basin_name.clone(),
             stream_name.clone(),
-            OptionalStreamConfig::default(),
-            CreateMode::CreateOnly(None),
+            CreateStreamIntent::CreateOnly {
+                config: OptionalStreamConfig::default(),
+                request_token: None,
+            },
         )
         .await;
     assert!(matches!(


### PR DESCRIPTION
## Summary

- add basin and stream create intent types under `s2_common::types` and remove the shared `CreateMode` enum
- update Lite create paths to use operation-specific payloads so create-only carries full config and create-or-reconfigure carries only reconfiguration patches
- preserve existing create idempotency metadata when reconfiguring existing resources and cover the behavior with regressions

## Tests

- `cargo check -p s2-lite --tests`
- `just fmt`
- `just test` (472/472 passed; nextest reported 1 leaky test while exiting successfully)