### PR TITLE
ci: runner specs diagnostic (do not merge)

### DIFF
--- a/.github/workflows/runner-specs.yml
+++ b/.github/workflows/runner-specs.yml
@@ -1,0 +1,44 @@
+name: Runner Specs
+
+# Throwaway diagnostic: prints CPU / memory / arch for the hosted runner labels
+# this repo uses, to confirm the public-repo 4-core / 16 GB tier. Not for merge.
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  specs:
+    name: ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - windows-latest
+          - macos-latest
+    steps:
+      - name: Show CPU / memory / arch
+        shell: bash
+        run: |
+          echo "label       : ${{ matrix.runner }}"
+          echo "RUNNER_OS   : $RUNNER_OS"
+          echo "RUNNER_ARCH : $RUNNER_ARCH"
+          echo "uname -m    : $(uname -m)"
+          case "$RUNNER_OS" in
+            Linux)
+              echo "cpu count   : $(nproc)"
+              free -h
+              ;;
+            macOS)
+              echo "cpu count   : $(sysctl -n hw.logicalcpu)"
+              echo "memory      : $(( $(sysctl -n hw.memsize) / 1073741824 )) GiB"
+              ;;
+            Windows)
+              echo "cpu count   : $NUMBER_OF_PROCESSORS"
+              echo "memory      : $(powershell -NoProfile -Command '[math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory/1GB,1)') GiB"
+              ;;
+          esac


### PR DESCRIPTION
Throwaway diagnostic to **empirically** confirm the GitHub-hosted runner tier this public repo actually gets (the docs say 4-core/16 GB for public repos, but nothing in CI prints it).

Adds `.github/workflows/runner-specs.yml` — a `fail-fast: false` matrix that prints `nproc` / memory / arch on each runner label this repo uses:

| Label | Expected (public repo) |
|---|---|
| `ubuntu-latest` (x64) | 4 vCPU / 16 GB |
| `ubuntu-24.04-arm` | 4 vCPU / 16 GB |
| `windows-latest` (x64) | 4 vCPU / 16 GB |
| `macos-latest` (M1) | 3 vCPU / 7 GB |

Runs automatically on this PR (`pull_request`) and on demand (`workflow_dispatch`). **Not for merge** — delete the branch once we've read the numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)