### PR TITLE
ci(release-cli): build aarch64-musl via cross from x86_64 host

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -92,7 +92,7 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
             builder: cross
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-musl
             builder: cross
           - os: macos-latest


### PR DESCRIPTION
## Summary

The s2-cli-v0.35.0 release-cli run failed on `aarch64-unknown-linux-musl` ([logs](https://github.com/s2-streamstore/s2/actions/runs/26132027705/job/76859016671)):

```
error: toolchain 'stable-x86_64-unknown-linux-gnu' may not be able to run on this system
Error: couldn't install toolchain `stable-x86_64-unknown-linux-gnu`
```

cross 0.2.5's default Docker image for `aarch64-unknown-linux-musl` is x86_64-host-only — when run on the `ubuntu-24.04-arm` runner, cross's preflight tries to provision an x86_64 rustup toolchain on the aarch64 host, which rustup refuses. Move that matrix entry to `ubuntu-22.04` so cross cross-compiles from x86_64 to aarch64-musl using the path its image actually supports.

## Test plan

Workflow-only. Will be exercised by re-running release-cli on the existing `s2-cli-v0.35.0` tag (workflow_dispatch), or by the next tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)