### PR TITLE
refactor(lite): use prefix scans for stream record checks

### DIFF
--- a/lite/src/backend/bgtasks/stream_doe.rs
+++ b/lite/src/backend/bgtasks/stream_doe.rs
@@ -3,10 +3,7 @@ use std::time::Duration;
 use futures::{StreamExt, stream};
 use indexmap::IndexMap;
 use itertools::Itertools;
-use s2_common::{
-    record::{SeqNum, StreamPosition, Timestamp},
-    types::resources::Page,
-};
+use s2_common::types::resources::Page;
 use slatedb::{
     WriteBatch,
     config::{DurabilityLevel, ScanOptions},
@@ -142,23 +139,9 @@ impl Backend {
 
     #[instrument(ret, err, skip(self))]
     async fn stream_has_records(&self, stream_id: StreamId) -> Result<bool, StorageError> {
-        let start_key = kv::stream_record_timestamp::ser_key(
-            stream_id,
-            StreamPosition {
-                seq_num: SeqNum::MIN,
-                timestamp: Timestamp::MIN,
-            },
-        );
-        // Use Memory durability so TTL filtering advances with wall time even when the DB is idle.
-        let mut it = self.db.scan(start_key..).await?;
-        let Some(kv) = it.next().await? else {
-            return Ok(false);
-        };
-        if kv.key.first().copied() != Some(kv::KeyType::StreamRecordTimestamp as u8) {
-            return Ok(false);
-        }
-        let (candidate_stream_id, _pos) = kv::stream_record_timestamp::deser_key(kv.key)?;
-        Ok(candidate_stream_id == stream_id)
+        let prefix = kv::stream_record_timestamp::ser_key_prefix(stream_id);
+        let mut it = self.db.scan_prefix(prefix).await?;
+        Ok(it.next().await?.is_some())
     }
 
     pub(super) async fn arm_doe_maybe(&self, stream_id: StreamId) -> Result<(), StorageError> {

--- a/lite/src/backend/bgtasks/stream_trim.rs
+++ b/lite/src/backend/bgtasks/stream_trim.rs
@@ -1,10 +1,7 @@
 use std::ops::RangeTo;
 
 use futures::{StreamExt, stream};
-use s2_common::{
-    record::{NonZeroSeqNum, SeqNum, StreamPosition, Timestamp},
-    types::resources::Page,
-};
+use s2_common::{record::NonZeroSeqNum, types::resources::Page};
 use slatedb::{
     WriteBatch,
     config::{DurabilityLevel, ScanOptions},
@@ -80,29 +77,18 @@ impl Backend {
         stream_id: StreamId,
         trim_point: RangeTo<NonZeroSeqNum>,
     ) -> Result<bool, StorageError> {
-        let start_key = kv::stream_record_timestamp::ser_key(
-            stream_id,
-            StreamPosition {
-                seq_num: SeqNum::MIN,
-                timestamp: Timestamp::MIN,
-            },
-        );
+        let prefix = kv::stream_record_timestamp::ser_key_prefix(stream_id);
         let scan_opts = ScanOptions {
             durability_filter: DurabilityLevel::Remote,
             ..Default::default()
         };
-        let mut it = self.db.scan_with_options(start_key.., &scan_opts).await?;
+        let mut it = self.db.scan_prefix_with_options(prefix, &scan_opts).await?;
         let mut batch = WriteBatch::new();
         let mut batch_size = 0usize;
         let mut has_remaining_records = false;
         while let Some(kv) = it.next().await? {
-            if kv.key.first().copied() != Some(kv::KeyType::StreamRecordTimestamp as u8) {
-                break;
-            }
             let (deser_stream_id, pos) = kv::stream_record_timestamp::deser_key(kv.key.clone())?;
-            if deser_stream_id != stream_id {
-                break;
-            }
+            debug_assert_eq!(deser_stream_id, stream_id);
             if pos.seq_num >= trim_point.end.get() {
                 has_remaining_records = true;
                 break;

--- a/lite/src/backend/kv/stream_record_timestamp.rs
+++ b/lite/src/backend/kv/stream_record_timestamp.rs
@@ -4,7 +4,16 @@ use s2_common::record::StreamPosition;
 use super::{DeserializationError, KeyType, check_exact_size};
 use crate::stream_id::StreamId;
 
+const KEY_PREFIX_LEN: usize = 1 + StreamId::LEN;
 const KEY_LEN: usize = 1 + StreamId::LEN + 8 + 8;
+
+pub fn ser_key_prefix(stream_id: StreamId) -> Bytes {
+    let mut buf = BytesMut::with_capacity(KEY_PREFIX_LEN);
+    buf.put_u8(KeyType::StreamRecordTimestamp as u8);
+    buf.put_slice(stream_id.as_bytes());
+    debug_assert_eq!(buf.len(), KEY_PREFIX_LEN, "serialized length mismatch");
+    buf.freeze()
+}
 
 pub fn ser_key(stream_id: StreamId, pos: StreamPosition) -> Bytes {
     let mut buf = BytesMut::with_capacity(KEY_LEN);
@@ -68,6 +77,19 @@ mod tests {
             prop_assert_eq!(stream_id, decoded_stream_id);
             prop_assert_eq!(timestamp, decoded_pos.timestamp);
             prop_assert_eq!(seq_num, decoded_pos.seq_num);
+        }
+
+        #[test]
+        fn stream_record_timestamp_key_prefix_matches_record_keys(
+            stream_id_bytes in any::<[u8; StreamId::LEN]>(),
+            timestamp in any::<Timestamp>(),
+            seq_num in any::<SeqNum>(),
+        ) {
+            let stream_id = StreamId::from(stream_id_bytes);
+            let prefix = super::ser_key_prefix(stream_id);
+            let key_bytes = super::ser_key(stream_id, StreamPosition { seq_num, timestamp });
+            prop_assert_eq!(prefix.len(), super::KEY_PREFIX_LEN);
+            prop_assert!(key_bytes.as_ref().starts_with(prefix.as_ref()));
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a StreamRecordTimestamp key-prefix serializer

## Test plan
- just fmt
- just test