### PR TITLE
feat(lite): enable lz4 and zstd SlateDB compression codecs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,6 +3000,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5272,6 +5281,7 @@ dependencies = [
  "foyer",
  "futures",
  "log",
+ "lz4_flex",
  "object_store",
  "once_cell",
  "ouroboros",
@@ -5293,6 +5303,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ schemars = "1.2"
 secrecy = "0.10.3"
 serde = "1.0"
 serde_json = "1.0"
-slatedb = "0.12.1"
+slatedb = { version = "0.12.1", features = ["lz4", "zstd"] }
 sonic-rs = "0.5"
 strum = "0.28"
 tabled = "0.20"


### PR DESCRIPTION
## Summary

- Compile in SlateDB's `lz4` and `zstd` codec features so users can opt into SSTable compression via `SL8_COMPRESSION_CODEC=lz4|zstd`.
- Disabled by default; existing deployments are unaffected until the env var is set.
- Backwards-compatible at the data-format level: each SST records its own codec in its footer, so old uncompressed SSTs remain readable and compactions progressively rewrite them once compression is enabled.

snappy and zlib are intentionally omitted — lz4 dominates snappy on both speed and ratio, and zstd dominates zlib; the two-codec set cleanly covers the speed-first / ratio-first axes.

Closes #460

## Test plan

- [x] `cargo check -p s2-lite` (done locally)
- [x] Start s2-lite with `SL8_COMPRESSION_CODEC=zstd` and confirm it boots and accepts appends
- [x] Restart same instance without the env var and confirm previously-written SSTs still read

🤖 Generated with [Claude Code](https://claude.com/claude-code)