### PR TITLE
fix: preserve explicit optional config values

### DIFF
--- a/api/src/v1/config.rs
+++ b/api/src/v1/config.rs
@@ -202,14 +202,9 @@ pub struct DeleteOnEmptyConfig {
 
 impl DeleteOnEmptyConfig {
     pub fn to_opt(config: types::config::OptionalDeleteOnEmptyConfig) -> Option<Self> {
-        let min_age = config.min_age.unwrap_or_default();
-        if min_age > Duration::ZERO {
-            Some(DeleteOnEmptyConfig {
-                min_age_secs: min_age.as_secs(),
-            })
-        } else {
-            None
-        }
+        config.min_age.map(|min_age| DeleteOnEmptyConfig {
+            min_age_secs: min_age.as_secs(),
+        })
     }
 }
 
@@ -1026,13 +1021,9 @@ mod tests {
         // default stream config -> None
         assert!(StreamConfig::to_opt(types::config::OptionalStreamConfig::default()).is_none());
 
-        // delete_on_empty: None or Some(ZERO) -> None
+        // delete_on_empty: None -> None
         let doe_none = types::config::OptionalDeleteOnEmptyConfig { min_age: None };
-        let doe_zero = types::config::OptionalDeleteOnEmptyConfig {
-            min_age: Some(Duration::ZERO),
-        };
         assert!(DeleteOnEmptyConfig::to_opt(doe_none).is_none());
-        assert!(DeleteOnEmptyConfig::to_opt(doe_zero).is_none());
 
         // default timestamping -> None
         assert!(
@@ -1050,6 +1041,22 @@ mod tests {
             ..Default::default()
         }
         .into();
+
+        assert_eq!(
+            api.delete_on_empty,
+            Some(DeleteOnEmptyConfig { min_age_secs: 0 })
+        );
+    }
+
+    #[test]
+    fn optional_stream_config_to_opt_preserves_explicit_zero_delete_on_empty() {
+        let api = StreamConfig::to_opt(types::config::OptionalStreamConfig {
+            delete_on_empty: types::config::OptionalDeleteOnEmptyConfig {
+                min_age: Some(Duration::ZERO),
+            },
+            ..Default::default()
+        })
+        .unwrap();
 
         assert_eq!(
             api.delete_on_empty,

--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -1720,7 +1720,7 @@ impl App {
                                 *retention_policy = RetentionPolicyOption::Infinite;
                             }
                             *timestamping_mode = info.timestamping_mode;
-                            *timestamping_uncapped = Some(info.timestamping_uncapped);
+                            *timestamping_uncapped = info.timestamping_uncapped;
                         }
                         Err(e) => {
                             self.input_mode = InputMode::Normal;
@@ -1757,7 +1757,7 @@ impl App {
                                 *retention_policy = RetentionPolicyOption::Infinite;
                             }
                             *timestamping_mode = info.timestamping_mode;
-                            *timestamping_uncapped = Some(info.timestamping_uncapped);
+                            *timestamping_uncapped = info.timestamping_uncapped;
 
                             if let Some(min_age_secs) = info.delete_on_empty_min_age_secs {
                                 *delete_on_empty_enabled = true;
@@ -4881,11 +4881,10 @@ impl App {
                         let ts_uncapped = default_config
                             .timestamping
                             .as_ref()
-                            .map(|t| t.uncapped)
-                            .unwrap_or(false);
+                            .and_then(|t| t.uncapped);
                         (sc, age, ts_mode, ts_uncapped)
                     } else {
-                        (None, None, None, false)
+                        (None, None, None, None)
                     };
 
                     let info = BasinConfigInfo {
@@ -4925,11 +4924,8 @@ impl App {
                         .timestamping
                         .as_ref()
                         .and_then(|t| t.mode.map(TimestampingMode::from));
-                    let timestamping_uncapped = config
-                        .timestamping
-                        .as_ref()
-                        .map(|t| t.uncapped)
-                        .unwrap_or(false);
+                    let timestamping_uncapped =
+                        config.timestamping.as_ref().and_then(|t| t.uncapped);
                     let delete_on_empty_min_age_secs =
                         config.delete_on_empty.map(|d| d.min_age_secs);
 

--- a/cli/src/tui/event.rs
+++ b/cli/src/tui/event.rs
@@ -18,7 +18,7 @@ pub struct BasinConfigInfo {
     pub storage_class: Option<StorageClass>,
     pub retention_age_secs: Option<u64>, // None = infinite
     pub timestamping_mode: Option<TimestampingMode>,
-    pub timestamping_uncapped: bool,
+    pub timestamping_uncapped: Option<bool>,
 }
 
 /// Stream config info for reconfiguration
@@ -27,7 +27,7 @@ pub struct StreamConfigInfo {
     pub storage_class: Option<StorageClass>,
     pub retention_age_secs: Option<u64>, // None = infinite
     pub timestamping_mode: Option<TimestampingMode>,
-    pub timestamping_uncapped: bool,
+    pub timestamping_uncapped: Option<bool>,
     pub delete_on_empty_min_age_secs: Option<u64>, // None = disabled
 }
 

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -378,7 +378,7 @@ impl From<sdk::types::TimestampingConfig> for TimestampingConfig {
     fn from(config: sdk::types::TimestampingConfig) -> Self {
         TimestampingConfig {
             timestamping_mode: config.mode.map(Into::into),
-            timestamping_uncapped: Some(config.uncapped),
+            timestamping_uncapped: config.uncapped,
         }
     }
 }

--- a/lite/src/backend/kv/basin_meta.rs
+++ b/lite/src/backend/kv/basin_meta.rs
@@ -125,7 +125,7 @@ pub fn deser_value(bytes: Bytes) -> Result<BasinMeta, DeserializationError> {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::{str::FromStr, time::Duration};
 
     use bytes::Bytes;
     use proptest::prelude::*;
@@ -133,7 +133,7 @@ mod tests {
         bash::Bash,
         types::{
             basin::{BasinName, BasinNamePrefix, BasinNameStartAfter},
-            config::BasinConfig,
+            config::{BasinConfig, OptionalDeleteOnEmptyConfig, OptionalStreamConfig},
         },
     };
     use time::OffsetDateTime;
@@ -244,6 +244,12 @@ mod tests {
     fn value_roundtrip_basin_meta() {
         let config = BasinConfig {
             create_stream_on_append: true,
+            default_stream_config: OptionalStreamConfig {
+                delete_on_empty: OptionalDeleteOnEmptyConfig {
+                    min_age: Some(Duration::ZERO),
+                },
+                ..Default::default()
+            },
             ..Default::default()
         };
         let created_at = OffsetDateTime::from_unix_timestamp(1234567890)
@@ -276,6 +282,14 @@ mod tests {
         assert_eq!(
             basin_meta.config.create_stream_on_read,
             decoded.config.create_stream_on_read
+        );
+        assert_eq!(
+            basin_meta
+                .config
+                .default_stream_config
+                .delete_on_empty
+                .min_age,
+            decoded.config.default_stream_config.delete_on_empty.min_age
         );
         assert_eq!(basin_meta.created_at, decoded.created_at);
         assert_eq!(basin_meta.deleted_at, decoded.deleted_at);

--- a/lite/src/backend/kv/stream_meta.rs
+++ b/lite/src/backend/kv/stream_meta.rs
@@ -151,7 +151,7 @@ pub fn deser_value(bytes: Bytes) -> Result<StreamMeta, DeserializationError> {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::{str::FromStr, time::Duration};
 
     use bytes::Bytes;
     use proptest::prelude::*;
@@ -160,7 +160,7 @@ mod tests {
         encryption::EncryptionAlgorithm,
         types::{
             basin::BasinName,
-            config::{OptionalStreamConfig, StorageClass},
+            config::{OptionalDeleteOnEmptyConfig, OptionalStreamConfig, StorageClass},
             stream::{StreamName, StreamNamePrefix, StreamNameStartAfter},
         },
     };
@@ -172,6 +172,9 @@ mod tests {
     fn value_roundtrip_stream_meta() {
         let config = OptionalStreamConfig {
             storage_class: Some(StorageClass::Express),
+            delete_on_empty: OptionalDeleteOnEmptyConfig {
+                min_age: Some(Duration::ZERO),
+            },
             ..Default::default()
         };
         let created_at = OffsetDateTime::from_unix_timestamp(1234567890)
@@ -202,6 +205,10 @@ mod tests {
         assert_eq!(
             stream_meta.config.storage_class,
             decoded.config.storage_class
+        );
+        assert_eq!(
+            stream_meta.config.delete_on_empty.min_age,
+            decoded.config.delete_on_empty.min_age
         );
         assert_eq!(stream_meta.cipher, decoded.cipher);
         assert_eq!(stream_meta.created_at, decoded.created_at);

--- a/lite/tests/backend/control_plane/basin.rs
+++ b/lite/tests/backend/control_plane/basin.rs
@@ -1,10 +1,13 @@
+use std::time::Duration;
+
 use s2_common::{
     maybe::Maybe,
     types::{
         basin::{BasinNamePrefix, BasinNameStartAfter, ListBasinsRequest},
         config::{
-            BasinConfig, BasinReconfiguration, OptionalStreamConfig, RetentionPolicy, StorageClass,
-            StreamReconfiguration, TimestampingMode, TimestampingReconfiguration,
+            BasinConfig, BasinReconfiguration, OptionalDeleteOnEmptyConfig, OptionalStreamConfig,
+            RetentionPolicy, StorageClass, StreamReconfiguration, TimestampingMode,
+            TimestampingReconfiguration,
         },
         resources::{ListItemsRequestParts, ProvisionMode, ProvisionResult, RequestToken},
     },
@@ -246,6 +249,48 @@ async fn test_provision_basin_ensure_resets_unspecified_config() {
     assert!(stored_config.create_stream_on_read);
     assert_eq!(stored_config.default_stream_config.storage_class, None);
     assert_eq!(stored_config.default_stream_config.retention_policy, None);
+}
+
+#[tokio::test]
+async fn test_provision_basin_ensure_noops_with_explicit_zero_delete_on_empty() {
+    let backend = create_backend().await;
+    let basin_name = test_basin_name("basin-zero-doe-noop");
+    let config = BasinConfig {
+        default_stream_config: OptionalStreamConfig {
+            delete_on_empty: OptionalDeleteOnEmptyConfig {
+                min_age: Some(Duration::ZERO),
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    backend
+        .provision_basin(
+            basin_name.clone(),
+            config.clone(),
+            ProvisionMode::CreateOnly {
+                request_token: None,
+            },
+        )
+        .await
+        .expect("Failed to create basin");
+
+    let ensured = backend
+        .provision_basin(basin_name.clone(), config, ProvisionMode::Ensure)
+        .await
+        .expect("Ensure should succeed");
+
+    assert!(matches!(ensured, ProvisionResult::Noop(_)));
+
+    let stored_config = backend
+        .get_basin_config(basin_name)
+        .await
+        .expect("Failed to fetch basin config");
+    assert_eq!(
+        stored_config.default_stream_config.delete_on_empty.min_age,
+        Some(Duration::ZERO)
+    );
 }
 
 #[tokio::test]

--- a/lite/tests/backend/control_plane/stream.rs
+++ b/lite/tests/backend/control_plane/stream.rs
@@ -6,9 +6,9 @@ use s2_common::{
     maybe::Maybe,
     types::{
         config::{
-            BasinConfig, BasinReconfiguration, OptionalStreamConfig, OptionalTimestampingConfig,
-            RetentionPolicy, StorageClass, StreamReconfiguration, TimestampingMode,
-            TimestampingReconfiguration,
+            BasinConfig, BasinReconfiguration, OptionalDeleteOnEmptyConfig, OptionalStreamConfig,
+            OptionalTimestampingConfig, RetentionPolicy, StorageClass, StreamReconfiguration,
+            TimestampingMode, TimestampingReconfiguration,
         },
         resources::{ListItemsRequestParts, ProvisionMode, ProvisionResult, RequestToken},
         stream::{
@@ -406,6 +406,57 @@ async fn test_provision_stream_ensure_noops_when_effective_config_matches() {
         )
         .await
         .expect("Failed to create stream");
+
+    let ensured = backend
+        .provision_stream(basin_name, stream_name, config, ProvisionMode::Ensure)
+        .await
+        .expect("Ensure should succeed");
+
+    assert!(matches!(ensured, ProvisionResult::Noop(_)));
+}
+
+#[tokio::test]
+async fn test_provision_stream_preserves_explicit_zero_delete_on_empty() {
+    let backend = create_backend().await;
+    let basin_name = create_test_basin(
+        &backend,
+        "stream-zero-doe",
+        BasinConfig {
+            default_stream_config: OptionalStreamConfig {
+                delete_on_empty: OptionalDeleteOnEmptyConfig {
+                    min_age: Some(Duration::from_secs(60)),
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .await;
+    let stream_name = test_stream_name("stream-zero-doe");
+    let config = OptionalStreamConfig {
+        delete_on_empty: OptionalDeleteOnEmptyConfig {
+            min_age: Some(Duration::ZERO),
+        },
+        ..Default::default()
+    };
+
+    backend
+        .provision_stream(
+            basin_name.clone(),
+            stream_name.clone(),
+            config.clone(),
+            ProvisionMode::CreateOnly {
+                request_token: None,
+            },
+        )
+        .await
+        .expect("Failed to create stream");
+
+    let stored_config = backend
+        .get_stream_config(basin_name.clone(), stream_name.clone())
+        .await
+        .expect("Failed to fetch stream config");
+    assert_eq!(stored_config.delete_on_empty.min_age, Some(Duration::ZERO));
 
     let ensured = backend
         .provision_stream(basin_name, stream_name, config, ProvisionMode::Ensure)

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -612,7 +612,7 @@ pub struct TimestampingConfig {
     /// Whether client-specified timestamps are allowed to exceed the arrival time.
     ///
     /// Defaults to `false` (client timestamps are capped at the arrival time).
-    pub uncapped: bool,
+    pub uncapped: Option<bool>,
 }
 
 impl TimestampingConfig {
@@ -631,7 +631,10 @@ impl TimestampingConfig {
 
     /// Set whether client-specified timestamps are allowed to exceed the arrival time.
     pub fn with_uncapped(self, uncapped: bool) -> Self {
-        Self { uncapped, ..self }
+        Self {
+            uncapped: Some(uncapped),
+            ..self
+        }
     }
 }
 
@@ -639,7 +642,7 @@ impl From<api::config::TimestampingConfig> for TimestampingConfig {
     fn from(value: api::config::TimestampingConfig) -> Self {
         Self {
             mode: value.mode.map(Into::into),
-            uncapped: value.uncapped.unwrap_or_default(),
+            uncapped: value.uncapped,
         }
     }
 }
@@ -648,7 +651,7 @@ impl From<TimestampingConfig> for api::config::TimestampingConfig {
     fn from(value: TimestampingConfig) -> Self {
         Self {
             mode: value.mode.map(Into::into),
-            uncapped: Some(value.uncapped),
+            uncapped: value.uncapped,
         }
     }
 }

--- a/sdk/tests/basin_ops.rs
+++ b/sdk/tests/basin_ops.rs
@@ -567,7 +567,7 @@ async fn create_stream_with_full_config(basin: &SharedS2Basin) -> Result<(), S2E
             retention_policy: Some(RetentionPolicy::Age(86400)),
             timestamping: Some(TimestampingConfig {
                 mode: Some(TimestampingMode::ClientRequire),
-                uncapped: true,
+                uncapped: Some(true),
                 ..
             }),
             delete_on_empty: Some(DeleteOnEmptyConfig {
@@ -701,10 +701,10 @@ async fn create_stream_timestamping_uncapped(basin: &SharedS2Basin) -> Result<()
             .await?;
 
         let retrieved = basin.get_stream_config(stream_name.clone()).await?;
-        match retrieved.timestamping {
-            Some(timestamping) => assert_eq!(timestamping.uncapped, uncapped),
-            None => assert!(!uncapped),
-        }
+        let timestamping = retrieved
+            .timestamping
+            .expect("explicit uncapped setting should be preserved");
+        assert_eq!(timestamping.uncapped, Some(uncapped));
 
         basin
             .delete_stream(DeleteStreamInput::new(stream_name))
@@ -964,10 +964,10 @@ async fn reconfigure_stream_timestamping_uncapped(basin: &SharedS2Basin) -> Resu
             ))
             .await?;
 
-        match config.timestamping {
-            Some(timestamping) => assert_eq!(timestamping.uncapped, uncapped),
-            None => assert!(!uncapped),
-        }
+        let timestamping = config
+            .timestamping
+            .expect("explicit uncapped setting should be preserved");
+        assert_eq!(timestamping.uncapped, Some(uncapped));
 
         basin
             .delete_stream(DeleteStreamInput::new(stream_name))


### PR DESCRIPTION
## Summary
- preserve explicit zero delete-on-empty values instead of coercing them to omitted config
- model SDK timestamping `uncapped` as `Option<bool>` so omitted/inherit stays distinct from `Some(false)`
- update CLI/TUI adapters and backend/API/KV tests for effective config noops and roundtrips

Closes #455

## Tests
- `just fmt`
- `cargo test -p s2-sdk --no-run`
- `cargo test -p s2-cli --no-run`
- `just test`