### PR TITLE
chore: upgrade aes-gcm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,12 +19,12 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.1.7",
- "generic-array",
+ "crypto-common 0.2.2",
+ "inout",
 ]
 
 [[package]]
@@ -39,20 +39,20 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead",
  "aes",
@@ -1205,11 +1205,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.1.7",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -1474,6 +1475,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,7 +1578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1581,7 +1587,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1596,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
  "cipher",
 ]
@@ -2449,11 +2457,10 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "opaque-debug",
  "polyval",
 ]
 
@@ -2972,11 +2979,11 @@ checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3678,12 +3685,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4036,13 +4037,12 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polyval"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
 dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpubits",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
 
@@ -4465,9 +4465,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"
@@ -6774,12 +6771,12 @@ checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.1.7",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ homepage = "https://s2.dev"
 
 [workspace.dependencies]
 aegis = "0.9"
-aes-gcm = "0.10"
+aes-gcm = "0.11"
 async-stream = "0.3"
 async-trait = "0.1"
 aws-config = "1"

--- a/storage/src/record/encryption.rs
+++ b/storage/src/record/encryption.rs
@@ -212,39 +212,57 @@ pub fn encrypt_record(
     let record = match (record.into_inner(), encryption) {
         (record @ Record::Command(_), _) => StoredRecord::Plaintext(record),
         (record @ Record::Envelope(_), EncryptionSpec::Plain) => StoredRecord::Plaintext(record),
-        (Record::Envelope(envelope), EncryptionSpec::Aegis256(key)) => {
-            let format = EncryptedRecordFormat::Aegis256V1;
-            let (mut encoded, payload_start) = prep_encryption_buffer(&envelope, format);
-            let (prefix, payload) = encoded.split_at_mut(payload_start);
-            let nonce: &[u8; 32] = prefix[FORMAT_ID_LEN..]
-                .try_into()
-                .expect("AEGIS-256 nonce must be 32 bytes");
-            let tag =
-                Aegis256::<16>::new(key.expose_secret(), nonce).encrypt_in_place(payload, aad);
-            encoded.put_slice(tag.as_ref());
-
-            let encrypted = EncryptedRecord::new(encoded.freeze(), format);
-            StoredRecord::encrypted(encrypted, metered_size)
-        }
-        (Record::Envelope(envelope), EncryptionSpec::Aes256Gcm(key)) => {
-            let format = EncryptedRecordFormat::Aes256GcmV1;
-            let (mut encoded, payload_start) = prep_encryption_buffer(&envelope, format);
-            let (prefix, payload) = encoded.split_at_mut(payload_start);
-            let nonce: &aes_gcm::aead::Nonce<Aes256Gcm> = prefix[FORMAT_ID_LEN..]
-                .try_into()
-                .expect("AES-256-GCM nonce must be 12 bytes");
-            let cipher = Aes256Gcm::new_from_slice(key.expose_secret())
-                .expect("AES-256-GCM key must be 32 bytes");
-            let tag = cipher
-                .encrypt_inout_detached(nonce, aad, payload.into())
-                .expect("AES-256-GCM encryption should not fail on size validation");
-            encoded.put_slice(tag.as_ref());
-
-            let encrypted = EncryptedRecord::new(encoded.freeze(), format);
-            StoredRecord::encrypted(encrypted, metered_size)
-        }
+        (Record::Envelope(envelope), EncryptionSpec::Aegis256(key)) => encrypt_envelope_record(
+            &envelope,
+            metered_size,
+            EncryptedRecordFormat::Aegis256V1,
+            |nonce, payload| {
+                let nonce: &[u8; 32] = nonce.try_into().expect("AEGIS-256 nonce must be 32 bytes");
+                Aegis256::<16>::new(key.expose_secret(), nonce).encrypt_in_place(payload, aad)
+            },
+        ),
+        (Record::Envelope(envelope), EncryptionSpec::Aes256Gcm(key)) => encrypt_envelope_record(
+            &envelope,
+            metered_size,
+            EncryptedRecordFormat::Aes256GcmV1,
+            |nonce, payload| {
+                let nonce: &aes_gcm::aead::Nonce<Aes256Gcm> = nonce
+                    .try_into()
+                    .expect("AES-256-GCM nonce must be 12 bytes");
+                let cipher = Aes256Gcm::new_from_slice(key.expose_secret())
+                    .expect("AES-256-GCM key must be 32 bytes");
+                cipher
+                    .encrypt_inout_detached(nonce, aad, payload.into())
+                    .expect("AES-256-GCM encryption should not fail on size validation")
+            },
+        ),
     };
     record.metered()
+}
+
+fn encrypt_envelope_record<Tag>(
+    envelope: &EnvelopeRecord,
+    metered_size: usize,
+    format: EncryptedRecordFormat,
+    encrypt_payload: impl FnOnce(&[u8], &mut [u8]) -> Tag,
+) -> StoredRecord
+where
+    Tag: AsRef<[u8]>,
+{
+    let payload_start = FORMAT_ID_LEN + format.nonce_len();
+    let mut encoded =
+        BytesMut::with_capacity(payload_start + envelope.encoded_size() + format.tag_len());
+    encoded.put_u8(format.format_id());
+    format.put_random_nonce(&mut encoded);
+    envelope.encode_into(&mut encoded);
+
+    let (prefix, payload) = encoded.split_at_mut(payload_start);
+    let tag = encrypt_payload(&prefix[FORMAT_ID_LEN..], payload);
+    debug_assert_eq!(tag.as_ref().len(), format.tag_len());
+    encoded.put_slice(tag.as_ref());
+
+    let encrypted = EncryptedRecord::new(encoded.freeze(), format);
+    StoredRecord::encrypted(encrypted, metered_size)
 }
 
 pub fn encrypt_append_input(
@@ -275,19 +293,6 @@ pub fn encrypt_append_input(
         match_seq_num,
         fencing_token,
     }
-}
-
-fn prep_encryption_buffer(
-    envelope: &EnvelopeRecord,
-    format: EncryptedRecordFormat,
-) -> (BytesMut, usize) {
-    let payload_start = FORMAT_ID_LEN + format.nonce_len();
-    let mut encoded =
-        BytesMut::with_capacity(payload_start + envelope.encoded_size() + format.tag_len());
-    encoded.put_u8(format.format_id());
-    format.put_random_nonce(&mut encoded);
-    envelope.encode_into(&mut encoded);
-    (encoded, payload_start)
 }
 
 impl TryFrom<Bytes> for EncryptedRecord {

--- a/storage/src/record/encryption.rs
+++ b/storage/src/record/encryption.rs
@@ -29,7 +29,7 @@
 //! append/read metering, limits, or accounting.
 
 use aegis::aegis256::Aegis256;
-use aes_gcm::{Aes256Gcm, KeyInit, aead::AeadInPlace};
+use aes_gcm::{Aes256Gcm, KeyInit, aead::AeadInOut};
 use bytes::{BufMut, Bytes, BytesMut};
 use rand::random;
 use s2_common::{
@@ -230,9 +230,13 @@ pub fn encrypt_record(
             let format = EncryptedRecordFormat::Aes256GcmV1;
             let (mut encoded, payload_start) = prep_encryption_buffer(&envelope, format);
             let (prefix, payload) = encoded.split_at_mut(payload_start);
-            let nonce = aes_gcm::Nonce::from_slice(&prefix[FORMAT_ID_LEN..]);
-            let tag = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key.expose_secret()))
-                .encrypt_in_place_detached(nonce, aad, payload)
+            let nonce: &aes_gcm::aead::Nonce<Aes256Gcm> = prefix[FORMAT_ID_LEN..]
+                .try_into()
+                .expect("AES-256-GCM nonce must be 12 bytes");
+            let cipher = Aes256Gcm::new_from_slice(key.expose_secret())
+                .expect("AES-256-GCM key must be 32 bytes");
+            let tag = cipher
+                .encrypt_inout_detached(nonce, aad, payload.into())
                 .expect("AES-256-GCM encryption should not fail on size validation");
             encoded.put_slice(tag.as_ref());
 
@@ -418,21 +422,20 @@ fn decrypt_payload(
         }
         (EncryptedRecordFormat::Aes256GcmV1, EncryptionSpec::Aes256Gcm(key)) => {
             let (prefix, payload_and_tag) = encoded.split_at_mut(payload_start);
-            let nonce: &[u8; 12] = prefix
+            let nonce: &aes_gcm::aead::Nonce<Aes256Gcm> = prefix
                 .get(FORMAT_ID_LEN..)
                 .ok_or(RecordDecryptionError::MalformedEncryptedRecord)?
                 .try_into()
                 .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
-            let nonce = aes_gcm::Nonce::from_slice(nonce);
             let (ciphertext, tag) = payload_and_tag.split_at_mut(plaintext_len);
-            let tag: &[u8; 16] = tag
+            let tag: &aes_gcm::aead::Tag<Aes256Gcm> = tag
                 .as_ref()
                 .try_into()
                 .map_err(|_| RecordDecryptionError::MalformedEncryptedRecord)?;
-            let tag = aes_gcm::Tag::from_slice(tag);
-            let cipher = Aes256Gcm::new(aes_gcm::Key::<Aes256Gcm>::from_slice(key.expose_secret()));
+            let cipher = Aes256Gcm::new_from_slice(key.expose_secret())
+                .expect("AES-256-GCM key must be 32 bytes");
             cipher
-                .decrypt_in_place_detached(nonce, aad, ciphertext, tag)
+                .decrypt_inout_detached(nonce, aad, ciphertext.into(), tag)
                 .map_err(|_| RecordDecryptionError::AuthenticationFailed)?;
             Ok(decryption_finish(encoded, payload_start, plaintext_len))
         }


### PR DESCRIPTION
## Summary

- upgrade `aes-gcm` from 0.10 to 0.11 and resolve the required crypto transitive dependencies
- migrate AES-GCM record encryption/decryption to `AeadInOut` and borrowed nonce/tag conversions
- share encrypted envelope frame construction while keeping algorithm-specific crypto calls explicit

## Validation

- `cargo metadata --locked --format-version 1`
- `cargo check --workspace --all-features --all-targets`
- `just fmt`
- `just test` (662 passed)
