### PR TITLE
fix: roll back hyper to 1.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2524,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -29,7 +29,7 @@ futures = { workspace = true }
 http = { workspace = true }
 http-body = "1"
 http-body-util = "0.1"
-hyper = "1.10"
+hyper = "1.9"
 hyper-rustls = { version = "0.27", default-features = false, features = ["http2", "native-tokio", "tls12"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "tokio", "http1", "http2"] }
 pin-project-lite = "0.2"


### PR DESCRIPTION
Reverts the hyper 1.9.0 -> 1.10.1 upgrade from #530, keeping all other dep upgrades from that PR intact.

- `sdk/Cargo.toml`: `hyper = "1.10"` -> `"1.9"`
- `Cargo.lock`: hyper pinned back to 1.9.0; no other lockfile entries changed (h2 untouched)

Verified with `cargo check --workspace` and `cargo check -p s2-sdk --locked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)