### PR TITLE
perf(sdk): enable `TCP_NODELAY` to reduce ack latency for small unary appends

### DIFF
--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -411,6 +411,7 @@ pub fn default_connector(
 ) -> Result<HttpsConnector<HttpConnector>, std::io::Error> {
     let mut connector = HttpConnector::new();
     connector.enforce_http(false);
+    connector.set_nodelay(true);
     if let Some(timeout) = connect_timeout {
         connector.set_connect_timeout(Some(timeout));
     }


### PR DESCRIPTION
[bandar comparison for before and after](http://bandar/compare?tests=01KWYWP7PC5MA7RC0SDHECFAYY,01KWZ172ES02446HH7W9KPBZJ8) 