### PR TITLE
fix(lite): add proxy-friendly S2S headers

### DIFF
--- a/lite/src/handlers/v1/records.rs
+++ b/lite/src/handlers/v1/records.rs
@@ -288,6 +288,8 @@ pub async fn read(
             Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header(http::header::CONTENT_TYPE, "s2s/proto")
+                .header(http::header::CACHE_CONTROL, "no-cache, no-transform")
+                .header("x-accel-buffering", "no")
                 .body(Body::from_stream(response_stream))
                 .expect("valid response builder"))
         }
@@ -448,6 +450,8 @@ pub async fn append(
             Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header(http::header::CONTENT_TYPE, "s2s/proto")
+                .header(http::header::CACHE_CONTROL, "no-cache, no-transform")
+                .header("x-accel-buffering", "no")
                 .body(Body::from_stream(response_stream))
                 .expect("valid response builder"))
         }


### PR DESCRIPTION
## Summary
- add no-cache/no-transform Cache-Control to s2-lite S2S read and append responses
- disable nginx accel buffering for S2S response streams

Closes #502

## Notes
- This improves response-side streaming behavior through buffering proxies, especially for S2S read heartbeats.
- It does not by itself make S2S append safe through proxies that buffer request bodies; those deployments still need request buffering disabled/full-duplex-capable routing.

## Testing
- just fmt