### PR TITLE
fix(cli): allow re-editing a custom basin location typed before locations load

### DIFF
--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -1051,6 +1051,10 @@ pub fn location_pill_idx(location: &str, custom_active: bool, names: &[&str]) ->
     }
 }
 
+fn location_field_editable(location: &str, custom_active: bool, names: &[&str]) -> bool {
+    names.is_empty() || location_pill_idx(location, custom_active, names) == names.len() + 1
+}
+
 fn select_location_pill(
     location: &mut String,
     custom_active: &mut bool,
@@ -2504,9 +2508,11 @@ impl App {
                                 *editing = true;
                             }
                             1 => {
-                                let editable =
-                                    known_location_names.is_empty() || *custom_location_active;
-                                if editable {
+                                if location_field_editable(
+                                    location,
+                                    *custom_location_active,
+                                    &known_location_names,
+                                ) {
                                     *cursor = location.len();
                                     *editing = true;
                                 }


### PR DESCRIPTION
Closes #537.

## Problem

In the TUI **Create basin** form, if you type a custom location *before* the async locations list finishes loading, you can't re-edit it afterwards — Enter is silently ignored even though the form still shows an editable-looking text input.

The field had two diverging sources of truth:
- The **UI** decides whether to show the custom text input via `location_pill_idx`, which resolves any unknown non-empty location to the `Custom…` pill — so it renders an editable input.
- The **Enter guard** only allowed editing when `known_location_names.is_empty() || custom_location_active`. `custom_location_active` is set only by Left/Right pill navigation, never when you type directly. So once locations load (list non-empty) and the flag was never set, the guard is `false`.

Result: input looks editable, Enter does nothing. The only workaround — navigating to the `Custom…` pill — clears the typed text (data loss). This was a regression from #496, which added the Enter guard.

## Fix

Derive editability from the **same** `location_pill_idx` logic the UI uses, via a shared `location_field_editable` helper, so the guard and the rendered state can't diverge.

I chose this over the issue's suggested "sync the flag on edit-exit": at edit-exit time the locations may not be loaded yet, so you can't reliably tell whether the typed value is a known or custom location. Deriving editability lazily at Enter-press time (when the list *is* loaded) matches the UI exactly and removes the divergence at the root.

Scope note: TUI-only; the plain CLI `--location` flag was never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
