### PR TITLE
fix(lite): map control-plane transaction conflicts

### DIFF
--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -355,6 +355,8 @@ pub enum DeleteStreamError {
     #[error(transparent)]
     Storage(#[from] StorageError),
     #[error(transparent)]
+    TransactionConflict(#[from] TransactionConflictError),
+    #[error(transparent)]
     StreamerMissingInActionError(#[from] StreamerMissingInActionError),
     #[error(transparent)]
     RequestDroppedError(#[from] RequestDroppedError),
@@ -364,7 +366,11 @@ pub enum DeleteStreamError {
 
 impl From<slatedb::Error> for DeleteStreamError {
     fn from(err: slatedb::Error) -> Self {
-        Self::Storage(err.into())
+        if err.kind() == slatedb::ErrorKind::Transaction {
+            Self::TransactionConflict(TransactionConflictError)
+        } else {
+            Self::Storage(err.into())
+        }
     }
 }
 
@@ -407,6 +413,8 @@ pub enum ProvisionBasinError {
     #[error(transparent)]
     Storage(#[from] StorageError),
     #[error(transparent)]
+    TransactionConflict(#[from] TransactionConflictError),
+    #[error(transparent)]
     BasinAlreadyExists(#[from] BasinAlreadyExistsError),
     #[error(transparent)]
     BasinDeletionPending(#[from] BasinDeletionPendingError),
@@ -414,7 +422,11 @@ pub enum ProvisionBasinError {
 
 impl From<slatedb::Error> for ProvisionBasinError {
     fn from(err: slatedb::Error) -> Self {
-        Self::Storage(err.into())
+        if err.kind() == slatedb::ErrorKind::Transaction {
+            Self::TransactionConflict(TransactionConflictError)
+        } else {
+            Self::Storage(err.into())
+        }
     }
 }
 
@@ -481,11 +493,17 @@ pub enum DeleteBasinError {
     #[error(transparent)]
     Storage(#[from] StorageError),
     #[error(transparent)]
+    TransactionConflict(#[from] TransactionConflictError),
+    #[error(transparent)]
     BasinNotFound(#[from] BasinNotFoundError),
 }
 
 impl From<slatedb::Error> for DeleteBasinError {
     fn from(err: slatedb::Error) -> Self {
-        Self::Storage(err.into())
+        if err.kind() == slatedb::ErrorKind::Transaction {
+            Self::TransactionConflict(TransactionConflictError)
+        } else {
+            Self::Storage(err.into())
+        }
     }
 }

--- a/lite/src/handlers/v1/basins.rs
+++ b/lite/src/handlers/v1/basins.rs
@@ -135,6 +135,7 @@ pub struct GetConfigArgs {
     tag = super::paths::basins::TAG,
     responses(
         (status = StatusCode::OK, body = v1t::config::BasinConfig),
+        (status = StatusCode::CONFLICT, body = v1t::error::ErrorInfo),
         (status = StatusCode::NOT_FOUND, body = v1t::error::ErrorInfo),
         (status = StatusCode::BAD_REQUEST, body = v1t::error::ErrorInfo),
         (status = StatusCode::FORBIDDEN, body = v1t::error::ErrorInfo),
@@ -168,6 +169,7 @@ pub struct EnsureArgs {
     responses(
         (status = StatusCode::OK, body = v1t::basin::BasinInfo),
         (status = StatusCode::CREATED, body = v1t::basin::BasinInfo),
+        (status = StatusCode::CONFLICT, body = v1t::error::ErrorInfo),
         (status = StatusCode::BAD_REQUEST, body = v1t::error::ErrorInfo),
         (status = StatusCode::REQUEST_TIMEOUT, body = v1t::error::ErrorInfo),
     ),
@@ -221,6 +223,7 @@ pub struct DeleteArgs {
     tag = super::paths::basins::TAG,
     responses(
         (status = StatusCode::ACCEPTED),
+        (status = StatusCode::CONFLICT, body = v1t::error::ErrorInfo),
         (status = StatusCode::NOT_FOUND, body = v1t::error::ErrorInfo),
         (status = StatusCode::BAD_REQUEST, body = v1t::error::ErrorInfo),
         (status = StatusCode::FORBIDDEN, body = v1t::error::ErrorInfo),

--- a/lite/src/handlers/v1/error.rs
+++ b/lite/src/handlers/v1/error.rs
@@ -100,6 +100,9 @@ impl ServiceError {
             },
             ServiceError::ProvisionBasin(e) => match e {
                 ProvisionBasinError::Storage(e) => standard(ErrorCode::Storage, e.to_string()),
+                ProvisionBasinError::TransactionConflict(e) => {
+                    standard(ErrorCode::TransactionConflict, e.to_string())
+                }
                 ProvisionBasinError::BasinAlreadyExists(e) => {
                     standard(ErrorCode::ResourceAlreadyExists, e.to_string())
                 }
@@ -115,6 +118,9 @@ impl ServiceError {
             },
             ServiceError::DeleteBasin(e) => match e {
                 DeleteBasinError::Storage(e) => standard(ErrorCode::Storage, e.to_string()),
+                DeleteBasinError::TransactionConflict(e) => {
+                    standard(ErrorCode::TransactionConflict, e.to_string())
+                }
                 DeleteBasinError::BasinNotFound(e) => {
                     standard(ErrorCode::BasinNotFound, e.to_string())
                 }
@@ -164,6 +170,9 @@ impl ServiceError {
             },
             ServiceError::DeleteStream(e) => match e {
                 DeleteStreamError::Storage(e) => standard(ErrorCode::Storage, e.to_string()),
+                DeleteStreamError::TransactionConflict(e) => {
+                    standard(ErrorCode::TransactionConflict, e.to_string())
+                }
                 DeleteStreamError::StreamerMissingInActionError(e) => {
                     standard(ErrorCode::Unavailable, e.to_string())
                 }

--- a/lite/src/handlers/v1/streams.rs
+++ b/lite/src/handlers/v1/streams.rs
@@ -269,6 +269,7 @@ pub struct DeleteArgs {
     tag = super::paths::streams::TAG,
     responses(
         (status = StatusCode::ACCEPTED),
+        (status = StatusCode::CONFLICT, body = v1t::error::ErrorInfo),
         (status = StatusCode::NOT_FOUND, body = v1t::error::ErrorInfo),
         (status = StatusCode::BAD_REQUEST, body = v1t::error::ErrorInfo),
         (status = StatusCode::FORBIDDEN, body = v1t::error::ErrorInfo),


### PR DESCRIPTION
## Summary
- classify SlateDB transaction errors as `transaction_conflict` for basin provisioning, basin deletion, and stream deletion
- document 409 responses for the affected v1 endpoints

Fixes #356.

## Tests
- `just fmt`
- `just test`