### PR TITLE
fix(lite): make provision_stream exists-outcomes durably visible

### DIFF
--- a/api/src/v1/stream/json.rs
+++ b/api/src/v1/stream/json.rs
@@ -276,13 +276,12 @@ impl std::fmt::Display for Base64Display<'_> {
         const OUTPUT_CHUNK: usize = 4 * 256;
 
         let mut output = [0u8; OUTPUT_CHUNK];
-        let mut chunks = self.0.chunks_exact(INPUT_CHUNK);
-        for chunk in &mut chunks {
+        let (chunks, remainder) = self.0.as_chunks::<INPUT_CHUNK>();
+        for chunk in chunks {
             let encoded = Base64::encode(chunk, &mut output).map_err(|_| std::fmt::Error)?;
             f.write_str(encoded)?;
         }
 
-        let remainder = chunks.remainder();
         if !remainder.is_empty() {
             let encoded_len = Base64::encoded_len(remainder);
             let encoded = Base64::encode(remainder, &mut output[..encoded_len])

--- a/cli/src/tui/ui.rs
+++ b/cli/src/tui/ui.rs
@@ -3487,7 +3487,7 @@ fn draw_append_view(f: &mut Frame, area: Rect, state: &AppendViewState) {
             if state.body.is_empty() && !body_editing {
                 "(empty)".to_string()
             } else {
-                format!("{}{}", &state.body, cursor(body_editing))
+                format!("{}{}", state.body, cursor(body_editing))
             },
             Style::default().fg(if body_editing {
                 CYAN
@@ -3538,7 +3538,7 @@ fn draw_append_view(f: &mut Frame, area: Rect, state: &AppendViewState) {
             Span::styled(
                 format!(
                     "{}{}",
-                    &state.header_key_input,
+                    state.header_key_input,
                     if state.editing_header_key { "▎" } else { "" }
                 ),
                 Style::default().fg(if state.editing_header_key {
@@ -3551,7 +3551,7 @@ fn draw_append_view(f: &mut Frame, area: Rect, state: &AppendViewState) {
             Span::styled(
                 format!(
                     "{}{}",
-                    &state.header_value_input,
+                    state.header_value_input,
                     if !state.editing_header_key { "▎" } else { "" }
                 ),
                 Style::default().fg(if !state.editing_header_key {
@@ -3590,7 +3590,7 @@ fn draw_append_view(f: &mut Frame, area: Rect, state: &AppendViewState) {
             if state.match_seq_num.is_empty() && !match_editing {
                 "(none)".to_string()
             } else {
-                format!("{}{}", &state.match_seq_num, cursor(match_editing))
+                format!("{}{}", state.match_seq_num, cursor(match_editing))
             },
             Style::default().fg(if match_editing {
                 CYAN
@@ -3629,7 +3629,7 @@ fn draw_append_view(f: &mut Frame, area: Rect, state: &AppendViewState) {
             if state.fencing_token.is_empty() && !fence_editing {
                 "(none)".to_string()
             } else {
-                format!("{}{}", &state.fencing_token, cursor(fence_editing))
+                format!("{}{}", state.fencing_token, cursor(fence_editing))
             },
             Style::default().fg(if fence_editing {
                 CYAN
@@ -3677,7 +3677,7 @@ fn draw_append_view(f: &mut Frame, area: Rect, state: &AppendViewState) {
             if state.input_file.is_empty() && !file_editing {
                 "(none)".to_string()
             } else {
-                format!("{}{}", &state.input_file, cursor(file_editing))
+                format!("{}{}", state.input_file, cursor(file_editing))
             },
             Style::default().fg(if file_editing {
                 CYAN
@@ -3811,7 +3811,7 @@ fn draw_append_view(f: &mut Frame, area: Rect, state: &AppendViewState) {
                 ));
             }
             spans.push(Span::styled(
-                format!(" {}", &result.body_preview),
+                format!(" {}", result.body_preview),
                 Style::default().fg(TEXT_SECONDARY),
             ));
             history_lines.push(Line::from(spans));

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -89,7 +89,6 @@ impl Backend {
         let reason = match rx.await {
             Ok(Ok(_)) => return Ok(()),
             Ok(Err(reason)) => reason,
-            // Callback dropped uninvoked: abrupt runtime shutdown.
             Err(_) => slatedb::CloseReason::Clean,
         };
         Err(slatedb::Error::closed(
@@ -376,8 +375,6 @@ impl Backend {
                             }
                         }
                     }
-                    // provision_stream guarantees the outcome is durably
-                    // visible, so start_streamer's Remote-level read sees it.
                     let client = self.streamer_client_guarded(basin, stream).await?;
                     let encryption = resolve_encryption(client.cipher())?;
                     Ok(StreamHandle {

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use bytesize::ByteSize;
 use dashmap::DashMap;
@@ -304,6 +304,32 @@ impl Backend {
         }
     }
 
+    /// Lookup for a stream that is known to exist: `start_streamer` reads at
+    /// `DurabilityLevel::Remote`, which can lag a concurrent creator's freshly
+    /// committed meta, so a transient not-found is retried until the durable
+    /// watermark catches up (bounded, in case the DB is wedged).
+    async fn streamer_client_guarded_provisioned(
+        &self,
+        basin: &BasinName,
+        stream: &StreamName,
+    ) -> Result<GuardedStreamerClient, StreamerError> {
+        const RETRY_DEADLINE: Duration = Duration::from_secs(2);
+        const MAX_BACKOFF: Duration = Duration::from_millis(100);
+        let deadline = tokio::time::Instant::now() + RETRY_DEADLINE;
+        let mut backoff = Duration::from_millis(1);
+        loop {
+            match self.streamer_client_guarded(basin, stream).await {
+                Err(StreamerError::StreamNotFound(_))
+                    if tokio::time::Instant::now() + backoff < deadline =>
+                {
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(MAX_BACKOFF);
+                }
+                result => return result,
+            }
+        }
+    }
+
     pub(super) async fn stream_handle_with_auto_create<E>(
         &self,
         basin: &BasinName,
@@ -356,7 +382,9 @@ impl Backend {
                             }
                         }
                     }
-                    let client = self.streamer_client_guarded(basin, stream).await?;
+                    let client = self
+                        .streamer_client_guarded_provisioned(basin, stream)
+                        .await?;
                     let encryption = resolve_encryption(client.cipher())?;
                     Ok(StreamHandle {
                         db: self.db.clone(),
@@ -555,6 +583,68 @@ mod tests {
                 assert_eq!(*generation_id, current_generation_id)
             }
             _ => panic!("expected initializing slot to remain unchanged"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn concurrent_appends_auto_create_stream_without_spurious_not_found() {
+        use s2_common::stream::{AppendInput, AppendRecord, AppendRecordParts};
+
+        use crate::backend::error::AppendError;
+
+        fn append_input(body: &str) -> AppendInput {
+            let record =
+                Record::try_from_parts(vec![], Bytes::copy_from_slice(body.as_bytes())).unwrap();
+            let record: AppendRecord = AppendRecordParts {
+                timestamp: None,
+                record: Metered::from(record),
+            }
+            .try_into()
+            .unwrap();
+            AppendInput {
+                records: vec![record].try_into().unwrap(),
+                match_seq_num: None,
+                fencing_token: None,
+            }
+        }
+
+        let backend = new_test_backend().await;
+        let basin = BasinName::from_str("autocreate").unwrap();
+        backend
+            .provision_basin(
+                basin.clone(),
+                BasinConfig {
+                    create_stream_on_append: true,
+                    ..BasinConfig::default()
+                },
+                ProvisionMode::CreateOnly {
+                    request_token: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        for round in 0..10 {
+            let stream = StreamName::from_str(&format!("fresh-{round}")).unwrap();
+            let tasks: Vec<_> = (0..4)
+                .map(|i| {
+                    let backend = backend.clone();
+                    let basin = basin.clone();
+                    let stream = stream.clone();
+                    tokio::spawn(async move {
+                        let handle = backend.open_for_append(&basin, &stream, None).await?;
+                        handle.append(append_input(&format!("r{i}"))).await
+                    })
+                })
+                .collect();
+            for task in tasks {
+                match task.await.unwrap() {
+                    Ok(_) => {}
+                    // Conflict losers surface as retryable 409s to clients.
+                    Err(AppendError::TransactionConflict(_)) => {}
+                    Err(e) => panic!("concurrent auto-create append failed: {e:?}"),
+                }
+            }
         }
     }
 }

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use bytesize::ByteSize;
 use dashmap::DashMap;
@@ -77,6 +77,26 @@ impl Backend {
 
     pub(super) fn bgtask_trigger_subscribe(&self) -> broadcast::Receiver<BgtaskTrigger> {
         self.bgtask_trigger_tx.subscribe()
+    }
+
+    /// Wait until writes up to `db_seq` are durable, i.e. visible to reads at
+    /// `DurabilityLevel::Remote`. Resolves immediately if they already are.
+    pub(super) async fn await_durable_seq(&self, db_seq: u64) -> Result<(), StorageError> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.durability_notifier.subscribe(db_seq, move |res| {
+            let _ = tx.send(res);
+        });
+        let reason = match rx.await {
+            Ok(Ok(_)) => return Ok(()),
+            Ok(Err(reason)) => reason,
+            // Callback dropped uninvoked: abrupt runtime shutdown.
+            Err(_) => slatedb::CloseReason::Clean,
+        };
+        Err(slatedb::Error::closed(
+            "database closed while waiting for durability".to_owned(),
+            reason,
+        )
+        .into())
     }
 
     async fn start_streamer(
@@ -304,32 +324,6 @@ impl Backend {
         }
     }
 
-    /// Lookup for a stream that is known to exist: `start_streamer` reads at
-    /// `DurabilityLevel::Remote`, which can lag a concurrent creator's freshly
-    /// committed meta, so a transient not-found is retried until the durable
-    /// watermark catches up (bounded, in case the DB is wedged).
-    async fn streamer_client_guarded_provisioned(
-        &self,
-        basin: &BasinName,
-        stream: &StreamName,
-    ) -> Result<GuardedStreamerClient, StreamerError> {
-        const RETRY_DEADLINE: Duration = Duration::from_secs(2);
-        const MAX_BACKOFF: Duration = Duration::from_millis(100);
-        let deadline = tokio::time::Instant::now() + RETRY_DEADLINE;
-        let mut backoff = Duration::from_millis(1);
-        loop {
-            match self.streamer_client_guarded(basin, stream).await {
-                Err(StreamerError::StreamNotFound(_))
-                    if tokio::time::Instant::now() + backoff < deadline =>
-                {
-                    tokio::time::sleep(backoff).await;
-                    backoff = (backoff * 2).min(MAX_BACKOFF);
-                }
-                result => return result,
-            }
-        }
-    }
-
     pub(super) async fn stream_handle_with_auto_create<E>(
         &self,
         basin: &BasinName,
@@ -382,9 +376,9 @@ impl Backend {
                             }
                         }
                     }
-                    let client = self
-                        .streamer_client_guarded_provisioned(basin, stream)
-                        .await?;
+                    // provision_stream guarantees the outcome is durably
+                    // visible, so start_streamer's Remote-level read sees it.
+                    let client = self.streamer_client_guarded(basin, stream).await?;
                     let encryption = resolve_encryption(client.cipher())?;
                     Ok(StreamHandle {
                         db: self.db.clone(),

--- a/lite/src/backend/streamer.rs
+++ b/lite/src/backend/streamer.rs
@@ -1076,7 +1076,7 @@ mod tests {
     use bytes::Bytes;
     use s2_common::{
         encryption::EncryptionSpec,
-        record::{EnvelopeRecord, MeteredExt as _, Record},
+        record::{EnvelopeRecord, Record},
     };
     use s2_storage::record::{
         StoredAppendInput, StoredAppendRecord, StoredAppendRecordBatch, StoredAppendRecordParts,

--- a/lite/src/backend/streams.rs
+++ b/lite/src/backend/streams.rs
@@ -226,7 +226,6 @@ impl Backend {
                 )?;
             }
 
-            // await_durable commit: the outcome is durably visible on return.
             txn.commit().await?;
         }
 

--- a/lite/src/backend/streams.rs
+++ b/lite/src/backend/streams.rs
@@ -76,6 +76,9 @@ impl Backend {
         Ok(Page::new(streams, has_more))
     }
 
+    /// Invariant: any outcome asserting the stream exists — `Created`,
+    /// `Updated`, `Noop`, or `StreamAlreadyExists` — is durably visible
+    /// (readable at `DurabilityLevel::Remote`) by the time this returns.
     pub async fn provision_stream(
         &self,
         basin: BasinName,
@@ -101,8 +104,14 @@ impl Backend {
 
         let stream_meta_key = kv::stream_meta::ser_key(&basin, &stream);
 
-        let existing_meta =
-            db_txn_get(&txn, &stream_meta_key, kv::stream_meta::deser_value).await?;
+        // Existence is decided from a Memory-level read; capture the row's
+        // commit seq so exists-outcomes can await durability (see fn doc).
+        let existing_entry = txn.get_key_value(&stream_meta_key).await?;
+        let existing_seq = existing_entry.as_ref().map(|kv| kv.seq);
+        let existing_meta = existing_entry
+            .map(|kv| kv::stream_meta::deser_value(kv.value))
+            .transpose()
+            .map_err(StorageError::from)?;
         if let Some(existing_meta) = &existing_meta
             && existing_meta.deleted_at.is_some()
         {
@@ -117,7 +126,7 @@ impl Backend {
                 let new_creation_idempotency_key = request_token
                     .as_ref()
                     .map(|req_token| creation_idempotency_key(req_token, &config));
-                return if new_creation_idempotency_key.is_some()
+                let result = if new_creation_idempotency_key.is_some()
                     && existing.creation_idempotency_key == new_creation_idempotency_key
                 {
                     Ok(ProvisionResult::Noop(StreamInfo {
@@ -129,6 +138,10 @@ impl Backend {
                 } else {
                     Err(StreamAlreadyExistsError { basin, stream }.into())
                 };
+                drop(txn);
+                self.await_durable_seq(existing_seq.expect("existing meta was read"))
+                    .await?;
+                return result;
             }
             (Some(existing), ProvisionMode::Ensure) => {
                 let desired_config = config.merge(basin_defaults);
@@ -176,7 +189,11 @@ impl Backend {
             ),
         };
 
-        if !matches!(&outcome, ProvisionResult::Noop(_)) {
+        if matches!(&outcome, ProvisionResult::Noop(_)) {
+            drop(txn);
+            self.await_durable_seq(existing_seq.expect("noop implies existing meta"))
+                .await?;
+        } else {
             let meta = outcome.inner();
 
             txn.put(&stream_meta_key, kv::stream_meta::ser_value(meta))?;
@@ -209,6 +226,7 @@ impl Backend {
                 )?;
             }
 
+            // await_durable commit: the outcome is durably visible on return.
             txn.commit().await?;
         }
 

--- a/sdk/tests/account_ops.rs
+++ b/sdk/tests/account_ops.rs
@@ -310,7 +310,7 @@ async fn delete_nonexistent_basin_errors() -> Result<(), S2Error> {
 
     assert_matches!(
         result,
-        Err(S2Error::Server(ErrorResponse { code, message: _, .. })) => {
+        Err(S2Error::Server(ErrorResponse { code, .. })) => {
             assert_eq!(code, "basin_not_found")
         }
     );

--- a/sdk/tests/basin_ops.rs
+++ b/sdk/tests/basin_ops.rs
@@ -318,7 +318,7 @@ async fn delete_nonexistent_stream_errors(basin: &S2Basin) -> Result<(), S2Error
 
     assert_matches!(
         result,
-        Err(S2Error::Server(ErrorResponse {code, message: _, ..})) => {
+        Err(S2Error::Server(ErrorResponse { code, .. })) => {
             assert_eq!(code, "stream_not_found")
         }
     );


### PR DESCRIPTION
## Problem

Concurrent appends (or reads) that auto-create the same fresh stream — basin has `create_stream_on_append` / `create_stream_on_read` — race in `stream_handle_with_auto_create`. Exactly one racer creates the stream cleanly; the others split into two fates:

- **Conflict losers**: their provision txn read the stream meta as absent, the winner committed first → SSI read-write conflict → `TransactionConflict` → HTTP 409, which clients retry and succeed. Fine.
- **Already-exists losers**: their txn began after the winner's memtable write → `provision_stream`'s existence check (`db_txn_get`, `DurabilityLevel::Memory`) sees the meta → `StreamAlreadyExists`, correctly swallowed. But the immediately following `start_streamer` reads that same meta at `DurabilityLevel::Remote`, whose watermark can lag the winner's `await_durable` commit by up to one flush interval → `StreamNotFound` → **HTTP 404, non-retryable**. For appends, clients that treat 404 as terminal silently lose the write.

The server proves the stream exists and denies it exists within the same request. Repro: 4 concurrent unary appends to a fresh auto-create stream → 1 OK, others 404 (some 409→retry→OK). Immediate retry of the 404s succeeds; once the stream exists the race is gone. S2 cloud is unaffected (verified 30/30 concurrent auto-create appends).

```
timeline ─────────────────────────────────────────────────────▶
winner:   get(meta)=None ── put ── commit(await_durable) ══flush══ done ── refetch OK
loser A:  get(meta)=None ─────── commit → CONFLICT → 409 → client retries → OK
loser B:            get(meta)=Some (Memory) → AlreadyExists → refetch (Remote) → 404 ← bug
```

## Verification

- New regression test `concurrent_appends_auto_create_stream_without_spurious_not_found` reproduces the 404 in-process on unfixed code (fails on first round) and passes with the fix.
- Full `s2-lite` suite: 120/120; `cargo fmt` + `clippy --lib --tests` clean.
- End-to-end against the rebuilt server binary: TypeScript SDK repro went 30/30 concurrent auto-create appends with zero 404s (conflict losers succeed via SDK retry), matching observed cloud behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)