### PR TITLE
fix: resolve lite stream config reconfigure defaults

### DIFF
--- a/common/src/types/config.rs
+++ b/common/src/types/config.rs
@@ -6,8 +6,8 @@
 //!   produced by merging optional configs with defaults using `merge()`.
 //!
 //! - Optional (`OptionalStreamConfig`, `OptionalTimestampingConfig`,
-//!   `OptionalDeleteOnEmptyConfig`): stored metadata, where `None` means "not set at this layer;
-//!   fall back to defaults."
+//!   `OptionalDeleteOnEmptyConfig`): partial configuration layers, where `None` means "not set at
+//!   this layer; fall back to defaults."
 //!
 //! - Reconfiguration (`StreamReconfiguration`, `TimestampingReconfiguration`,
 //!   `DeleteOnEmptyReconfiguration`): PATCH-style updates applied with `reconfigure()`.
@@ -91,6 +91,12 @@ pub struct TimestampingConfig {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct DeleteOnEmptyConfig {
     pub min_age: Duration,
+}
+
+impl DeleteOnEmptyConfig {
+    pub fn min_age(&self) -> Option<Duration> {
+        Some(self.min_age).filter(|age| !age.is_zero())
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/lite/src/backend/bgtasks/basin_deletion.rs
+++ b/lite/src/backend/bgtasks/basin_deletion.rs
@@ -134,7 +134,7 @@ mod tests {
 
     use s2_common::types::{
         basin::BasinName,
-        config::BasinConfig,
+        config::{BasinConfig, StreamConfig},
         resources::ListLimit,
         stream::{StreamName, StreamNameStartAfter},
     };
@@ -154,7 +154,7 @@ mod tests {
 
     fn stream_meta(deleted_at: Option<OffsetDateTime>) -> kv::stream_meta::StreamMeta {
         kv::stream_meta::StreamMeta {
-            config: Default::default(),
+            config: StreamConfig::default(),
             cipher: None,
             created_at: OffsetDateTime::now_utc(),
             deleted_at,

--- a/lite/src/backend/bgtasks/stream_doe.rs
+++ b/lite/src/backend/bgtasks/stream_doe.rs
@@ -15,7 +15,7 @@ use crate::{
         Backend,
         error::{DeleteStreamError, StorageError, StreamDeleteOnEmptyError},
         kv::{self, timestamp::TimestampSecs},
-        streamer::{doe_arm_delay, retention_age_or_zero},
+        streamer::doe_arm_delay,
     },
     stream_id::StreamId,
 };
@@ -160,11 +160,13 @@ impl Backend {
         if meta.deleted_at.is_some() {
             return Ok(());
         }
-        let Some(min_age) = meta.config.delete_on_empty.min_age.filter(|d| !d.is_zero()) else {
+        let Some(min_age) = meta.config.delete_on_empty.min_age() else {
             return Ok(());
         };
-        let deadline =
-            TimestampSecs::after(doe_arm_delay(retention_age_or_zero(&meta.config), min_age));
+        let deadline = TimestampSecs::after(doe_arm_delay(
+            meta.config.retention_policy.age().unwrap_or_default(),
+            min_age,
+        ));
         self.db
             .put(
                 kv::stream_doe_deadline::ser_key(deadline, stream_id),
@@ -185,7 +187,7 @@ mod tests {
         types::{
             basin::BasinName,
             config::{
-                DeleteOnEmptyReconfiguration, OptionalStreamConfig, RetentionPolicy,
+                BasinConfig, DeleteOnEmptyReconfiguration, OptionalStreamConfig, RetentionPolicy,
                 StreamReconfiguration,
             },
             stream::StreamName,
@@ -211,7 +213,7 @@ mod tests {
         created_at: OffsetDateTime,
     ) -> kv::stream_meta::StreamMeta {
         kv::stream_meta::StreamMeta {
-            config,
+            config: config.into(),
             cipher: None,
             created_at,
             deleted_at: None,
@@ -230,6 +232,19 @@ mod tests {
         meta: kv::stream_meta::StreamMeta,
     ) -> StreamId {
         let stream_id = StreamId::new(basin, stream);
+        backend
+            .db
+            .put(
+                kv::basin_meta::ser_key(basin),
+                kv::basin_meta::ser_value(&kv::basin_meta::BasinMeta {
+                    config: BasinConfig::default(),
+                    created_at: OffsetDateTime::now_utc(),
+                    deleted_at: None,
+                    creation_idempotency_key: None,
+                }),
+            )
+            .await
+            .unwrap();
         backend
             .db
             .put(

--- a/lite/src/backend/bgtasks/stream_trim.rs
+++ b/lite/src/backend/bgtasks/stream_trim.rs
@@ -158,7 +158,7 @@ mod tests {
         record::{
             FencingToken, Metered, NonZeroSeqNum, Record, SeqNum, StoredRecord, StreamPosition,
         },
-        types::{basin::BasinName, config::OptionalStreamConfig, stream::StreamName},
+        types::{basin::BasinName, config::StreamConfig, stream::StreamName},
     };
     use slatedb::WriteBatch;
     use time::OffsetDateTime;
@@ -256,7 +256,7 @@ mod tests {
         let metered = test_record();
 
         let meta = kv::stream_meta::StreamMeta {
-            config: OptionalStreamConfig::default(),
+            config: StreamConfig::default(),
             cipher: None,
             created_at: OffsetDateTime::now_utc(),
             deleted_at: None,

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -364,7 +364,7 @@ mod tests {
     use s2_common::{
         record::{Metered, Record, StoredRecord, StreamPosition},
         types::{
-            config::{BasinConfig, OptionalStreamConfig},
+            config::{BasinConfig, OptionalStreamConfig, StreamConfig},
             resources::ProvisionMode,
         },
     };
@@ -393,7 +393,7 @@ mod tests {
         let stream_id = StreamId::new(&basin, &stream);
 
         let meta = kv::stream_meta::StreamMeta {
-            config: OptionalStreamConfig::default(),
+            config: StreamConfig::default(),
             cipher: None,
             created_at: OffsetDateTime::now_utc(),
             deleted_at: None,

--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -457,6 +457,8 @@ pub enum ReconfigureStreamError {
     #[error(transparent)]
     BasinNotFound(#[from] BasinNotFoundError),
     #[error(transparent)]
+    BasinDeletionPending(#[from] BasinDeletionPendingError),
+    #[error(transparent)]
     StreamNotFound(#[from] StreamNotFoundError),
     #[error(transparent)]
     StreamDeletionPending(#[from] StreamDeletionPendingError),

--- a/lite/src/backend/kv/stream_meta.rs
+++ b/lite/src/backend/kv/stream_meta.rs
@@ -7,7 +7,7 @@ use s2_common::{
     encryption::EncryptionAlgorithm,
     types::{
         basin::BasinName,
-        config::OptionalStreamConfig,
+        config::{OptionalStreamConfig, StreamConfig},
         stream::{StreamName, StreamNamePrefix, StreamNameStartAfter},
     },
 };
@@ -23,7 +23,7 @@ const FIELD_SEPARATOR: u8 = b'\0';
 
 #[derive(Debug, Clone)]
 pub struct StreamMeta {
-    pub config: OptionalStreamConfig,
+    pub config: StreamConfig,
     pub cipher: Option<EncryptionAlgorithm>,
     pub created_at: OffsetDateTime,
     pub deleted_at: Option<OffsetDateTime>,
@@ -44,7 +44,7 @@ struct StreamMetaSerde {
 impl From<StreamMeta> for StreamMetaSerde {
     fn from(meta: StreamMeta) -> Self {
         Self {
-            config: s2_api::v1::config::StreamConfig::to_opt(meta.config),
+            config: Some(meta.config.into()),
             cipher: meta.cipher,
             created_at: meta.created_at,
             deleted_at: meta.deleted_at,
@@ -58,8 +58,8 @@ impl TryFrom<StreamMetaSerde> for StreamMeta {
 
     fn try_from(serde: StreamMetaSerde) -> Result<Self, Self::Error> {
         let config = match serde.config {
-            Some(api_config) => api_config.try_into()?,
-            None => OptionalStreamConfig::default(),
+            Some(api_config) => OptionalStreamConfig::try_from(api_config)?.into(),
+            None => StreamConfig::default(),
         };
 
         Ok(Self {
@@ -160,7 +160,9 @@ mod tests {
         encryption::EncryptionAlgorithm,
         types::{
             basin::BasinName,
-            config::{OptionalDeleteOnEmptyConfig, OptionalStreamConfig, StorageClass},
+            config::{
+                OptionalDeleteOnEmptyConfig, OptionalStreamConfig, StorageClass, StreamConfig,
+            },
             stream::{StreamName, StreamNamePrefix, StreamNameStartAfter},
         },
     };
@@ -188,7 +190,7 @@ mod tests {
                 .unwrap(),
         );
         let stream_meta = super::StreamMeta {
-            config: config.clone(),
+            config: config.into(),
             cipher: Some(EncryptionAlgorithm::Aegis256),
             created_at,
             deleted_at,
@@ -230,7 +232,7 @@ mod tests {
         };
         let bytes = Bytes::from(serde_json::to_vec(&serde_value).unwrap());
         let decoded = super::deser_value(bytes).unwrap();
-        let default_config = OptionalStreamConfig::default();
+        let default_config = StreamConfig::default();
 
         assert_eq!(decoded.config.storage_class, default_config.storage_class);
         assert_eq!(

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -20,9 +20,7 @@ use s2_common::{
         StoredRecord, StoredSequencedRecord, StreamPosition, Timestamp,
     },
     types::{
-        config::{
-            OptionalStreamConfig, OptionalTimestampingConfig, RetentionPolicy, TimestampingMode,
-        },
+        config::{RetentionPolicy, StreamConfig, TimestampingConfig, TimestampingMode},
         stream::{
             AppendAck, StoredAppendInput, StoredAppendRecord, StoredAppendRecordBatch,
             StoredAppendRecordParts,
@@ -61,14 +59,6 @@ pub(super) fn doe_arm_delay(retention_age: Duration, min_age: Duration) -> Durat
     retention_age
         .saturating_add(min_age)
         .saturating_add(DOE_DEADLINE_REFRESH_PERIOD)
-}
-
-pub(super) fn retention_age_or_zero(config: &OptionalStreamConfig) -> Duration {
-    config
-        .retention_policy
-        .unwrap_or_default()
-        .age()
-        .unwrap_or_default()
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -215,7 +205,7 @@ pub(super) struct Spawner {
     pub generation_id: StreamerGenerationId,
     pub db: slatedb::Db,
     pub stream_id: StreamId,
-    pub config: OptionalStreamConfig,
+    pub config: StreamConfig,
     pub cipher: Option<EncryptionAlgorithm>,
     pub tail_pos: StreamPosition,
     pub fencing_token: FencingToken,
@@ -309,7 +299,7 @@ struct Streamer {
     db: slatedb::Db,
     stream_id: StreamId,
     msg_tx: mpsc::UnboundedSender<Message>,
-    config: OptionalStreamConfig,
+    config: StreamConfig,
     fencing_token: CommandState<FencingToken>,
     trim_point: CommandState<RangeTo<SeqNum>>,
     last_doe_deadline_at: Option<Instant>,
@@ -402,8 +392,7 @@ impl Streamer {
         };
         match self.sequence_records(input) {
             Ok(sequenced_records) => {
-                let retention = self.config.retention_policy.unwrap_or_default();
-                let doe_deadline = self.maybe_doe_deadline(retention.age());
+                let doe_deadline = self.maybe_doe_deadline();
                 if append_type == AppendType::Terminal {
                     assert_eq!(sequenced_records.len(), 1);
                     assert_eq!(
@@ -422,7 +411,7 @@ impl Streamer {
                     db_submit_append(
                         self.db.clone(),
                         self.stream_id,
-                        retention,
+                        self.config.retention_policy,
                         doe_deadline,
                         sequenced_records,
                         self.fencing_token
@@ -442,16 +431,9 @@ impl Streamer {
         }
     }
 
-    fn maybe_doe_deadline(
-        &mut self,
-        retention_age: Option<Duration>,
-    ) -> Option<DeleteOnEmptyDeadline> {
-        let retention_age = retention_age?;
-        let min_age = self
-            .config
-            .delete_on_empty
-            .min_age
-            .filter(|d| !d.is_zero())?;
+    fn maybe_doe_deadline(&mut self) -> Option<DeleteOnEmptyDeadline> {
+        let retention_age = self.config.retention_policy.age()?;
+        let min_age = self.config.delete_on_empty.min_age()?;
         let now = Instant::now();
         if self
             .last_doe_deadline_at
@@ -616,7 +598,7 @@ enum Message {
         reply_tx: oneshot::Sender<StreamPosition>,
     },
     Reconfigure {
-        config: OptionalStreamConfig,
+        config: StreamConfig,
     },
     DurabilityStatus(Result<u64, slatedb::CloseReason>),
 }
@@ -698,7 +680,7 @@ impl StreamerClient {
         })
     }
 
-    pub(super) fn advise_reconfig(&self, config: OptionalStreamConfig) -> bool {
+    pub(super) fn advise_reconfig(&self, config: StreamConfig) -> bool {
         self.msg_tx.send(Message::Reconfigure { config }).is_ok()
     }
 
@@ -814,10 +796,8 @@ fn sequenced_records(
     batch: StoredAppendRecordBatch,
     first_seq_num: SeqNum,
     prev_max_timestamp: Timestamp,
-    config: &OptionalTimestampingConfig,
+    config: &TimestampingConfig,
 ) -> Result<Vec<Metered<StoredSequencedRecord>>, AppendErrorInternal> {
-    let mode = config.mode.unwrap_or_default();
-    let uncapped = config.uncapped.unwrap_or_default();
     let mut sequenced_records = Vec::with_capacity(batch.len());
     let mut max_timestamp = prev_max_timestamp;
     let now = timestamp_now();
@@ -836,12 +816,12 @@ fn sequenced_records(
                 max_assignable_seq_num,
             })?;
         }
-        let mut timestamp = match mode {
+        let mut timestamp = match config.mode {
             TimestampingMode::ClientPrefer => timestamp.unwrap_or(now),
             TimestampingMode::ClientRequire => timestamp.ok_or(AppendTimestampRequiredError)?,
             TimestampingMode::Arrival => now,
         };
-        if !uncapped && timestamp > now {
+        if !config.uncapped && timestamp > now {
             timestamp = now;
         }
         if timestamp < max_timestamp {
@@ -969,9 +949,9 @@ mod tests {
 
     #[test]
     fn sequenced_records_client_prefer_with_timestamps() {
-        let config = OptionalTimestampingConfig {
-            mode: Some(TimestampingMode::ClientPrefer),
-            uncapped: Some(false),
+        let config = TimestampingConfig {
+            mode: TimestampingMode::ClientPrefer,
+            uncapped: false,
         };
 
         let records: StoredAppendRecordBatch = vec![
@@ -993,9 +973,9 @@ mod tests {
     #[test]
     fn sequenced_records_client_prefer_without_timestamps() {
         let now = timestamp_now();
-        let config = OptionalTimestampingConfig {
-            mode: Some(TimestampingMode::ClientPrefer),
-            uncapped: Some(false),
+        let config = TimestampingConfig {
+            mode: TimestampingMode::ClientPrefer,
+            uncapped: false,
         };
 
         let records: StoredAppendRecordBatch = vec![
@@ -1016,9 +996,9 @@ mod tests {
 
     #[test]
     fn sequenced_records_client_require_missing_timestamp() {
-        let config = OptionalTimestampingConfig {
-            mode: Some(TimestampingMode::ClientRequire),
-            uncapped: Some(false),
+        let config = TimestampingConfig {
+            mode: TimestampingMode::ClientRequire,
+            uncapped: false,
         };
 
         let records: StoredAppendRecordBatch = vec![test_record(vec![1, 2, 3].into(), None)]
@@ -1035,9 +1015,9 @@ mod tests {
 
     #[test]
     fn sequenced_records_client_require_with_timestamps() {
-        let config = OptionalTimestampingConfig {
-            mode: Some(TimestampingMode::ClientRequire),
-            uncapped: Some(false),
+        let config = TimestampingConfig {
+            mode: TimestampingMode::ClientRequire,
+            uncapped: false,
         };
 
         let records: StoredAppendRecordBatch = vec![
@@ -1057,9 +1037,9 @@ mod tests {
     #[test]
     fn sequenced_records_arrival_mode() {
         let now = timestamp_now();
-        let config = OptionalTimestampingConfig {
-            mode: Some(TimestampingMode::Arrival),
-            uncapped: Some(false),
+        let config = TimestampingConfig {
+            mode: TimestampingMode::Arrival,
+            uncapped: false,
         };
 
         let records: StoredAppendRecordBatch = vec![
@@ -1078,9 +1058,9 @@ mod tests {
 
     #[test]
     fn sequenced_records_timestamp_monotonicity() {
-        let config = OptionalTimestampingConfig {
-            mode: Some(TimestampingMode::ClientPrefer),
-            uncapped: Some(false),
+        let config = TimestampingConfig {
+            mode: TimestampingMode::ClientPrefer,
+            uncapped: false,
         };
 
         let records: StoredAppendRecordBatch = vec![
@@ -1101,9 +1081,9 @@ mod tests {
 
     #[test]
     fn sequenced_records_prev_max_timestamp_enforced() {
-        let config = OptionalTimestampingConfig {
-            mode: Some(TimestampingMode::ClientPrefer),
-            uncapped: Some(false),
+        let config = TimestampingConfig {
+            mode: TimestampingMode::ClientPrefer,
+            uncapped: false,
         };
 
         let records: StoredAppendRecordBatch = vec![
@@ -1123,9 +1103,9 @@ mod tests {
     #[test]
     fn sequenced_records_future_timestamp_capped() {
         let now = timestamp_now();
-        let config = OptionalTimestampingConfig {
-            mode: Some(TimestampingMode::ClientPrefer),
-            uncapped: Some(false),
+        let config = TimestampingConfig {
+            mode: TimestampingMode::ClientPrefer,
+            uncapped: false,
         };
 
         let future = now + 10_000;
@@ -1143,9 +1123,9 @@ mod tests {
     #[test]
     fn sequenced_records_future_timestamp_uncapped() {
         let now = timestamp_now();
-        let config = OptionalTimestampingConfig {
-            mode: Some(TimestampingMode::ClientPrefer),
-            uncapped: Some(true),
+        let config = TimestampingConfig {
+            mode: TimestampingMode::ClientPrefer,
+            uncapped: true,
         };
 
         let future = now + 10_000;
@@ -1162,7 +1142,7 @@ mod tests {
 
     #[test]
     fn sequenced_records_seq_num_assignment() {
-        let config = OptionalTimestampingConfig::default();
+        let config = TimestampingConfig::default();
 
         let records: StoredAppendRecordBatch = vec![
             test_record(vec![1].into(), None),
@@ -1182,7 +1162,7 @@ mod tests {
 
     #[test]
     fn sequenced_records_reject_aes256gcm_records_past_random_nonce_limit() {
-        let config = OptionalTimestampingConfig::default();
+        let config = TimestampingConfig::default();
         let first_record = test_encrypted_record(
             vec![1, 2, 3].into(),
             None,
@@ -1214,7 +1194,7 @@ mod tests {
 
     #[test]
     fn sequenced_records_allow_aes256gcm_command_records_past_random_nonce_limit() {
-        let config = OptionalTimestampingConfig::default();
+        let config = TimestampingConfig::default();
         let max_assignable_seq_num = test_encrypted_record(
             vec![1, 2, 3].into(),
             None,
@@ -1271,7 +1251,7 @@ mod tests {
             db: db.clone(),
             stream_id: [3u8; StreamId::LEN].into(),
             msg_tx,
-            config: OptionalStreamConfig::default(),
+            config: StreamConfig::default(),
             fencing_token: CommandState {
                 state: FencingToken::default(),
                 applied_point: ..SeqNum::MIN,

--- a/lite/src/backend/streams.rs
+++ b/lite/src/backend/streams.rs
@@ -3,7 +3,7 @@ use s2_common::{
     record::StreamPosition,
     types::{
         basin::BasinName,
-        config::{OptionalStreamConfig, StreamReconfiguration},
+        config::{OptionalStreamConfig, StreamConfig, StreamReconfiguration},
         resources::{ListItemsRequestParts, Page, ProvisionMode, ProvisionResult, RequestToken},
         stream::{ListStreamsRequest, StreamInfo, StreamName},
     },
@@ -15,11 +15,7 @@ use slatedb::{
 use time::OffsetDateTime;
 use tracing::instrument;
 
-use super::{
-    Backend,
-    store::db_txn_get,
-    streamer::{doe_arm_delay, retention_age_or_zero},
-};
+use super::{Backend, store::db_txn_get, streamer::doe_arm_delay};
 use crate::{
     backend::{
         error::{
@@ -133,27 +129,22 @@ impl Backend {
                 };
             }
             (Some(existing), ProvisionMode::Ensure) => {
-                let prior_doe_min_age = existing
-                    .config
-                    .delete_on_empty
-                    .min_age
-                    .filter(|age| !age.is_zero());
-                let desired_config = config.merge(basin_defaults.clone());
-                let current_config = existing.config.clone().merge(basin_defaults);
+                let desired_config = config.merge(basin_defaults);
+                let config_unchanged = existing.config == desired_config;
                 let meta = kv::stream_meta::StreamMeta {
-                    config: desired_config.clone().into(),
+                    config: desired_config,
                     cipher: existing.cipher,
                     created_at: existing.created_at,
                     deleted_at: None,
                     creation_idempotency_key: existing.creation_idempotency_key,
                 };
                 (
-                    if current_config == desired_config {
+                    if config_unchanged {
                         ProvisionResult::Noop(meta)
                     } else {
                         ProvisionResult::Updated(meta)
                     },
-                    prior_doe_min_age,
+                    existing.config.delete_on_empty.min_age(),
                 )
             }
             (None, ProvisionMode::CreateOnly { request_token }) => {
@@ -162,7 +153,7 @@ impl Backend {
                     .map(|req_token| creation_idempotency_key(req_token, &config));
                 (
                     ProvisionResult::Created(kv::stream_meta::StreamMeta {
-                        config: config.merge(basin_defaults).into(),
+                        config: config.merge(basin_defaults),
                         cipher: basin_meta.config.stream_cipher,
                         created_at: OffsetDateTime::now_utc(),
                         deleted_at: None,
@@ -173,7 +164,7 @@ impl Backend {
             }
             (None, ProvisionMode::Ensure) => (
                 ProvisionResult::Created(kv::stream_meta::StreamMeta {
-                    config: config.merge(basin_defaults).into(),
+                    config: config.merge(basin_defaults),
                     cipher: basin_meta.config.stream_cipher,
                     created_at: OffsetDateTime::now_utc(),
                     deleted_at: None,
@@ -209,17 +200,13 @@ impl Backend {
                     ),
                 )?;
             }
-            if let Some(min_age) = meta
-                .config
-                .delete_on_empty
-                .min_age
-                .filter(|age| !age.is_zero())
+            if let Some(min_age) = meta.config.delete_on_empty.min_age()
                 && (matches!(&outcome, ProvisionResult::Created(_)) || prior_doe_min_age.is_none())
             {
                 txn.put(
                     kv::stream_doe_deadline::ser_key(
                         kv::timestamp::TimestampSecs::after(doe_arm_delay(
-                            retention_age_or_zero(&meta.config),
+                            meta.config.retention_policy.age().unwrap_or_default(),
                             min_age,
                         )),
                         stream_id,
@@ -260,7 +247,7 @@ impl Backend {
         &self,
         basin: BasinName,
         stream: StreamName,
-    ) -> Result<OptionalStreamConfig, GetStreamConfigError> {
+    ) -> Result<StreamConfig, GetStreamConfigError> {
         let meta = self
             .db_get(
                 kv::stream_meta::ser_key(&basin, &stream),
@@ -282,44 +269,51 @@ impl Backend {
         basin: BasinName,
         stream: StreamName,
         reconfig: StreamReconfiguration,
-    ) -> Result<OptionalStreamConfig, ReconfigureStreamError> {
+    ) -> Result<StreamConfig, ReconfigureStreamError> {
         let txn = self.db.begin(IsolationLevel::SerializableSnapshot).await?;
 
         let meta_key = kv::stream_meta::ser_key(&basin, &stream);
+        let (basin_meta, meta) = tokio::try_join!(
+            db_txn_get(
+                &txn,
+                kv::basin_meta::ser_key(&basin),
+                kv::basin_meta::deser_value,
+            ),
+            db_txn_get(&txn, &meta_key, kv::stream_meta::deser_value),
+        )?;
 
-        let mut meta = db_txn_get(&txn, &meta_key, kv::stream_meta::deser_value)
-            .await?
-            .ok_or_else(|| StreamNotFoundError {
-                basin: basin.clone(),
-                stream: stream.clone(),
-            })?;
+        let basin_meta = basin_meta.ok_or_else(|| BasinNotFoundError {
+            basin: basin.clone(),
+        })?;
+        if basin_meta.deleted_at.is_some() {
+            return Err(BasinDeletionPendingError { basin }.into());
+        }
+
+        let mut meta = meta.ok_or_else(|| StreamNotFoundError {
+            basin: basin.clone(),
+            stream: stream.clone(),
+        })?;
 
         if meta.deleted_at.is_some() {
             return Err(StreamDeletionPendingError { basin, stream }.into());
         }
 
-        let prior_doe_min_age = meta
-            .config
-            .delete_on_empty
-            .min_age
-            .filter(|age| !age.is_zero());
+        let prior_doe_min_age = meta.config.delete_on_empty.min_age();
 
-        meta.config = meta.config.reconfigure(reconfig);
+        meta.config = OptionalStreamConfig::from(meta.config)
+            .reconfigure(reconfig)
+            .merge(basin_meta.config.default_stream_config);
 
         txn.put(&meta_key, kv::stream_meta::ser_value(&meta))?;
 
         let stream_id = StreamId::new(&basin, &stream);
-        if let Some(min_age) = meta
-            .config
-            .delete_on_empty
-            .min_age
-            .filter(|age| !age.is_zero())
+        if let Some(min_age) = meta.config.delete_on_empty.min_age()
             && prior_doe_min_age.is_none()
         {
             txn.put(
                 kv::stream_doe_deadline::ser_key(
                     kv::timestamp::TimestampSecs::after(doe_arm_delay(
-                        retention_age_or_zero(&meta.config),
+                        meta.config.retention_policy.age().unwrap_or_default(),
                         min_age,
                     )),
                     stream_id,

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -184,6 +184,9 @@ impl ServiceError {
                 ReconfigureStreamError::BasinNotFound(e) => {
                     standard(ErrorCode::BasinNotFound, e.to_string())
                 }
+                ReconfigureStreamError::BasinDeletionPending(e) => {
+                    standard(ErrorCode::BasinDeletionPending, e.to_string())
+                }
                 ReconfigureStreamError::StreamNotFound(e) => {
                     standard(ErrorCode::StreamNotFound, e.to_string())
                 }

--- a/lite/src/handlers/v1/streams.rs
+++ b/lite/src/handlers/v1/streams.rs
@@ -181,10 +181,7 @@ pub async fn get_stream_config(
     State(backend): State<Backend>,
     GetConfigArgs { basin, stream }: GetConfigArgs,
 ) -> Result<Json<v1t::config::StreamConfig>, ServiceError> {
-    let config = backend.get_stream_config(basin, stream).await?;
-    Ok(Json(
-        v1t::config::StreamConfig::to_opt(config).unwrap_or_default(),
-    ))
+    Ok(Json(backend.get_stream_config(basin, stream).await?.into()))
 }
 
 #[derive(FromRequest)]
@@ -340,7 +337,5 @@ pub async fn reconfigure_stream(
     let config = backend
         .reconfigure_stream(basin, stream, reconfiguration)
         .await?;
-    Ok(Json(
-        v1t::config::StreamConfig::to_opt(config).unwrap_or_default(),
-    ))
+    Ok(Json(config.into()))
 }

--- a/lite/tests/backend/control_plane/stream.rs
+++ b/lite/tests/backend/control_plane/stream.rs
@@ -6,9 +6,10 @@ use s2_common::{
     maybe::Maybe,
     types::{
         config::{
-            BasinConfig, BasinReconfiguration, OptionalDeleteOnEmptyConfig, OptionalStreamConfig,
-            OptionalTimestampingConfig, RetentionPolicy, StorageClass, StreamReconfiguration,
-            TimestampingMode, TimestampingReconfiguration,
+            BasinConfig, BasinReconfiguration, DeleteOnEmptyReconfiguration,
+            OptionalDeleteOnEmptyConfig, OptionalStreamConfig, OptionalTimestampingConfig,
+            RetentionPolicy, StorageClass, StreamReconfiguration, TimestampingMode,
+            TimestampingReconfiguration,
         },
         resources::{ListItemsRequestParts, ProvisionMode, ProvisionResult, RequestToken},
         stream::{
@@ -71,12 +72,9 @@ async fn test_create_stream_honors_basin_defaults() {
         .get_stream_config(basin_name, stream_name)
         .await
         .expect("Failed to fetch stream config");
-    assert_eq!(config.storage_class, Some(StorageClass::Standard));
-    assert_eq!(config.retention_policy, Some(RetentionPolicy::Infinite()));
-    assert_eq!(
-        config.timestamping.mode,
-        Some(TimestampingMode::ClientRequire)
-    );
+    assert_eq!(config.storage_class, StorageClass::Standard);
+    assert_eq!(config.retention_policy, RetentionPolicy::Infinite());
+    assert_eq!(config.timestamping.mode, TimestampingMode::ClientRequire);
 }
 
 #[tokio::test]
@@ -238,7 +236,7 @@ async fn test_create_stream_idempotency_and_request_token() {
         .get_stream_config(basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to fetch stored stream config");
-    assert_eq!(stored_config.storage_class, Some(StorageClass::Express));
+    assert_eq!(stored_config.storage_class, StorageClass::Express);
 
     let idempotent = backend
         .provision_stream(
@@ -351,11 +349,8 @@ async fn test_provision_stream_ensure_preserves_idempotency_key() {
         .get_stream_config(basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to fetch stream config");
-    assert_eq!(stored_config.storage_class, Some(StorageClass::Express));
-    assert_eq!(
-        stored_config.timestamping.mode,
-        Some(TimestampingMode::Arrival)
-    );
+    assert_eq!(stored_config.storage_class, StorageClass::Express);
+    assert_eq!(stored_config.timestamping.mode, TimestampingMode::Arrival);
 
     backend
         .provision_stream(
@@ -456,7 +451,7 @@ async fn test_provision_stream_preserves_explicit_zero_delete_on_empty() {
         .get_stream_config(basin_name.clone(), stream_name.clone())
         .await
         .expect("Failed to fetch stream config");
-    assert_eq!(stored_config.delete_on_empty.min_age, Some(Duration::ZERO));
+    assert_eq!(stored_config.delete_on_empty.min_age, Duration::ZERO);
 
     let ensured = backend
         .provision_stream(basin_name, stream_name, config, ProvisionMode::Ensure)
@@ -575,19 +570,106 @@ async fn test_reconfigure_stream_updates_selected_fields() {
         .await
         .expect("Failed to reconfigure stream");
 
-    assert_eq!(updated.storage_class, Some(StorageClass::Express));
-    assert_eq!(updated.retention_policy, Some(RetentionPolicy::Infinite()));
-    assert_eq!(updated.timestamping.mode, Some(TimestampingMode::Arrival));
-    assert_eq!(updated.timestamping.uncapped, Some(true));
+    assert_eq!(updated.storage_class, StorageClass::Express);
+    assert_eq!(updated.retention_policy, RetentionPolicy::Infinite());
+    assert_eq!(updated.timestamping.mode, TimestampingMode::Arrival);
+    assert!(updated.timestamping.uncapped);
 
     let fetched = backend
         .get_stream_config(basin_name, stream_name)
         .await
         .expect("Failed to fetch stream config after reconfigure");
-    assert_eq!(fetched.storage_class, Some(StorageClass::Express));
-    assert_eq!(fetched.retention_policy, Some(RetentionPolicy::Infinite()));
-    assert_eq!(fetched.timestamping.mode, Some(TimestampingMode::Arrival));
-    assert_eq!(fetched.timestamping.uncapped, Some(true));
+    assert_eq!(fetched.storage_class, StorageClass::Express);
+    assert_eq!(fetched.retention_policy, RetentionPolicy::Infinite());
+    assert_eq!(fetched.timestamping.mode, TimestampingMode::Arrival);
+    assert!(fetched.timestamping.uncapped);
+}
+
+#[tokio::test]
+async fn test_reconfigure_stream_clears_fields_to_basin_defaults() {
+    let backend = create_backend().await;
+    let basin_name = test_basin_name("stream-reconfigure-clear-defaults");
+
+    let basin_config = BasinConfig {
+        default_stream_config: OptionalStreamConfig {
+            storage_class: Some(StorageClass::Standard),
+            retention_policy: Some(RetentionPolicy::Infinite()),
+            timestamping: OptionalTimestampingConfig {
+                mode: Some(TimestampingMode::Arrival),
+                uncapped: Some(true),
+            },
+            delete_on_empty: OptionalDeleteOnEmptyConfig {
+                min_age: Some(Duration::from_secs(300)),
+            },
+        },
+        ..Default::default()
+    };
+
+    backend
+        .provision_basin(
+            basin_name.clone(),
+            basin_config,
+            ProvisionMode::CreateOnly {
+                request_token: None,
+            },
+        )
+        .await
+        .expect("Failed to create basin");
+
+    let stream_name = test_stream_name("stream-reconfigure-clear-defaults");
+    let stream_config = OptionalStreamConfig {
+        storage_class: Some(StorageClass::Express),
+        retention_policy: Some(RetentionPolicy::Age(Duration::from_secs(60))),
+        timestamping: OptionalTimestampingConfig {
+            mode: Some(TimestampingMode::ClientRequire),
+            uncapped: Some(false),
+        },
+        delete_on_empty: OptionalDeleteOnEmptyConfig {
+            min_age: Some(Duration::ZERO),
+        },
+    };
+
+    backend
+        .provision_stream(
+            basin_name.clone(),
+            stream_name.clone(),
+            stream_config,
+            ProvisionMode::CreateOnly {
+                request_token: None,
+            },
+        )
+        .await
+        .expect("Failed to create stream");
+
+    let reconfig = StreamReconfiguration {
+        storage_class: Maybe::from(None),
+        retention_policy: Maybe::from(None),
+        timestamping: Maybe::from(Some(TimestampingReconfiguration {
+            mode: Maybe::from(None),
+            uncapped: Maybe::from(None),
+        })),
+        delete_on_empty: Maybe::from(Some(DeleteOnEmptyReconfiguration {
+            min_age: Maybe::from(None),
+        })),
+    };
+
+    let updated = backend
+        .reconfigure_stream(basin_name.clone(), stream_name.clone(), reconfig)
+        .await
+        .expect("Failed to reconfigure stream");
+
+    assert_eq!(updated.storage_class, StorageClass::Standard);
+    assert_eq!(updated.retention_policy, RetentionPolicy::Infinite());
+    assert_eq!(updated.timestamping.mode, TimestampingMode::Arrival);
+    assert!(updated.timestamping.uncapped);
+    assert_eq!(updated.delete_on_empty.min_age, Duration::from_secs(300));
+
+    let fetched = backend
+        .get_stream_config(basin_name, stream_name)
+        .await
+        .expect("Failed to fetch stream config after reconfigure");
+
+    assert_eq!(fetched, updated);
 }
 
 #[tokio::test]

--- a/lite/tests/backend/data_plane/mixed.rs
+++ b/lite/tests/backend/data_plane/mixed.rs
@@ -159,7 +159,7 @@ async fn test_concurrent_reconfigure_during_append() {
         .reconfigure_stream(basin_name.clone(), stream_name.clone(), reconfig)
         .await
         .expect("Failed to reconfigure stream during appends");
-    assert_eq!(updated_config.storage_class, Some(StorageClass::Express));
+    assert_eq!(updated_config.storage_class, StorageClass::Express);
 
     append_handle.await.unwrap();
 


### PR DESCRIPTION
## Summary
- resolve explicitly cleared lite stream config fields through basin defaults during reconfigure
- reject stream reconfigure while the containing basin is deletion-pending
- store and pass effective stream config as concrete `StreamConfig` in stream metadata, streamer state, and backend get/reconfigure returns
- keep `OptionalStreamConfig` on request/config-default surfaces where partial config is still meaningful
- clean up follow-on concrete-config callsites and stale optional-config wording
- add regression coverage for clearing top-level and nested stream config fields

## Notes
- Matches the s2-cloud patch endpoint behavior: apply the reconfiguration, merge basin default stream config, then write and return the effective stream config.

Fixes #327

## Tests
- `just fmt`
- `cargo check -p s2-lite`
- `cargo test -p s2-lite streamer::`
- `cargo test -p s2-lite test_reconfigure_stream_clears_fields_to_basin_defaults`
- `cargo test -p s2-lite backend::control_plane::stream::`
- `cargo test -p s2-lite backend::data_plane::mixed::test_concurrent_reconfigure_during_append`
- `cargo test -p s2-lite handlers::v1::streams`
- `just test`