### PR TITLE
chore: remove unused Error::is_connect method from sdk client

### DIFF
--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -85,12 +85,6 @@ pub enum Error {
     Compression(String),
 }
 
-impl Error {
-    pub fn is_connect(&self) -> bool {
-        matches!(self, Error::Send(e) if e.is_connect())
-    }
-}
-
 enum BodyInner {
     Empty,
     Full(Bytes),


### PR DESCRIPTION
Removes the `is_connect()` method on `client::Error` in the SDK, which has no callers anywhere in the codebase. The only apparent call site (`api.rs:704`) calls `.is_connect()` directly on the inner `hyper_util` error destructured from the `Error::Send` variant, not on `client::Error` itself.

This is a clean re-do of #602 from latest `main` — that PR's only failing check was **Format**, because the removal left a double blank line. Here the trailing blank line is removed too, so `cargo +nightly fmt --all --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)