### PR TITLE
chore: ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,8 @@ ignore = [
     # Transitive deps via slatedb/foyer — not actionable.
     "RUSTSEC-2024-0436", # paste unmaintained
     "RUSTSEC-2025-0141", # bincode unmaintained
+    # Transitive dep via tabled_derive — no fixed release available.
+    "RUSTSEC-2026-0173", # proc-macro-error2 unmaintained
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary
- `cargo deny check` started failing on RUSTSEC-2026-0173: `proc-macro-error2` is unmaintained
- It is a transitive dep via `tabled_derive` → `tabled` → `s2-cli` (and `json_to_table`); latest `tabled_derive` (0.11.0) still depends on it, so there is no upgrade path
- Add it to the `deny.toml` ignore list alongside the other non-actionable unmaintained advisories

Proc-macro-only dependency, so no runtime exposure. Can revisit if `tabled` ships a release that drops it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)