### PR TITLE
chore: scope as free string

### DIFF
--- a/api/src/v1/basin.rs
+++ b/api/src/v1/basin.rs
@@ -48,7 +48,7 @@ pub struct BasinInfo {
     /// Basin name.
     pub name: BasinName,
     /// Basin scope.
-    pub scope: Option<BasinScope>,
+    pub scope: Option<String>,
     /// Creation time in RFC 3339 format.
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
@@ -71,7 +71,7 @@ impl From<types::basin::BasinInfo> for BasinInfo {
 
         Self {
             name,
-            scope: scope.map(Into::into),
+            scope,
             created_at,
             deleted_at,
             state: basin_state_for_deleted_at(deleted_at.as_ref()),
@@ -90,7 +90,7 @@ fn basin_state_for_deleted_at(deleted_at: Option<&OffsetDateTime>) -> BasinState
 #[derive(Deserialize)]
 struct BasinInfoSerde {
     name: BasinName,
-    scope: Option<BasinScope>,
+    scope: Option<String>,
     #[serde(with = "time::serde::rfc3339")]
     created_at: OffsetDateTime,
     #[serde(default, with = "time::serde::rfc3339::option")]
@@ -123,41 +123,6 @@ impl<'de> Deserialize<'de> for BasinInfo {
 #[rustfmt::skip]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-pub enum BasinScope {
-    /// AWS `us-east-1` region.
-    #[serde(rename = "aws:us-east-1")]
-    AwsUsEast1,
-    /// AWS `us-west-2` region.
-    #[serde(rename = "aws:us-west-2")]
-    AwsUsWest2,
-    /// AWS `eu-north-1` region.
-    #[serde(rename = "aws:eu-north-1")]
-    AwsEuNorth1,
-}
-
-impl From<BasinScope> for types::basin::BasinScope {
-    fn from(value: BasinScope) -> Self {
-        match value {
-            BasinScope::AwsUsEast1 => Self::AwsUsEast1,
-            BasinScope::AwsUsWest2 => Self::AwsUsWest2,
-            BasinScope::AwsEuNorth1 => Self::AwsEuNorth1,
-        }
-    }
-}
-
-impl From<types::basin::BasinScope> for BasinScope {
-    fn from(value: types::basin::BasinScope) -> Self {
-        match value {
-            types::basin::BasinScope::AwsUsEast1 => Self::AwsUsEast1,
-            types::basin::BasinScope::AwsUsWest2 => Self::AwsUsWest2,
-            types::basin::BasinScope::AwsEuNorth1 => Self::AwsEuNorth1,
-        }
-    }
-}
-
-#[rustfmt::skip]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum BasinState {
     /// Basin is active.
@@ -175,7 +140,7 @@ pub struct EnsureBasinRequest {
     /// Basin scope.
     /// If omitted when creating, defaults to `aws:us-east-1`.
     /// This cannot be changed.
-    pub scope: Option<BasinScope>,
+    pub scope: Option<String>,
 }
 
 #[rustfmt::skip]
@@ -190,5 +155,5 @@ pub struct CreateBasinRequest {
     pub config: Option<BasinConfig>,
     /// Basin scope.
     /// If omitted, defaults to `aws:us-east-1`.
-    pub scope: Option<BasinScope>,
+    pub scope: Option<String>,
 }

--- a/api/src/v1/basin.rs
+++ b/api/src/v1/basin.rs
@@ -138,7 +138,7 @@ pub struct EnsureBasinRequest {
     /// Basin configuration.
     pub config: Option<BasinConfig>,
     /// Basin scope.
-    /// If omitted when creating, uses the configured default scope.
+    /// If omitted when creating, the server assigns the default scope.
     /// This cannot be changed.
     pub scope: Option<String>,
 }
@@ -154,6 +154,6 @@ pub struct CreateBasinRequest {
     /// Basin configuration.
     pub config: Option<BasinConfig>,
     /// Basin scope.
-    /// If omitted when creating, uses the configured default scope.
+    /// If omitted, the server assigns the default scope.
     pub scope: Option<String>,
 }

--- a/api/src/v1/basin.rs
+++ b/api/src/v1/basin.rs
@@ -138,7 +138,7 @@ pub struct EnsureBasinRequest {
     /// Basin configuration.
     pub config: Option<BasinConfig>,
     /// Basin scope.
-    /// If omitted when creating, the server assigns the default scope.
+    /// If omitted when creating, uses the configured default scope.
     /// This cannot be changed.
     pub scope: Option<String>,
 }
@@ -154,6 +154,6 @@ pub struct CreateBasinRequest {
     /// Basin configuration.
     pub config: Option<BasinConfig>,
     /// Basin scope.
-    /// If omitted, the server assigns the default scope.
+    /// If omitted when creating, uses the configured default scope.
     pub scope: Option<String>,
 }

--- a/api/src/v1/basin.rs
+++ b/api/src/v1/basin.rs
@@ -138,7 +138,7 @@ pub struct EnsureBasinRequest {
     /// Basin configuration.
     pub config: Option<BasinConfig>,
     /// Basin scope.
-    /// If omitted when creating, defaults to `aws:us-east-1`.
+    /// If omitted when creating, uses the configured default scope.
     /// This cannot be changed.
     pub scope: Option<String>,
 }
@@ -154,6 +154,6 @@ pub struct CreateBasinRequest {
     /// Basin configuration.
     pub config: Option<BasinConfig>,
     /// Basin scope.
-    /// If omitted, defaults to `aws:us-east-1`.
+    /// If omitted when creating, uses the configured default scope.
     pub scope: Option<String>,
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -263,7 +263,7 @@ pub struct CreateBasinArgs {
     /// Name of the basin to create.
     pub basin: S2BasinUri,
 
-    /// Cloud provider and region for the basin.
+    /// Basin scope.
     #[arg(long)]
     pub scope: Option<BasinScope>,
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -226,7 +226,11 @@ async fn run() -> Result<(), CliError> {
 
                 let (basins, _) = ops::list_basins(&s2, list_basins_args).await?;
                 for basin_info in basins {
-                    print_listing_uri(basin_info.name.to_string(), basin_info.deleted_at.is_some());
+                    print_basin_listing(
+                        basin_info.name.to_string(),
+                        basin_info.scope.as_deref(),
+                        basin_info.deleted_at.is_some(),
+                    );
                 }
             }
         }
@@ -234,7 +238,11 @@ async fn run() -> Result<(), CliError> {
         Command::ListBasins(args) => {
             let (basins, _) = ops::list_basins(&s2, args).await?;
             for basin_info in basins {
-                print_listing_uri(basin_info.name.to_string(), basin_info.deleted_at.is_some());
+                print_basin_listing(
+                    basin_info.name.to_string(),
+                    basin_info.scope.as_deref(),
+                    basin_info.deleted_at.is_some(),
+                );
             }
         }
 
@@ -632,6 +640,16 @@ fn print_listing_uri(uri: String, is_deleting: bool) {
     }
 }
 
+fn print_basin_listing(name: String, scope: Option<&str>, is_deleting: bool) {
+    let name = format_listing_uri(name, is_deleting);
+    let scope = format_listing_scope(&format!("({})", scope.unwrap_or("-")), is_deleting);
+    if is_deleting {
+        println!("{} {} {}", name, scope, deletion_marker());
+    } else {
+        println!("{} {}", name, scope);
+    }
+}
+
 fn print_listing_with_created_at(uri: String, created_at: String, is_deleting: bool) {
     let uri = format_listing_uri(uri, is_deleting);
     let created_at = if is_deleting {
@@ -649,6 +667,14 @@ fn print_listing_with_created_at(uri: String, created_at: String, is_deleting: b
 
 fn format_listing_uri(uri: String, is_deleting: bool) -> colored::ColoredString {
     if is_deleting { uri.red() } else { uri.normal() }
+}
+
+fn format_listing_scope(scope: &str, is_deleting: bool) -> colored::ColoredString {
+    if is_deleting {
+        scope.red()
+    } else {
+        scope.yellow()
+    }
 }
 
 fn deletion_marker() -> colored::ColoredString {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -642,11 +642,12 @@ fn print_listing_uri(uri: String, is_deleting: bool) {
 
 fn print_basin_listing(name: String, scope: Option<&str>, is_deleting: bool) {
     let name = format_listing_uri(name, is_deleting);
-    let scope = format_listing_scope(&format!("({})", scope.unwrap_or("-")), is_deleting);
-    if is_deleting {
-        println!("{} {} {}", name, scope, deletion_marker());
-    } else {
-        println!("{} {}", name, scope);
+    let scope = scope.map(|scope| format_listing_scope(&format!("({scope})"), is_deleting));
+    match (scope, is_deleting) {
+        (Some(scope), true) => println!("{} {} {}", name, scope, deletion_marker()),
+        (Some(scope), false) => println!("{} {}", name, scope),
+        (None, true) => println!("{} {}", name, deletion_marker()),
+        (None, false) => println!("{name}"),
     }
 }
 

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -96,7 +96,7 @@ pub async fn list_basins(
 pub async fn create_basin(s2: &S2, args: CreateBasinArgs) -> Result<BasinInfo, CliError> {
     let mut input = CreateBasinInput::new(args.basin.into()).with_config(args.config.into());
     if let Some(scope) = args.scope {
-        input = input.with_scope(scope.into());
+        input = input.with_scope(scope);
     }
     s2.create_basin(input)
         .await

--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -627,7 +627,7 @@ pub enum InputMode {
     /// Creating a new basin
     CreateBasin {
         name: String,
-        scope: BasinScopeOption,
+        scope: String,
         create_stream_on_append: bool,
         create_stream_on_read: bool,
         storage_class: Option<StorageClass>,
@@ -816,33 +816,6 @@ fn timestamping_mode_prev(tm: &Option<TimestampingMode>) -> Option<TimestampingM
         Some(TimestampingMode::ClientPrefer) => None,
         Some(TimestampingMode::ClientRequire) => Some(TimestampingMode::ClientPrefer),
         Some(TimestampingMode::Arrival) => Some(TimestampingMode::ClientRequire),
-    }
-}
-
-/// Basin scope option for UI (cloud provider/region)
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
-pub enum BasinScopeOption {
-    #[default]
-    AwsUsEast1,
-    AwsUsWest2,
-    AwsEuNorth1,
-}
-
-impl BasinScopeOption {
-    pub fn next(self) -> Self {
-        match self {
-            Self::AwsUsEast1 => Self::AwsUsWest2,
-            Self::AwsUsWest2 => Self::AwsEuNorth1,
-            Self::AwsEuNorth1 => Self::AwsUsEast1,
-        }
-    }
-
-    pub fn prev(self) -> Self {
-        match self {
-            Self::AwsUsEast1 => Self::AwsEuNorth1,
-            Self::AwsUsWest2 => Self::AwsUsEast1,
-            Self::AwsEuNorth1 => Self::AwsUsWest2,
-        }
     }
 }
 
@@ -2329,6 +2302,7 @@ impl App {
                 if *editing {
                     let field: Option<&mut String> = match *selected {
                         0 => Some(name),
+                        1 => Some(scope),
                         4 => Some(retention_age_input),
                         8 => Some(delete_on_empty_min_age),
                         _ => None,
@@ -2374,6 +2348,9 @@ impl App {
                                     name.insert(*cursor, c);
                                     *cursor += 1;
                                 }
+                            } else if *selected == 1 && c.is_ascii_graphic() {
+                                scope.insert(*cursor, c);
+                                *cursor += 1;
                             } else if *selected == 4 && c.is_ascii_alphanumeric() {
                                 retention_age_input.insert(*cursor, c);
                                 *cursor += 1;
@@ -2416,6 +2393,10 @@ impl App {
                                 *cursor = name.len();
                                 *editing = true;
                             }
+                            1 => {
+                                *cursor = scope.len();
+                                *editing = true;
+                            }
                             4 if *retention_policy == RetentionPolicyOption::Age => {
                                 *cursor = retention_age_input.len();
                                 *editing = true;
@@ -2426,7 +2407,7 @@ impl App {
                             }
                             11 if name.len() >= 8 => {
                                 let basin_name = name.clone();
-                                let basin_scope = *scope;
+                                let basin_scope = scope.clone();
                                 let csoa = *create_stream_on_append;
                                 let csor = *create_stream_on_read;
                                 let sc = storage_class.clone();
@@ -2455,7 +2436,6 @@ impl App {
                             _ => {}
                         },
                         KeyCode::Left | KeyCode::Char('h') => match *selected {
-                            1 => *scope = scope.prev(),
                             2 => *storage_class = storage_class_prev(storage_class),
                             3 => *retention_policy = retention_policy.toggle(),
                             5 => *timestamping_mode = timestamping_mode_prev(timestamping_mode),
@@ -2463,7 +2443,6 @@ impl App {
                             _ => {}
                         },
                         KeyCode::Right | KeyCode::Char('l') => match *selected {
-                            1 => *scope = scope.next(),
                             2 => *storage_class = storage_class_next(storage_class),
                             3 => *retention_policy = retention_policy.toggle(),
                             5 => *timestamping_mode = timestamping_mode_next(timestamping_mode),
@@ -3645,7 +3624,7 @@ impl App {
             KeyCode::Char('c') => {
                 self.input_mode = InputMode::CreateBasin {
                     name: String::new(),
-                    scope: BasinScopeOption::AwsUsEast1,
+                    scope: "aws:us-east-1".to_owned(),
                     create_stream_on_append: false,
                     create_stream_on_read: false,
                     storage_class: None,
@@ -4309,7 +4288,7 @@ impl App {
     fn create_basin_with_config(
         &mut self,
         name: String,
-        scope: BasinScopeOption,
+        scope: String,
         config: BasinConfig,
         tx: mpsc::UnboundedSender<Event>,
     ) {
@@ -4326,14 +4305,11 @@ impl App {
                     return;
                 }
             };
-            let sdk_scope = match scope {
-                BasinScopeOption::AwsUsEast1 => s2_sdk::types::BasinScope::AwsUsEast1,
-                BasinScopeOption::AwsUsWest2 => s2_sdk::types::BasinScope::AwsUsWest2,
-                BasinScopeOption::AwsEuNorth1 => s2_sdk::types::BasinScope::AwsEuNorth1,
-            };
-            let input = s2_sdk::types::CreateBasinInput::new(basin_name)
-                .with_config(config.into())
-                .with_scope(sdk_scope);
+            let mut input =
+                s2_sdk::types::CreateBasinInput::new(basin_name).with_config(config.into());
+            if !scope.is_empty() {
+                input = input.with_scope(scope);
+            }
 
             match s2
                 .create_basin(input)

--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -3624,7 +3624,7 @@ impl App {
             KeyCode::Char('c') => {
                 self.input_mode = InputMode::CreateBasin {
                     name: String::new(),
-                    scope: "aws:us-east-1".to_owned(),
+                    scope: String::new(),
                     create_stream_on_append: false,
                     create_stream_on_read: false,
                     storage_class: None,

--- a/cli/src/tui/ui.rs
+++ b/cli/src/tui/ui.rs
@@ -2473,16 +2473,7 @@ fn draw_basins(f: &mut Frame, area: Rect, state: &BasinsState) {
         } else {
             ("Active", BADGE_ACTIVE)
         };
-        let scope = basin
-            .scope
-            .as_ref()
-            .map(|s| match s {
-                s2_sdk::types::BasinScope::AwsUsEast1 => "aws:us-east-1",
-                s2_sdk::types::BasinScope::AwsUsWest2 => "aws:us-west-2",
-                s2_sdk::types::BasinScope::AwsEuNorth1 => "aws:eu-north-1",
-                _ => "unknown",
-            })
-            .unwrap_or("—");
+        let scope = basin.scope.as_ref().map(String::as_str).unwrap_or("—");
 
         let prefix = if is_selected { "▸ " } else { "  " };
         let name_style = if is_selected {
@@ -4423,7 +4414,7 @@ fn get_selected_line_hint(mode: &InputMode) -> usize {
         InputMode::Normal => 0,
         InputMode::CreateBasin { selected, .. } => match selected {
             0 => 3,   // Name
-            1 => 7,   // Region
+            1 => 7,   // Scope
             2 => 12,  // Storage
             3 => 16,  // Retention
             4 => 19,  // Duration
@@ -4528,16 +4519,7 @@ fn draw_input_dialog(f: &mut Frame, mode: &InputMode) {
             editing,
             cursor,
         } => {
-            use crate::tui::app::BasinScopeOption;
-
             let name_valid = name.len() >= 8 && name.len() <= 48;
-
-            // Scope options
-            let scope_opts = [
-                ("AWS us-east-1", *scope == BasinScopeOption::AwsUsEast1),
-                ("AWS us-west-2", *scope == BasinScopeOption::AwsUsWest2),
-                ("AWS eu-north-1", *scope == BasinScopeOption::AwsEuNorth1),
-            ];
 
             // Storage class options
             let storage_opts = [
@@ -4622,14 +4604,17 @@ fn draw_input_dialog(f: &mut Frame, mode: &InputMode) {
                 Span::styled(hint_text, Style::default().fg(hint_color).italic()),
             ]));
 
-            // Basin Scope (Cloud Provider/Region)
+            // Basin scope
             lines.push(Line::from(""));
-            let (ind, lbl) = render_field_row_bold(1, "Region", *selected);
+            let (ind, lbl) = render_field_row_bold(1, "Scope", *selected);
             let mut scope_spans = vec![ind, lbl, Span::raw("  ")];
-            for (label, active) in &scope_opts {
-                scope_spans.push(render_pill(label, *selected == 1, *active));
-                scope_spans.push(Span::raw(" "));
-            }
+            scope_spans.extend(render_text_input_with_cursor(
+                scope,
+                *selected == 1 && *editing,
+                "aws:us-east-1",
+                CYAN,
+                *cursor,
+            ));
             lines.push(Line::from(scope_spans));
 
             // Default stream configuration section

--- a/cli/src/tui/ui.rs
+++ b/cli/src/tui/ui.rs
@@ -4611,7 +4611,7 @@ fn draw_input_dialog(f: &mut Frame, mode: &InputMode) {
             scope_spans.extend(render_text_input_with_cursor(
                 scope,
                 *selected == 1 && *editing,
-                "aws:us-east-1",
+                "server default",
                 CYAN,
                 *cursor,
             ));

--- a/cli/src/tui/ui.rs
+++ b/cli/src/tui/ui.rs
@@ -2473,7 +2473,7 @@ fn draw_basins(f: &mut Frame, area: Rect, state: &BasinsState) {
         } else {
             ("Active", BADGE_ACTIVE)
         };
-        let scope = basin.scope.as_ref().map(String::as_str).unwrap_or("—");
+        let scope = basin.scope.as_deref().unwrap_or("—");
 
         let prefix = if is_selected { "▸ " } else { "  " };
         let name_style = if is_selected {

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -172,18 +172,7 @@ impl StreamConfig {
     }
 }
 
-#[derive(ValueEnum, Debug, Clone, Serialize)]
-pub enum BasinScope {
-    #[value(name = "aws:us-east-1")]
-    #[serde(rename = "aws:us-east-1")]
-    AwsUsEast1,
-    #[value(name = "aws:us-west-2")]
-    #[serde(rename = "aws:us-west-2")]
-    AwsUsWest2,
-    #[value(name = "aws:eu-north-1")]
-    #[serde(rename = "aws:eu-north-1")]
-    AwsEuNorth1,
-}
+pub type BasinScope = String;
 
 #[derive(ValueEnum, Debug, Clone, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -297,29 +286,6 @@ impl From<StreamConfig> for sdk::types::StreamConfig {
             stream_config = stream_config.with_delete_on_empty(delete_on_empty.into());
         }
         stream_config
-    }
-}
-
-impl From<BasinScope> for sdk::types::BasinScope {
-    fn from(scope: BasinScope) -> Self {
-        match scope {
-            BasinScope::AwsUsEast1 => sdk::types::BasinScope::AwsUsEast1,
-            BasinScope::AwsUsWest2 => sdk::types::BasinScope::AwsUsWest2,
-            BasinScope::AwsEuNorth1 => sdk::types::BasinScope::AwsEuNorth1,
-        }
-    }
-}
-
-impl From<sdk::types::BasinScope> for BasinScope {
-    fn from(scope: sdk::types::BasinScope) -> Self {
-        match scope {
-            sdk::types::BasinScope::AwsUsEast1 => BasinScope::AwsUsEast1,
-            sdk::types::BasinScope::AwsUsWest2 => BasinScope::AwsUsWest2,
-            sdk::types::BasinScope::AwsEuNorth1 => BasinScope::AwsEuNorth1,
-            _ => unreachable!(
-                "s2-cli is released together with s2-sdk; new BasinScope variants are added to both"
-            ),
-        }
     }
 }
 

--- a/common/src/types/basin.rs
+++ b/common/src/types/basin.rs
@@ -200,17 +200,7 @@ impl crate::http::ParseableHeader for BasinName {
 
 pub type ListBasinsRequest = ListItemsRequest<BasinNamePrefix, BasinNameStartAfter>;
 
-#[derive(
-    Debug, strum::Display, strum::EnumString, strum::IntoStaticStr, Clone, Copy, PartialEq, Eq,
-)]
-pub enum BasinScope {
-    #[strum(serialize = "aws:us-east-1")]
-    AwsUsEast1,
-    #[strum(serialize = "aws:us-west-2")]
-    AwsUsWest2,
-    #[strum(serialize = "aws:eu-north-1")]
-    AwsEuNorth1,
-}
+pub type BasinScope = String;
 
 #[derive(Debug, Clone)]
 pub struct BasinInfo {

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -876,7 +876,7 @@ pub struct CreateBasinInput {
     pub config: Option<BasinConfig>,
     /// Scope of the basin.
     ///
-    /// If omitted, the server assigns the default scope.
+    /// If omitted when creating, uses the configured default scope.
     pub scope: Option<BasinScope>,
     idempotency_token: String,
 }
@@ -936,7 +936,7 @@ pub struct EnsureBasinInput {
     config: Option<api::config::BasinConfig>,
     /// Scope of the basin.
     ///
-    /// If omitted when creating, the server assigns the default scope. Cannot be changed once set.
+    /// If omitted when creating, uses the configured default scope. Cannot be changed once set.
     pub scope: Option<BasinScope>,
 }
 

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -876,7 +876,7 @@ pub struct CreateBasinInput {
     pub config: Option<BasinConfig>,
     /// Scope of the basin.
     ///
-    /// Defaults to `aws:us-east-1`.
+    /// If omitted, the server assigns the default scope.
     pub scope: Option<BasinScope>,
     idempotency_token: String,
 }
@@ -936,7 +936,7 @@ pub struct EnsureBasinInput {
     config: Option<api::config::BasinConfig>,
     /// Scope of the basin.
     ///
-    /// Defaults to `aws:us-east-1`. Cannot be changed once set.
+    /// If omitted when creating, the server assigns the default scope. Cannot be changed once set.
     pub scope: Option<BasinScope>,
 }
 

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -861,37 +861,8 @@ impl From<BasinConfig> for api::config::BasinConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 /// Scope of a basin.
-#[non_exhaustive]
-pub enum BasinScope {
-    /// AWS `us-east-1` region.
-    AwsUsEast1,
-    /// AWS `us-west-2` region.
-    AwsUsWest2,
-    /// AWS `eu-north-1` region.
-    AwsEuNorth1,
-}
-
-impl From<api::basin::BasinScope> for BasinScope {
-    fn from(value: api::basin::BasinScope) -> Self {
-        match value {
-            api::basin::BasinScope::AwsUsEast1 => BasinScope::AwsUsEast1,
-            api::basin::BasinScope::AwsUsWest2 => BasinScope::AwsUsWest2,
-            api::basin::BasinScope::AwsEuNorth1 => BasinScope::AwsEuNorth1,
-        }
-    }
-}
-
-impl From<BasinScope> for api::basin::BasinScope {
-    fn from(value: BasinScope) -> Self {
-        match value {
-            BasinScope::AwsUsEast1 => api::basin::BasinScope::AwsUsEast1,
-            BasinScope::AwsUsWest2 => api::basin::BasinScope::AwsUsWest2,
-            BasinScope::AwsEuNorth1 => api::basin::BasinScope::AwsEuNorth1,
-        }
-    }
-}
+pub type BasinScope = String;
 
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -905,7 +876,7 @@ pub struct CreateBasinInput {
     pub config: Option<BasinConfig>,
     /// Scope of the basin.
     ///
-    /// Defaults to [`AwsUsEast1`](BasinScope::AwsUsEast1).
+    /// Defaults to `aws:us-east-1`.
     pub scope: Option<BasinScope>,
     idempotency_token: String,
 }
@@ -930,9 +901,9 @@ impl CreateBasinInput {
     }
 
     /// Set the scope of the basin.
-    pub fn with_scope(self, scope: BasinScope) -> Self {
+    pub fn with_scope(self, scope: impl Into<BasinScope>) -> Self {
         Self {
-            scope: Some(scope),
+            scope: Some(scope.into()),
             ..self
         }
     }
@@ -944,7 +915,7 @@ impl From<CreateBasinInput> for (api::basin::CreateBasinRequest, String) {
             api::basin::CreateBasinRequest {
                 basin: value.name,
                 config: value.config.map(Into::into),
-                scope: value.scope.map(Into::into),
+                scope: value.scope,
             },
             value.idempotency_token,
         )
@@ -965,7 +936,7 @@ pub struct EnsureBasinInput {
     config: Option<api::config::BasinConfig>,
     /// Scope of the basin.
     ///
-    /// Defaults to [`AwsUsEast1`](BasinScope::AwsUsEast1). Cannot be changed once set.
+    /// Defaults to `aws:us-east-1`. Cannot be changed once set.
     pub scope: Option<BasinScope>,
 }
 
@@ -989,9 +960,9 @@ impl EnsureBasinInput {
     }
 
     /// Set the scope of the basin.
-    pub fn with_scope(self, scope: BasinScope) -> Self {
+    pub fn with_scope(self, scope: impl Into<BasinScope>) -> Self {
         Self {
-            scope: Some(scope),
+            scope: Some(scope.into()),
             ..self
         }
     }
@@ -1004,7 +975,7 @@ impl From<EnsureBasinInput> for (BasinName, Option<api::basin::EnsureBasinReques
         let request = if config.is_some() || value.scope.is_some() {
             Some(api::basin::EnsureBasinRequest {
                 config,
-                scope: value.scope.map(Into::into),
+                scope: value.scope,
             })
         } else {
             None
@@ -1140,7 +1111,7 @@ impl TryFrom<api::basin::BasinInfo> for BasinInfo {
     fn try_from(value: api::basin::BasinInfo) -> Result<Self, Self::Error> {
         Ok(Self {
             name: value.name,
-            scope: value.scope.map(Into::into),
+            scope: value.scope,
             created_at: value.created_at.try_into()?,
             deleted_at: value.deleted_at.map(S2DateTime::try_from).transpose()?,
         })


### PR DESCRIPTION
Moves `scope` to a server-validated field. Also adds it to `list-basins` display output in cli.