### PR TITLE
feat(tui): pills for known basin locations in create form

### DIFF
--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -1007,16 +1007,12 @@ pub struct App {
     pub show_help: bool,
     pub input_mode: InputMode,
     pub pip: Option<PipState>,
-    /// Cached list of available basin locations. `None` until first fetched.
     pub locations: Option<Vec<s2_sdk::types::LocationInfo>>,
     should_quit: bool,
     /// Stop signal for the benchmark task
     bench_stop_signal: Option<Arc<AtomicBool>>,
 }
 
-/// Update `location` to the canonical value for a given Location pill index.
-/// Default (0) and Custom (`custom_idx`) both clear the field; a named pill
-/// writes the location's name. Out-of-range indices are ignored.
 fn set_location_for_pill(
     location: &mut String,
     pill_idx: usize,
@@ -1938,7 +1934,6 @@ impl App {
             }
 
             Event::LocationsLoaded(result) => {
-                // Silent on failure: form falls back to freeform text input.
                 if let Ok(locations) = result {
                     self.locations = Some(locations);
                 }
@@ -2316,8 +2311,6 @@ impl App {
             return;
         }
 
-        // Snapshot known location names so we can reference them while holding a
-        // mutable borrow of self.input_mode below.
         let known_location_names: Vec<String> = self
             .locations
             .as_deref()
@@ -2345,9 +2338,6 @@ impl App {
             } => {
                 const FIELD_COUNT: usize = 12;
 
-                // Pill index for the Location field. Only meaningful when
-                // `known_location_names` is non-empty (pill row rendered).
-                // 0 = Default, 1..=N = named, N+1 = Custom.
                 let location_pill_idx = || -> usize {
                     if location.is_empty() {
                         0
@@ -2449,8 +2439,6 @@ impl App {
                                 *editing = true;
                             }
                             1 => {
-                                // Only enter edit mode when there's a text input to edit:
-                                // either no pill row (fallback) or user is on the Custom pill.
                                 let custom_idx = known_location_names.len() + 1;
                                 let editable = known_location_names.is_empty()
                                     || location_pill_idx() == custom_idx;

--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -629,6 +629,7 @@ pub enum InputMode {
     CreateBasin {
         name: String,
         location: String,
+        custom_location_active: bool,
         create_stream_on_append: bool,
         create_stream_on_read: bool,
         storage_class: Option<StorageClass>,
@@ -1013,17 +1014,36 @@ pub struct App {
     bench_stop_signal: Option<Arc<AtomicBool>>,
 }
 
-fn set_location_for_pill(
+pub fn location_pill_idx(location: &str, custom_active: bool, names: &[&str]) -> usize {
+    let custom_idx = names.len() + 1;
+    if custom_active {
+        custom_idx
+    } else if location.is_empty() {
+        0
+    } else if let Some(i) = names.iter().position(|n| *n == location) {
+        i + 1
+    } else {
+        custom_idx
+    }
+}
+
+fn select_location_pill(
     location: &mut String,
+    custom_active: &mut bool,
     pill_idx: usize,
-    names: &[String],
-    custom_idx: usize,
+    names: &[&str],
 ) {
-    if pill_idx == 0 || pill_idx == custom_idx {
+    let custom_idx = names.len() + 1;
+    if pill_idx == 0 {
         location.clear();
+        *custom_active = false;
+    } else if pill_idx == custom_idx {
+        location.clear();
+        *custom_active = true;
     } else if let Some(name) = names.get(pill_idx - 1) {
         location.clear();
         location.push_str(name);
+        *custom_active = false;
     }
 }
 
@@ -2311,10 +2331,10 @@ impl App {
             return;
         }
 
-        let known_location_names: Vec<String> = self
+        let known_location_names: Vec<&str> = self
             .locations
             .as_deref()
-            .map(|v| v.iter().map(|l| l.name.to_string()).collect())
+            .map(|v| v.iter().map(|l| l.name.as_ref()).collect())
             .unwrap_or_default();
 
         match &mut self.input_mode {
@@ -2323,6 +2343,7 @@ impl App {
             InputMode::CreateBasin {
                 name,
                 location,
+                custom_location_active,
                 create_stream_on_append,
                 create_stream_on_read,
                 storage_class,
@@ -2337,17 +2358,6 @@ impl App {
                 cursor,
             } => {
                 const FIELD_COUNT: usize = 12;
-
-                let location_pill_idx = || -> usize {
-                    if location.is_empty() {
-                        0
-                    } else if let Some(i) = known_location_names.iter().position(|n| n == location)
-                    {
-                        i + 1
-                    } else {
-                        known_location_names.len() + 1
-                    }
-                };
 
                 if *editing {
                     let field: Option<&mut String> = match *selected {
@@ -2439,9 +2449,8 @@ impl App {
                                 *editing = true;
                             }
                             1 => {
-                                let custom_idx = known_location_names.len() + 1;
-                                let editable = known_location_names.is_empty()
-                                    || location_pill_idx() == custom_idx;
+                                let editable =
+                                    known_location_names.is_empty() || *custom_location_active;
                                 if editable {
                                     *cursor = location.len();
                                     *editing = true;
@@ -2487,13 +2496,16 @@ impl App {
                         },
                         KeyCode::Left | KeyCode::Char('h') => match *selected {
                             1 if !known_location_names.is_empty() => {
-                                let custom_idx = known_location_names.len() + 1;
-                                let new_idx = location_pill_idx().saturating_sub(1);
-                                set_location_for_pill(
+                                let cur = location_pill_idx(
                                     location,
-                                    new_idx,
+                                    *custom_location_active,
                                     &known_location_names,
-                                    custom_idx,
+                                );
+                                select_location_pill(
+                                    location,
+                                    custom_location_active,
+                                    cur.saturating_sub(1),
+                                    &known_location_names,
                                 );
                             }
                             2 => *storage_class = storage_class_prev(storage_class),
@@ -2505,12 +2517,16 @@ impl App {
                         KeyCode::Right | KeyCode::Char('l') => match *selected {
                             1 if !known_location_names.is_empty() => {
                                 let custom_idx = known_location_names.len() + 1;
-                                let new_idx = (location_pill_idx() + 1).min(custom_idx);
-                                set_location_for_pill(
+                                let cur = location_pill_idx(
                                     location,
-                                    new_idx,
+                                    *custom_location_active,
                                     &known_location_names,
-                                    custom_idx,
+                                );
+                                select_location_pill(
+                                    location,
+                                    custom_location_active,
+                                    (cur + 1).min(custom_idx),
+                                    &known_location_names,
                                 );
                             }
                             2 => *storage_class = storage_class_next(storage_class),
@@ -3616,6 +3632,7 @@ impl App {
                 self.input_mode = InputMode::CreateBasin {
                     name: String::new(),
                     location: String::new(),
+                    custom_location_active: false,
                     create_stream_on_append: false,
                     create_stream_on_read: false,
                     storage_class: None,

--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -1007,9 +1007,28 @@ pub struct App {
     pub show_help: bool,
     pub input_mode: InputMode,
     pub pip: Option<PipState>,
+    /// Cached list of available basin locations. `None` until first fetched.
+    pub locations: Option<Vec<s2_sdk::types::LocationInfo>>,
     should_quit: bool,
     /// Stop signal for the benchmark task
     bench_stop_signal: Option<Arc<AtomicBool>>,
+}
+
+/// Update `location` to the canonical value for a given Location pill index.
+/// Default (0) and Custom (`custom_idx`) both clear the field; a named pill
+/// writes the location's name. Out-of-range indices are ignored.
+fn set_location_for_pill(
+    location: &mut String,
+    pill_idx: usize,
+    names: &[String],
+    custom_idx: usize,
+) {
+    if pill_idx == 0 || pill_idx == custom_idx {
+        location.clear();
+    } else if let Some(name) = names.get(pill_idx - 1) {
+        location.clear();
+        location.push_str(name);
+    }
 }
 
 /// Build a basin config from form values
@@ -1126,6 +1145,7 @@ impl App {
             show_help: false,
             input_mode: InputMode::Normal,
             pip: None,
+            locations: None,
             should_quit: false,
             bench_stop_signal: None,
         }
@@ -1917,6 +1937,13 @@ impl App {
                 }
             }
 
+            Event::LocationsLoaded(result) => {
+                // Silent on failure: form falls back to freeform text input.
+                if let Ok(locations) = result {
+                    self.locations = Some(locations);
+                }
+            }
+
             Event::AccessTokenIssued(result) => {
                 self.input_mode = InputMode::Normal;
                 match result {
@@ -2289,6 +2316,14 @@ impl App {
             return;
         }
 
+        // Snapshot known location names so we can reference them while holding a
+        // mutable borrow of self.input_mode below.
+        let known_location_names: Vec<String> = self
+            .locations
+            .as_deref()
+            .map(|v| v.iter().map(|l| l.name.to_string()).collect())
+            .unwrap_or_default();
+
         match &mut self.input_mode {
             InputMode::Normal => {}
 
@@ -2309,6 +2344,20 @@ impl App {
                 cursor,
             } => {
                 const FIELD_COUNT: usize = 12;
+
+                // Pill index for the Location field. Only meaningful when
+                // `known_location_names` is non-empty (pill row rendered).
+                // 0 = Default, 1..=N = named, N+1 = Custom.
+                let location_pill_idx = || -> usize {
+                    if location.is_empty() {
+                        0
+                    } else if let Some(i) = known_location_names.iter().position(|n| n == location)
+                    {
+                        i + 1
+                    } else {
+                        known_location_names.len() + 1
+                    }
+                };
 
                 if *editing {
                     let field: Option<&mut String> = match *selected {
@@ -2400,8 +2449,15 @@ impl App {
                                 *editing = true;
                             }
                             1 => {
-                                *cursor = location.len();
-                                *editing = true;
+                                // Only enter edit mode when there's a text input to edit:
+                                // either no pill row (fallback) or user is on the Custom pill.
+                                let custom_idx = known_location_names.len() + 1;
+                                let editable = known_location_names.is_empty()
+                                    || location_pill_idx() == custom_idx;
+                                if editable {
+                                    *cursor = location.len();
+                                    *editing = true;
+                                }
                             }
                             4 if *retention_policy == RetentionPolicyOption::Age => {
                                 cursor_move_end(retention_age_input, cursor);
@@ -2442,6 +2498,16 @@ impl App {
                             _ => {}
                         },
                         KeyCode::Left | KeyCode::Char('h') => match *selected {
+                            1 if !known_location_names.is_empty() => {
+                                let custom_idx = known_location_names.len() + 1;
+                                let new_idx = location_pill_idx().saturating_sub(1);
+                                set_location_for_pill(
+                                    location,
+                                    new_idx,
+                                    &known_location_names,
+                                    custom_idx,
+                                );
+                            }
                             2 => *storage_class = storage_class_prev(storage_class),
                             3 => *retention_policy = retention_policy.toggle(),
                             5 => *timestamping_mode = timestamping_mode_prev(timestamping_mode),
@@ -2449,6 +2515,16 @@ impl App {
                             _ => {}
                         },
                         KeyCode::Right | KeyCode::Char('l') => match *selected {
+                            1 if !known_location_names.is_empty() => {
+                                let custom_idx = known_location_names.len() + 1;
+                                let new_idx = (location_pill_idx() + 1).min(custom_idx);
+                                set_location_for_pill(
+                                    location,
+                                    new_idx,
+                                    &known_location_names,
+                                    custom_idx,
+                                );
+                            }
                             2 => *storage_class = storage_class_next(storage_class),
                             3 => *retention_policy = retention_policy.toggle(),
                             5 => *timestamping_mode = timestamping_mode_next(timestamping_mode),
@@ -3546,6 +3622,9 @@ impl App {
                 self.load_basins(tx);
             }
             KeyCode::Char('c') => {
+                if self.locations.is_none() {
+                    self.load_locations(tx.clone());
+                }
                 self.input_mode = InputMode::CreateBasin {
                     name: String::new(),
                     location: String::new(),
@@ -4107,6 +4186,16 @@ impl App {
                     }
                 }
             };
+            let _ = tx.send(event);
+        });
+    }
+
+    fn load_locations(&self, tx: mpsc::UnboundedSender<Event>) {
+        let Some(s2) = self.s2.clone() else {
+            return;
+        };
+        tokio::spawn(async move {
+            let event = Event::LocationsLoaded(ops::list_locations(&s2).await);
             let _ = tx.send(event);
         });
     }

--- a/cli/src/tui/event.rs
+++ b/cli/src/tui/event.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use s2_sdk::types::{
-    AccessTokenInfo, BasinInfo, Metric, SequencedRecord, StreamInfo, StreamPosition,
+    AccessTokenInfo, BasinInfo, LocationInfo, Metric, SequencedRecord, StreamInfo, StreamPosition,
 };
 
 use crate::{
@@ -109,6 +109,9 @@ pub enum Event {
 
     /// Access tokens have been loaded from the API
     AccessTokensLoaded(Result<Vec<AccessTokenInfo>, CliError>),
+
+    /// Available basin locations have been loaded from the API
+    LocationsLoaded(Result<Vec<LocationInfo>, CliError>),
 
     /// Access token issued successfully (token string)
     AccessTokenIssued(Result<String, CliError>),

--- a/cli/src/tui/ui.rs
+++ b/cli/src/tui/ui.rs
@@ -4607,8 +4607,6 @@ fn draw_input_dialog(
             lines.push(Line::from(""));
             let known_locs = locations.unwrap_or(&[]);
             if known_locs.is_empty() {
-                // Fallback: freeform text input (locations not loaded yet, fetch failed,
-                // or the account has no listable locations).
                 let (ind, lbl) = render_field_row_bold(1, "Location", *selected);
                 let mut location_spans = vec![ind, lbl, Span::raw("  ")];
                 location_spans.extend(render_text_input_with_cursor(
@@ -4620,7 +4618,6 @@ fn draw_input_dialog(
                 ));
                 lines.push(Line::from(location_spans));
             } else {
-                // Pill row: Default | <known locations> | Custom
                 let custom_pill_idx = known_locs.len() + 1;
                 let pill_idx = if location.is_empty() {
                     0
@@ -4652,7 +4649,6 @@ fn draw_input_dialog(
                 ));
                 lines.push(Line::from(loc_spans));
 
-                // Conditional text input row when Custom is active
                 if pill_idx == custom_pill_idx {
                     let mut custom_spans = vec![Span::raw("                  ")];
                     custom_spans.extend(render_text_input_with_cursor(

--- a/cli/src/tui/ui.rs
+++ b/cli/src/tui/ui.rs
@@ -441,7 +441,7 @@ pub fn draw(f: &mut Frame, app: &App) {
         draw_help_overlay(f, &app.screen);
     }
     if !matches!(app.input_mode, InputMode::Normal) {
-        draw_input_dialog(f, &app.input_mode);
+        draw_input_dialog(f, &app.input_mode, app.locations.as_deref());
     }
     // Draw PiP overlay last so it's on top
     if let Some(ref pip) = app.pip {
@@ -4494,7 +4494,11 @@ fn get_selected_line_hint(mode: &InputMode) -> usize {
     }
 }
 
-fn draw_input_dialog(f: &mut Frame, mode: &InputMode) {
+fn draw_input_dialog(
+    f: &mut Frame,
+    mode: &InputMode,
+    locations: Option<&[s2_sdk::types::LocationInfo]>,
+) {
     let (title, content, hint) = match mode {
         InputMode::Normal => return,
 
@@ -4601,16 +4605,66 @@ fn draw_input_dialog(f: &mut Frame, mode: &InputMode) {
 
             // Basin location
             lines.push(Line::from(""));
-            let (ind, lbl) = render_field_row_bold(1, "Location", *selected);
-            let mut location_spans = vec![ind, lbl, Span::raw("  ")];
-            location_spans.extend(render_text_input_with_cursor(
-                location,
-                *selected == 1 && *editing,
-                "server default",
-                CYAN,
-                *cursor,
-            ));
-            lines.push(Line::from(location_spans));
+            let known_locs = locations.unwrap_or(&[]);
+            if known_locs.is_empty() {
+                // Fallback: freeform text input (locations not loaded yet, fetch failed,
+                // or the account has no listable locations).
+                let (ind, lbl) = render_field_row_bold(1, "Location", *selected);
+                let mut location_spans = vec![ind, lbl, Span::raw("  ")];
+                location_spans.extend(render_text_input_with_cursor(
+                    location,
+                    *selected == 1 && *editing,
+                    "server default",
+                    CYAN,
+                    *cursor,
+                ));
+                lines.push(Line::from(location_spans));
+            } else {
+                // Pill row: Default | <known locations> | Custom
+                let custom_pill_idx = known_locs.len() + 1;
+                let pill_idx = if location.is_empty() {
+                    0
+                } else if let Some(i) = known_locs
+                    .iter()
+                    .position(|l| l.name.as_ref() == location.as_str())
+                {
+                    i + 1
+                } else {
+                    custom_pill_idx
+                };
+
+                let (ind, lbl) = render_field_row_bold(1, "Location", *selected);
+                let mut loc_spans = vec![ind, lbl, Span::raw("  ")];
+                loc_spans.push(render_pill("Default", *selected == 1, pill_idx == 0));
+                loc_spans.push(Span::raw(" "));
+                for (i, loc) in known_locs.iter().enumerate() {
+                    loc_spans.push(render_pill(
+                        loc.name.as_ref(),
+                        *selected == 1,
+                        pill_idx == i + 1,
+                    ));
+                    loc_spans.push(Span::raw(" "));
+                }
+                loc_spans.push(render_pill(
+                    "Custom…",
+                    *selected == 1,
+                    pill_idx == custom_pill_idx,
+                ));
+                lines.push(Line::from(loc_spans));
+
+                // Conditional text input row when Custom is active
+                if pill_idx == custom_pill_idx {
+                    let mut custom_spans = vec![Span::raw("                  ")];
+                    custom_spans.extend(render_text_input_with_cursor(
+                        location,
+                        *selected == 1 && *editing,
+                        "type location",
+                        CYAN,
+                        *cursor,
+                    ));
+                    lines.push(Line::from(custom_spans));
+                }
+            }
 
             // Default stream configuration section
             lines.push(Line::from(""));

--- a/cli/src/tui/ui.rs
+++ b/cli/src/tui/ui.rs
@@ -4505,6 +4505,7 @@ fn draw_input_dialog(
         InputMode::CreateBasin {
             name,
             location,
+            custom_location_active,
             create_stream_on_append,
             create_stream_on_read,
             storage_class,
@@ -4618,17 +4619,10 @@ fn draw_input_dialog(
                 ));
                 lines.push(Line::from(location_spans));
             } else {
-                let custom_pill_idx = known_locs.len() + 1;
-                let pill_idx = if location.is_empty() {
-                    0
-                } else if let Some(i) = known_locs
-                    .iter()
-                    .position(|l| l.name.as_ref() == location.as_str())
-                {
-                    i + 1
-                } else {
-                    custom_pill_idx
-                };
+                let names: Vec<&str> = known_locs.iter().map(|l| l.name.as_ref()).collect();
+                let custom_pill_idx = names.len() + 1;
+                let pill_idx =
+                    crate::tui::app::location_pill_idx(location, *custom_location_active, &names);
 
                 let (ind, lbl) = render_field_row_bold(1, "Location", *selected);
                 let mut loc_spans = vec![ind, lbl, Span::raw("  ")];


### PR DESCRIPTION
Fetches `list_locations` lazily on first CreateBasin open and renders the result as pills (`[Default] [aws:us-east-1] … [Custom…]`). Falls back to today's freeform text input if the fetch fails or returns empty.