### PR TITLE
ci(release-cli): use musl.cc toolchain for musl targets

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -91,15 +91,14 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
-            # for static bin
             deps: |
-              sudo apt-get update
-              sudo apt-get install -y musl-tools
+              curl -sSL https://musl.cc/x86_64-linux-musl-native.tgz | sudo tar -xzf - -C /opt
+              echo "/opt/x86_64-linux-musl-native/bin" >> "$GITHUB_PATH"
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             deps: |
-              sudo apt-get update
-              sudo apt-get install -y musl-tools
+              curl -sSL https://musl.cc/aarch64-linux-musl-native.tgz | sudo tar -xzf - -C /opt
+              echo "/opt/aarch64-linux-musl-native/bin" >> "$GITHUB_PATH"
           - os: macos-latest
             target: x86_64-apple-darwin
           - os: macos-latest
@@ -124,6 +123,18 @@ jobs:
       - name: Set CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+      - name: Configure musl cross compiler
+        if: endsWith(matrix.target, '-unknown-linux-musl')
+        run: |
+          ARCH="${MATRIX_TARGET%%-unknown-linux-musl}"
+          CC="${ARCH}-linux-musl-gcc"
+          TARGET_UPPER="$(echo "${MATRIX_TARGET}" | tr 'a-z-' 'A-Z_')"
+          {
+            echo "CC_${MATRIX_TARGET//-/_}=${CC}"
+            echo "CARGO_TARGET_${TARGET_UPPER}_LINKER=${CC}"
+          } >> "$GITHUB_ENV"
+        env:
+          MATRIX_TARGET: ${{ matrix.target }}
       - name: Build
         run: cargo build --release --package s2-cli --target ${{ matrix.target }}
       - name: Create pem and certificate.der files


### PR DESCRIPTION
## Summary

- The release-cli build for `s2-cli-v0.34.0` failed on `aarch64-unknown-linux-musl` because the apt `musl-tools` wrapper doesn't expose C11 `<stdatomic.h>` cleanly, breaking the `tikv-jemalloc-sys` build introduced in #472.
- Swap the apt `musl-tools` dep for the musl.cc native musl toolchains (`x86_64-linux-musl-native.tgz`, `aarch64-linux-musl-native.tgz`) and point `CC_*` / `CARGO_TARGET_*_LINKER` at them so jemalloc builds against a proper musl libc.

## Test plan

Workflow-only change — validation requires running `release-cli` itself. Two options:

- [ ] Dispatch `release-cli.yml` from this branch with `--ref cc/fix-musl-jemalloc`. Note: as currently written, the downstream `build_images` / `upload_release_artifacts` / `update_homebrew` jobs read version from `cli/Cargo.toml` and would overwrite the existing 0.34.0 release artifacts. Recommend gating those on `github.ref_type == 'tag'` before dispatching, or accepting the overwrite.
- [ ] Or: merge as-is, then trigger a `s2-cli` patch release and let the next tag run the workflow naturally; if it still fails, follow up with another fix commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)