### PR TITLE
feat(sdk): default account endpoint aws.s2.dev -> a.s2.dev (+ openapi servers URL)

### DIFF
--- a/lite/src/handlers/v1/paths.rs
+++ b/lite/src/handlers/v1/paths.rs
@@ -58,6 +58,6 @@ pub mod streams {
 }
 
 pub mod cloud_endpoints {
-    pub const ACCOUNT: &str = "https://aws.s2.dev/v1";
+    pub const ACCOUNT: &str = "https://a.s2.dev/v1";
     pub const BASIN: &str = "https://{basin}.b.s2.dev/v1";
 }

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -261,7 +261,7 @@ impl S2Endpoints {
     pub(crate) fn for_aws() -> Self {
         Self {
             scheme: Scheme::HTTPS,
-            account_authority: "aws.s2.dev".try_into().expect("valid authority"),
+            account_authority: "a.s2.dev".try_into().expect("valid authority"),
             basin_authority: BasinAuthority::ParentZone(
                 "b.s2.dev".try_into().expect("valid authority"),
             ),


### PR DESCRIPTION
Flip the account endpoint default `aws.s2.dev` → `a.s2.dev` in both spots:

- `lite/src/handlers/v1/paths.rs` — `cloud_endpoints::ACCOUNT`, the sole input to the generated openapi `servers` block (`lite/src/bin/openapi.rs`).
- `sdk/src/types.rs` — `S2Endpoints::for_aws()` account default (reaches users on the next crates.io release).

Basin endpoints unchanged; `aws.s2.dev` keeps serving (same dual-stack NLB). Companion spec regen: s2-streamstore/s2-specs#18.