### PR TITLE
fix(lite): reject appends during stream deletion

### DIFF
--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -119,7 +119,7 @@ impl Backend {
         let fencing_token = fencing_token.unwrap_or_default();
 
         if trim_point == Some(..NonZeroSeqNum::MAX) {
-            return Err(StreamDeletionPendingError { basin, stream }.into());
+            return Err(StreamDeletionPendingError.into());
         }
 
         let streamer_slots = self.streamer_slots.clone();

--- a/lite/src/backend/error.rs
+++ b/lite/src/backend/error.rs
@@ -55,11 +55,8 @@ pub struct BasinDeletionPendingError {
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
-#[error("stream `{stream}` in basin `{basin}` is being deleted")]
-pub struct StreamDeletionPendingError {
-    pub basin: BasinName,
-    pub stream: StreamName,
-}
+#[error("stream deletion pending")]
+pub struct StreamDeletionPendingError;
 
 #[derive(Debug, Clone, thiserror::Error)]
 #[error("unwritten position: {0}")]
@@ -107,6 +104,8 @@ pub(super) enum AppendErrorInternal {
     StreamerMissingInActionError(#[from] StreamerMissingInActionError),
     #[error(transparent)]
     RequestDroppedError(#[from] RequestDroppedError),
+    #[error(transparent)]
+    StreamDeletionPending(#[from] StreamDeletionPendingError),
     #[error(transparent)]
     ConditionFailed(#[from] AppendConditionFailedError),
     #[error(transparent)]
@@ -189,6 +188,7 @@ impl From<AppendErrorInternal> for AppendError {
                 AppendError::StreamerMissingInActionError(e)
             }
             AppendErrorInternal::RequestDroppedError(e) => AppendError::RequestDroppedError(e),
+            AppendErrorInternal::StreamDeletionPending(e) => AppendError::StreamDeletionPending(e),
             AppendErrorInternal::ConditionFailed(e) => AppendError::ConditionFailed(e),
             AppendErrorInternal::TimestampMissing(e) => AppendError::TimestampMissing(e),
             AppendErrorInternal::MaxSeqNum(e) => AppendError::MaxSeqNum(e),

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -43,7 +43,8 @@ use crate::{
         durability_notifier::DurabilityNotifier,
         error::{
             AppendConditionFailedError, AppendErrorInternal, AppendTimestampRequiredError,
-            DeleteStreamError, MaxSeqNumError, RequestDroppedError, StreamerMissingInActionError,
+            DeleteStreamError, MaxSeqNumError, RequestDroppedError, StreamDeletionPendingError,
+            StreamerMissingInActionError,
         },
         kv,
     },
@@ -390,7 +391,12 @@ impl Streamer {
         let Some(ticket) = append::admit(reply_tx, session) else {
             return;
         };
-        match self.sequence_records(input) {
+        let sequenced_records = if self.trim_point.state.end == SeqNum::MAX {
+            Err(StreamDeletionPendingError.into())
+        } else {
+            self.sequence_records(input)
+        };
+        match sequenced_records {
             Ok(sequenced_records) => {
                 let doe_deadline = self.maybe_doe_deadline();
                 if append_type == AppendType::Terminal {
@@ -527,14 +533,7 @@ impl Streamer {
                             reply_tx,
                             append_type,
                         } => {
-                            if self.trim_point.state.end < SeqNum::MAX {
-                                self.handle_append(
-                                    input,
-                                    session,
-                                    reply_tx,
-                                    append_type,
-                                );
-                            }
+                            self.handle_append(input, session, reply_tx, append_type);
                         }
                         Message::Follow {
                             start_seq_num,
@@ -702,21 +701,19 @@ impl StreamerClient {
             .submit_internal(None, AppendType::Terminal)
             .await
         {
-            Ok(_ack) => Ok(()),
-            Err(e) => Err(match e {
-                AppendErrorInternal::Storage(e) => DeleteStreamError::Storage(e),
-                AppendErrorInternal::StreamerMissingInActionError(e) => {
-                    DeleteStreamError::StreamerMissingInActionError(e)
-                }
-                AppendErrorInternal::RequestDroppedError(e) => {
-                    DeleteStreamError::RequestDroppedError(e)
-                }
-                AppendErrorInternal::ConditionFailed(_) => unreachable!("unconditional write"),
-                AppendErrorInternal::TimestampMissing(_) => unreachable!("Timestamp::MAX used"),
-                AppendErrorInternal::MaxSeqNum(_) => {
-                    unreachable!("terminal append is plaintext command record")
-                }
-            }),
+            Ok(_) | Err(AppendErrorInternal::StreamDeletionPending(_)) => Ok(()),
+            Err(AppendErrorInternal::Storage(e)) => Err(DeleteStreamError::Storage(e)),
+            Err(AppendErrorInternal::StreamerMissingInActionError(e)) => {
+                Err(DeleteStreamError::StreamerMissingInActionError(e))
+            }
+            Err(AppendErrorInternal::RequestDroppedError(e)) => {
+                Err(DeleteStreamError::RequestDroppedError(e))
+            }
+            Err(AppendErrorInternal::ConditionFailed(_)) => unreachable!("unconditional write"),
+            Err(AppendErrorInternal::TimestampMissing(_)) => unreachable!("Timestamp::MAX used"),
+            Err(AppendErrorInternal::MaxSeqNum(_)) => {
+                unreachable!("terminal append is plaintext command record")
+            }
         }
     }
 }
@@ -1314,6 +1311,37 @@ mod tests {
 
         drop(lease);
         assert!(client_lease_state.is_closed());
+    }
+
+    #[tokio::test]
+    async fn append_during_terminal_trim_returns_stream_deletion_pending() {
+        let mut streamer = test_streamer().await;
+        streamer.trim_point = CommandState {
+            state: ..SeqNum::MAX,
+            applied_point: ..1,
+        };
+        let (msg_tx, msg_rx) = mpsc::unbounded_channel();
+        let run_handle = tokio::spawn(streamer.run(msg_rx));
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        msg_tx
+            .send(Message::Append {
+                input: append_input(b"late"),
+                session: None,
+                reply_tx,
+                append_type: AppendType::Regular,
+            })
+            .expect("streamer should accept append message");
+
+        let err = reply_rx
+            .await
+            .expect("streamer should reply")
+            .expect_err("append should be rejected");
+        let AppendErrorInternal::StreamDeletionPending(_) = err else {
+            panic!("expected stream deletion pending");
+        };
+
+        run_handle.abort();
     }
 
     #[tokio::test]

--- a/lite/src/backend/streams.rs
+++ b/lite/src/backend/streams.rs
@@ -105,7 +105,7 @@ impl Backend {
             && existing_meta.deleted_at.is_some()
         {
             return Err(ProvisionStreamError::StreamDeletionPending(
-                StreamDeletionPendingError { basin, stream },
+                StreamDeletionPendingError,
             ));
         }
 
@@ -259,7 +259,7 @@ impl Backend {
                 stream: stream.clone(),
             })?;
         if meta.deleted_at.is_some() {
-            return Err(StreamDeletionPendingError { basin, stream }.into());
+            return Err(StreamDeletionPendingError.into());
         }
         Ok(meta.config)
     }
@@ -295,7 +295,7 @@ impl Backend {
         })?;
 
         if meta.deleted_at.is_some() {
-            return Err(StreamDeletionPendingError { basin, stream }.into());
+            return Err(StreamDeletionPendingError.into());
         }
 
         let prior_doe_min_age = meta.config.delete_on_empty.min_age();
@@ -347,10 +347,7 @@ impl Backend {
             Err(StreamerError::StreamNotFound(e)) => {
                 return Err(DeleteStreamError::StreamNotFound(e));
             }
-            Err(StreamerError::StreamDeletionPending(e)) => {
-                assert_eq!(e.basin, basin);
-                assert_eq!(e.stream, stream);
-            }
+            Err(StreamerError::StreamDeletionPending(_)) => {}
         }
 
         let txn = self.db.begin(IsolationLevel::SerializableSnapshot).await?;

--- a/lite/tests/backend/control_plane/stream.rs
+++ b/lite/tests/backend/control_plane/stream.rs
@@ -20,7 +20,7 @@ use s2_common::{
 };
 use s2_lite::backend::error::{
     AppendError, CheckTailError, DeleteStreamError, GetStreamConfigError, ProvisionStreamError,
-    ReadError, ReconfigureStreamError, StreamDeletionPendingError,
+    ReadError, ReconfigureStreamError,
 };
 
 use super::common::*;
@@ -823,9 +823,7 @@ async fn test_delete_stream_marks_deleted_and_blocks_recreation() {
         .await;
     assert!(matches!(
         recreate_result,
-        Err(ProvisionStreamError::StreamDeletionPending(
-            StreamDeletionPendingError { basin, stream }
-        )) if basin == basin_name && stream == stream_name
+        Err(ProvisionStreamError::StreamDeletionPending(_))
     ));
 
     let reconfigure_result = backend


### PR DESCRIPTION
## Summary
- reject appends received while terminal trim is pending with `StreamDeletionPending` instead of dropping the request
- make `StreamDeletionPendingError` context-free and keep transparent conversions through append errors
- update deletion-pending assertions for the unit error shape

Fixes #378

## Testing
- `just fmt`
- `cargo test -p s2-lite backend::streamer::tests::append_during_terminal_trim_returns_stream_deletion_pending`
- `just test` (483 passed)

Regression note: the focused test fails without the run-loop fix because the reply channel is dropped with `RecvError`.
