### PR TITLE
ci(release-cli): pin cross-rs musl images to main-branch SHA digests

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-musl]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-musl@sha256:b21940afb5d20705a9b0b9f95f033a50efb0480eb0cf19a0588a252e0ce46989"
+
+[target.aarch64-unknown-linux-musl]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl@sha256:13c8c2839a4ca78706d6885add4f836f9d1d5756518b29954d1e35821b4ffea8"


### PR DESCRIPTION
## Summary

cross 0.2.5's stable images are based on Ubuntu 16.04 (GLIBC 2.23), too old for modern Rust. proc-macro2 1.0.106's build script fails inside the container with:

\`\`\`
/lib/x86_64-linux-gnu/libc.so.6: version \`GLIBC_2.28' not found
\`\`\`

Pin each musl target to the current main-branch image by SHA digest via a new \`Cross.toml\`. The main-branch images use a newer Ubuntu base with sufficient GLIBC. SHA digests are captured one-time via \`docker buildx imagetools inspect\`, so upstream can't silently rotate underneath us — any change is a visible diff.

\`\`\`toml
[target.x86_64-unknown-linux-musl]
image = "ghcr.io/cross-rs/x86_64-unknown-linux-musl@sha256:b21940afb5d20705a9b0b9f95f033a50efb0480eb0cf19a0588a252e0ce46989"

[target.aarch64-unknown-linux-musl]
image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl@sha256:13c8c2839a4ca78706d6885add4f836f9d1d5756518b29954d1e35821b4ffea8"
\`\`\`

## Test plan

Workflow-only. Will be exercised by re-running release-cli on \`s2-cli-v0.35.0\` (the tag was moved to main HEAD earlier; we'll move it again to include this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)