### PR TITLE
feat(sdk)!: expose caught-up-to-tail signal on read sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
       RUSTFLAGS: --cfg tokio_unstable
       # The Go linearizability checker must be built from the same rev as the
       # s2-verification dependency pinned in sim/Cargo.toml.
-      S2_VERIFICATION_REV: 050063e2573e2769c60ed24f71767db1c289e745
+      S2_VERIFICATION_REV: 113770a40f96cba9c5bfd4eb1f1a46989c813283
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
       RUSTFLAGS: --cfg tokio_unstable
       # The Go linearizability checker must be built from the same rev as the
       # s2-verification dependency pinned in sim/Cargo.toml.
-      S2_VERIFICATION_REV: 394929f199480fd3a2d49ec1992779a9772e77fe
+      S2_VERIFICATION_REV: 050063e2573e2769c60ed24f71767db1c289e745
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -529,10 +529,12 @@ pub async fn read(
         stop = stop.with_until(..until);
     }
 
-    stream
+    let session = stream
         .read_session(ReadInput::new().with_start(start).with_stop(stop))
         .await
-        .map_err(|e| CliError::op(OpKind::Read, e))
+        .map_err(|e| CliError::op(OpKind::Read, e))?;
+
+    Ok(Box::pin(session))
 }
 
 pub fn append<'a, S, E>(

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -5,6 +5,7 @@ use s2_sdk::{
     self as sdk, S2, S2Stream,
     batching::BatchingConfig,
     producer::{IndexedAppendAck, ProducerConfig},
+    read_session::ReadSession,
     types::{
         AccessTokenId, AccessTokenInfo, AccessTokenScopeInput, AccountMetricSet, AppendAck,
         AppendInput, AppendRecord, AppendRecordBatch, BasinInfo, BasinMetricSet, BasinName,
@@ -12,10 +13,10 @@ use s2_sdk::{
         DeleteStreamInput, EncryptionKey, FencingToken, GetAccountMetricsInput,
         GetBasinMetricsInput, GetStreamMetricsInput, IssueAccessTokenInput, ListAccessTokensInput,
         ListAllAccessTokensInput, ListAllBasinsInput, ListAllStreamsInput, ListBasinsInput,
-        ListStreamsInput, LocationInfo, LocationName, MeteredBytes, Metric, ReadBatch, ReadFrom,
-        ReadInput, ReadLimits, ReadStart, ReadStop, ReconfigureBasinInput, ReconfigureStreamInput,
-        S2DateTime, SequencedRecord, StreamInfo, StreamMetricSet, StreamPosition,
-        StreamReconfiguration, Streaming, TimeRange, TimeRangeAndInterval,
+        ListStreamsInput, LocationInfo, LocationName, MeteredBytes, Metric, ReadFrom, ReadInput,
+        ReadLimits, ReadStart, ReadStop, ReconfigureBasinInput, ReconfigureStreamInput, S2DateTime,
+        SequencedRecord, StreamInfo, StreamMetricSet, StreamPosition, StreamReconfiguration,
+        TimeRange, TimeRangeAndInterval,
     },
 };
 
@@ -491,7 +492,7 @@ pub async fn read(
     s2: &S2,
     args: &ReadArgs,
     encryption_key: Option<&EncryptionKey>,
-) -> Result<Streaming<ReadBatch>, CliError> {
+) -> Result<ReadSession, CliError> {
     use std::time::SystemTime;
 
     let stream = stream_with_encryption(s2, args.uri.clone(), encryption_key);
@@ -529,12 +530,10 @@ pub async fn read(
         stop = stop.with_until(..until);
     }
 
-    let session = stream
+    stream
         .read_session(ReadInput::new().with_start(start).with_stop(stop))
         .await
-        .map_err(|e| CliError::op(OpKind::Read, e))?;
-
-    Ok(Box::pin(session))
+        .map_err(|e| CliError::op(OpKind::Read, e))
 }
 
 pub fn append<'a, S, E>(

--- a/sdk/examples/caught_up.rs
+++ b/sdk/examples/caught_up.rs
@@ -1,0 +1,100 @@
+use futures_util::StreamExt;
+use s2_sdk::{
+    S2,
+    types::{
+        AppendInput, AppendRecord, AppendRecordBatch, BasinName, CreateBasinInput,
+        CreateStreamInput, DeleteBasinInput, DeleteStreamInput, ReadBatch, ReadFrom, ReadInput,
+        ReadStart, S2Config, S2Endpoints, StreamName,
+    },
+};
+
+fn print_batch(label: &str, batch: &ReadBatch) {
+    let seq_nums = batch
+        .records
+        .iter()
+        .map(|record| record.seq_num)
+        .collect::<Vec<_>>();
+    println!("{label}: {seq_nums:?}");
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let access_token =
+        std::env::var("S2_ACCESS_TOKEN").map_err(|_| "S2_ACCESS_TOKEN env var not set")?;
+    let mut config = S2Config::new(access_token);
+    if std::env::var_os("S2_ACCOUNT_ENDPOINT").is_some()
+        || std::env::var_os("S2_BASIN_ENDPOINT").is_some()
+    {
+        config = config.with_endpoints(S2Endpoints::from_env()?);
+    }
+
+    let suffix = &uuid::Uuid::new_v4().simple().to_string()[..8];
+    let basin_name: BasinName = format!("caught-up-{suffix}").parse()?;
+    let stream_name: StreamName = "example".parse()?;
+    let s2 = S2::new(config)?;
+    let basin = s2.basin(basin_name.clone());
+
+    s2.create_basin(CreateBasinInput::new(basin_name.clone()))
+        .await?;
+    basin
+        .create_stream(CreateStreamInput::new(stream_name.clone()))
+        .await?;
+    let stream = basin.stream(stream_name.clone());
+
+    stream
+        .append(AppendInput::new(AppendRecordBatch::try_from_iter([
+            AppendRecord::new("first")?,
+            AppendRecord::new("second")?,
+        ])?))
+        .await?;
+
+    let mut session = stream
+        .read_session(
+            ReadInput::new().with_start(ReadStart::new().with_from(ReadFrom::TailOffset(2))),
+        )
+        .await?;
+    let mut caught_up = session.caught_up();
+
+    loop {
+        tokio::select! {
+            tail = &mut caught_up => {
+                println!("Caught up through sequence number {}", tail?.seq_num);
+                break;
+            }
+            Some(batch) = session.next() => {
+                print_batch("Read before catching up", &batch?);
+            }
+        }
+    }
+
+    let ack = stream
+        .append(AppendInput::new(AppendRecordBatch::try_from_iter([
+            AppendRecord::new("third")?,
+        ])?))
+        .await?;
+    println!(
+        "Appended another record at sequence number {}",
+        ack.start.seq_num
+    );
+
+    while let Some(batch) = session.next().await {
+        let batch = batch?;
+        print_batch("Read after catching up", &batch);
+        if batch
+            .records
+            .iter()
+            .any(|record| record.seq_num == ack.start.seq_num)
+        {
+            break;
+        }
+    }
+    println!("Session is caught up again: {}", session.is_caught_up());
+
+    drop(session);
+    basin
+        .delete_stream(DeleteStreamInput::new(stream_name))
+        .await?;
+    s2.delete_basin(DeleteBasinInput::new(basin_name)).await?;
+
+    Ok(())
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -50,6 +50,7 @@ demonstrating how to use the SDK effectively:
 * [Explicit stream trimming](https://github.com/s2-streamstore/s2/blob/main/sdk/examples/explicit_trim.rs)
 * [Producer](https://github.com/s2-streamstore/s2/blob/main/sdk/examples/producer.rs)
 * [Consumer](https://github.com/s2-streamstore/s2/blob/main/sdk/examples/consumer.rs)
+* [Caught-up read session](https://github.com/s2-streamstore/s2/blob/main/sdk/examples/caught_up.rs)
 * and many more...
 
 This documentation is generated using

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -110,5 +110,5 @@ pub mod append_session {
 }
 /// Continuous read sessions.
 pub mod read_session {
-    pub use crate::session::read::{CaughtUp, CaughtUpError, ReadSession};
+    pub use crate::session::read::{CaughtUpError, ReadSession};
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -108,3 +108,7 @@ pub mod append_session {
         AppendSession, AppendSessionConfig, BatchSubmitPermit, BatchSubmitTicket,
     };
 }
+/// Continuous read sessions.
+pub mod read_session {
+    pub use crate::session::read::{CaughtUp, CaughtUpError, ReadSession};
+}

--- a/sdk/src/ops.rs
+++ b/sdk/src/ops.rs
@@ -1,11 +1,9 @@
-use futures_util::StreamExt;
-
 #[cfg(feature = "_hidden")]
 use crate::client::Connect;
 use crate::{
     api::{AccountClient, BaseClient, BasinClient},
     producer::{Producer, ProducerConfig},
-    session::{self, AppendSession, AppendSessionConfig},
+    session::{self, AppendSession, AppendSessionConfig, ReadSession},
     types::{
         AccessTokenId, AccessTokenInfo, AppendAck, AppendInput, BasinConfig, BasinInfo, BasinName,
         CreateBasinInput, CreateStreamInput, DeleteBasinInput, DeleteStreamInput, EncryptionKey,
@@ -461,8 +459,8 @@ impl S2Stream {
     }
 
     /// Create a read session.
-    pub async fn read_session(&self, input: ReadInput) -> Result<Streaming<ReadBatch>, S2Error> {
-        let batches = session::read_session(
+    pub async fn read_session(&self, input: ReadInput) -> Result<ReadSession, S2Error> {
+        Ok(session::read_session(
             self.client.clone(),
             self.name.clone(),
             self.encryption.clone(),
@@ -470,10 +468,6 @@ impl S2Stream {
             input.stop.into(),
             input.ignore_command_records,
         )
-        .await?;
-        Ok(Box::pin(batches.map(|res| match res {
-            Ok(batch) => Ok(batch),
-            Err(err) => Err(err.into()),
-        })))
+        .await?)
     }
 }

--- a/sdk/src/session/mod.rs
+++ b/sdk/src/session/mod.rs
@@ -3,4 +3,4 @@ pub mod read;
 
 pub(crate) use append::{AppendPermit, AppendPermits, AppendSessionInternal, BatchSubmitTicket};
 pub use append::{AppendSession, AppendSessionConfig};
-pub use read::read_session;
+pub use read::{ReadSession, read_session};

--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -230,41 +230,11 @@ impl ReadSession {
 
     /// Return a future for the current or next caught-up tail.
     ///
-    /// It is ready immediately when already caught up and remains pending across retries.
-    /// Once resolved, it keeps that tail if the session later falls behind.
-    /// Keep reading batches while waiting. Call again after falling behind. Returns
-    /// [`CaughtUpError`] if the read fails or ends first.
-    ///
-    /// # Example
-    ///
-    /// Drive the session stream while waiting for the caught-up signal:
-    ///
-    /// ```rust
-    /// use futures_util::StreamExt;
-    /// use s2_sdk::read_session::{CaughtUpError, ReadSession};
-    ///
-    /// # async fn consume(mut session: ReadSession) -> Result<(), CaughtUpError> {
-    /// let mut caught_up = session.caught_up();
-    /// loop {
-    ///     tokio::select! {
-    ///         tail = &mut caught_up => {
-    ///             println!("Caught up through {}", tail?);
-    ///             break;
-    ///         }
-    ///         Some(batch) = session.next() => {
-    ///             let batch = batch?;
-    ///             println!("Read {} records", batch.records.len());
-    ///         }
-    ///     }
-    /// }
-    ///
-    /// while let Some(batch) = session.next().await {
-    ///     let batch = batch?;
-    ///     println!("Read {} records", batch.records.len());
-    /// }
-    /// # Ok(())
-    /// # }
-    /// ```
+    /// Continue polling the read session while awaiting this future; the future does not drive
+    /// reads itself. It is ready immediately when the session is already caught up and remains
+    /// pending across retries. Once it resolves, its returned tail never changes. If the session
+    /// later falls behind, call `caught_up()` again to wait for the next catch-up. The future
+    /// returns [`CaughtUpError`] if the session fails or closes before catching up.
     pub fn caught_up(
         &self,
     ) -> impl Future<Output = Result<StreamPosition, CaughtUpError>>

--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -76,12 +76,12 @@ impl From<CaughtUpError> for S2Error {
 }
 
 type CaughtUpResult = Result<StreamPosition, CaughtUpError>;
-type SharedCaughtUp = Shared<BoxFuture<'static, CaughtUpResult>>;
+type CaughtUpFuture = Shared<BoxFuture<'static, CaughtUpResult>>;
 
 /// A future that returns the next caught-up tail.
 #[derive(Clone)]
 pub struct CaughtUp {
-    inner: SharedCaughtUp,
+    inner: CaughtUpFuture,
 }
 
 impl Future for CaughtUp {
@@ -93,10 +93,14 @@ impl Future for CaughtUp {
 }
 
 struct CaughtUpState {
+    /// Latest reported tail we've fully delivered, if currently caught up.
     tail: Option<StreamPosition>,
+    /// Once set, the session has ended.
     terminal: bool,
+    /// Fires the current `CaughtUp` future.
     tx: Option<oneshot::Sender<CaughtUpResult>>,
-    future: SharedCaughtUp,
+    /// The future handed out by `caught_up()`.
+    future: CaughtUpFuture,
 }
 
 impl CaughtUpState {
@@ -159,7 +163,7 @@ impl CaughtUpState {
     }
 }
 
-fn pending_caught_up() -> (oneshot::Sender<CaughtUpResult>, SharedCaughtUp) {
+fn pending_caught_up() -> (oneshot::Sender<CaughtUpResult>, CaughtUpFuture) {
     let (tx, rx) = oneshot::channel();
     let future = async move { rx.await.unwrap_or(Err(CaughtUpError::SessionClosed)) }
         .boxed()

--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -1,15 +1,26 @@
-use std::{pin::Pin, time::Duration};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
 
 use async_stream::{stream, try_stream};
-use futures_util::StreamExt;
+use futures_util::{
+    StreamExt,
+    future::{BoxFuture, FutureExt, Shared, ready},
+};
 use s2_api::v1::stream::{ReadEnd, ReadStart};
-use tokio::time::{Instant, timeout};
+use tokio::{
+    sync::oneshot,
+    time::{Instant, timeout},
+};
 use tracing::debug;
 
 use crate::{
     api::{ApiError, BasinClient, retry_builder},
     retry::RetryBackoff,
-    types::{EncryptionKey, MeteredBytes, ReadBatch, S2Error, StreamName},
+    types::{EncryptionKey, MeteredBytes, ReadBatch, S2Error, StreamName, StreamPosition},
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -41,6 +52,237 @@ impl From<ReadSessionError> for S2Error {
 pub type Streaming<R> =
     Pin<Box<dyn Send + futures_core::Stream<Item = Result<R, ReadSessionError>>>>;
 
+#[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
+/// Error returned while waiting for a read session to catch up.
+pub enum CaughtUpError {
+    #[error("read session ended before catching up")]
+    /// The session ended before reaching a reported tail.
+    SessionClosed,
+    #[error(transparent)]
+    /// The read failed.
+    Read(#[from] S2Error),
+}
+
+impl From<CaughtUpError> for S2Error {
+    fn from(err: CaughtUpError) -> Self {
+        match err {
+            CaughtUpError::SessionClosed => {
+                Self::Client("read session ended before catching up".into())
+            }
+            CaughtUpError::Read(err) => err,
+        }
+    }
+}
+
+type CaughtUpResult = Result<StreamPosition, CaughtUpError>;
+type SharedCaughtUp = Shared<BoxFuture<'static, CaughtUpResult>>;
+
+pin_project_lite::pin_project! {
+    /// A future that returns the next caught-up tail.
+    #[derive(Clone)]
+    pub struct CaughtUp {
+        #[pin]
+        inner: SharedCaughtUp,
+    }
+}
+
+impl Future for CaughtUp {
+    type Output = CaughtUpResult;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll(cx)
+    }
+}
+
+struct CaughtUpState {
+    tail: Option<StreamPosition>,
+    terminal: bool,
+    tx: Option<oneshot::Sender<CaughtUpResult>>,
+    future: SharedCaughtUp,
+}
+
+impl CaughtUpState {
+    fn new() -> Self {
+        let (tx, future) = pending_caught_up();
+        Self {
+            tail: None,
+            terminal: false,
+            tx: Some(tx),
+            future,
+        }
+    }
+
+    fn is_caught_up(&self) -> bool {
+        self.tail.is_some()
+    }
+
+    fn future(&self) -> CaughtUp {
+        CaughtUp {
+            inner: self.future.clone(),
+        }
+    }
+
+    fn set_behind(&mut self) {
+        if self.terminal || self.tail.take().is_none() {
+            return;
+        }
+        let (tx, future) = pending_caught_up();
+        self.tx = Some(tx);
+        self.future = future;
+    }
+
+    fn set_caught_up(&mut self, tail: StreamPosition) {
+        if self.terminal {
+            return;
+        }
+        self.tail = Some(tail);
+        self.complete(Ok(tail));
+    }
+
+    fn end(&mut self, error: Option<S2Error>) {
+        if self.terminal {
+            return;
+        }
+        self.terminal = true;
+        if let Some(error) = error {
+            self.tail = None;
+            self.complete(Err(CaughtUpError::Read(error)));
+        } else if self.tail.is_none() {
+            self.complete(Err(CaughtUpError::SessionClosed));
+        }
+    }
+
+    fn complete(&mut self, result: CaughtUpResult) {
+        if let Some(tx) = self.tx.take() {
+            let _ = tx.send(result);
+        } else {
+            self.future = ready(result).boxed().shared();
+        }
+    }
+}
+
+fn pending_caught_up() -> (oneshot::Sender<CaughtUpResult>, SharedCaughtUp) {
+    let (tx, rx) = oneshot::channel();
+    let future = async move { rx.await.unwrap_or(Err(CaughtUpError::SessionClosed)) }
+        .boxed()
+        .shared();
+    (tx, future)
+}
+
+struct ReadUpdate {
+    batch: Option<ReadBatch>,
+    caught_up_tail: Option<StreamPosition>,
+}
+
+impl ReadUpdate {
+    fn behind() -> Self {
+        Self {
+            batch: None,
+            caught_up_tail: None,
+        }
+    }
+
+    fn from_batch(mut batch: ReadBatch, ignore_command_records: bool) -> Self {
+        let caught_up_tail = batch.tail.filter(|tail| {
+            batch.records.is_empty()
+                || batch
+                    .records
+                    .last()
+                    .is_some_and(|record| record.seq_num.checked_add(1) == Some(tail.seq_num))
+        });
+
+        if ignore_command_records {
+            batch.records.retain(|record| !record.is_command_record());
+        }
+
+        Self {
+            batch: (!batch.records.is_empty()).then_some(batch),
+            caught_up_tail,
+        }
+    }
+}
+
+/// A continuous stream of read batches.
+pub struct ReadSession {
+    updates: Streaming<ReadUpdate>,
+    state: CaughtUpState,
+    terminated: bool,
+}
+
+impl ReadSession {
+    fn new(updates: Streaming<ReadUpdate>) -> Self {
+        Self {
+            updates,
+            state: CaughtUpState::new(),
+            terminated: false,
+        }
+    }
+
+    /// Return whether all records through the latest reported tail were delivered.
+    ///
+    /// A later batch that does not reach a reported tail or a reconnect resets it.
+    /// Ignored command records count toward progress. Use
+    /// [`S2Stream::check_tail`](crate::S2Stream::check_tail) for the current tail.
+    pub fn is_caught_up(&self) -> bool {
+        self.state.is_caught_up()
+    }
+
+    /// Return a future for the next caught-up tail.
+    ///
+    /// It is ready immediately when already caught up and remains pending across retries.
+    /// Keep reading batches while waiting. Call again after falling behind. Returns
+    /// [`CaughtUpError`] if the read fails or ends first.
+    pub fn caught_up(&self) -> CaughtUp {
+        self.state.future()
+    }
+}
+
+impl futures_core::Stream for ReadSession {
+    type Item = Result<ReadBatch, S2Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.terminated {
+            return Poll::Ready(None);
+        }
+
+        loop {
+            match self.updates.as_mut().poll_next(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Some(Ok(update))) => {
+                    self.state.set_behind();
+                    if let Some(batch) = update.batch {
+                        if let Some(tail) = update.caught_up_tail {
+                            self.state.set_caught_up(tail);
+                        }
+                        return Poll::Ready(Some(Ok(batch)));
+                    }
+                    if let Some(tail) = update.caught_up_tail {
+                        self.state.set_caught_up(tail);
+                    }
+                }
+                Poll::Ready(Some(Err(error))) => {
+                    let error = S2Error::from(error);
+                    self.state.end(Some(error.clone()));
+                    self.terminated = true;
+                    return Poll::Ready(Some(Err(error)));
+                }
+                Poll::Ready(None) => {
+                    self.state.end(None);
+                    self.terminated = true;
+                    return Poll::Ready(None);
+                }
+            }
+        }
+    }
+}
+
+impl Drop for ReadSession {
+    fn drop(&mut self) {
+        self.state.end(None);
+    }
+}
+
 pub async fn read_session(
     client: BasinClient,
     name: StreamName,
@@ -48,7 +290,7 @@ pub async fn read_session(
     mut start: ReadStart,
     mut end: ReadEnd,
     ignore_command_records: bool,
-) -> Result<Streaming<ReadBatch>, ReadSessionError> {
+) -> Result<ReadSession, ReadSessionError> {
     let mut retry_backoff = retry_builder(&client.config.retry).build();
     let baseline_wait = end.wait;
     let mut last_tail_at: Option<Instant> = None;
@@ -69,7 +311,8 @@ pub async fn read_session(
                 break batches;
             }
             Err(err) => {
-                if can_retry(&err, &mut retry_backoff).await {
+                if let Some(backoff) = retry_delay(&err, &mut retry_backoff) {
+                    tokio::time::sleep(backoff).await;
                     continue;
                 }
                 return Err(err);
@@ -77,7 +320,7 @@ pub async fn read_session(
         }
     };
 
-    Ok(Box::pin(stream! {
+    let updates = Box::pin(stream! {
         let mut batches: Option<Streaming<ReadBatch>> = Some(batches);
 
         loop {
@@ -92,7 +335,8 @@ pub async fn read_session(
                 ).await {
                     Ok(b) => batches = Some(b),
                     Err(err) => {
-                        if can_retry(&err, &mut retry_backoff).await {
+                        if let Some(backoff) = retry_delay(&err, &mut retry_backoff) {
+                            tokio::time::sleep(backoff).await;
                             continue;
                         }
                         yield Err(err);
@@ -107,7 +351,7 @@ pub async fn read_session(
                 .next()
                 .await
             {
-                Some(Ok(mut batch)) => {
+                Some(Ok(batch)) => {
                     if retry_backoff.used() > 0 {
                         retry_backoff.reset();
                     }
@@ -133,17 +377,13 @@ pub async fn read_session(
                         )
                     }
 
-                    if ignore_command_records {
-                        batch.records.retain(|r| !r.is_command_record());
-                    }
-
-                    if !batch.records.is_empty() {
-                        yield Ok(batch);
-                    }
+                    yield Ok(ReadUpdate::from_batch(batch, ignore_command_records));
                 }
                 Some(Err(err)) => {
                     batches = None;
-                    if can_retry(&err, &mut retry_backoff).await {
+                    if let Some(backoff) = retry_delay(&err, &mut retry_backoff) {
+                        yield Ok(ReadUpdate::behind());
+                        tokio::time::sleep(backoff).await;
                         continue;
                     }
                     yield Err(err);
@@ -152,7 +392,8 @@ pub async fn read_session(
                 None => break,
             }
         }
-    }))
+    });
+    Ok(ReadSession::new(updates))
 }
 
 async fn session_inner(
@@ -191,7 +432,7 @@ fn remaining_wait(baseline_wait: Option<u32>, last_tail_at: Option<Instant>) -> 
     })
 }
 
-async fn can_retry(err: &ReadSessionError, backoffs: &mut RetryBackoff) -> bool {
+fn retry_delay(err: &ReadSessionError, backoffs: &mut RetryBackoff) -> Option<Duration> {
     if err.is_retryable()
         && let Some(backoff) = backoffs.next()
     {
@@ -201,8 +442,7 @@ async fn can_retry(err: &ReadSessionError, backoffs: &mut RetryBackoff) -> bool 
             num_retries_remaining = backoffs.remaining(),
             "retrying read session"
         );
-        tokio::time::sleep(backoff).await;
-        true
+        Some(backoff)
     } else {
         debug!(
             %err,
@@ -210,6 +450,199 @@ async fn can_retry(err: &ReadSessionError, backoffs: &mut RetryBackoff) -> bool 
             retries_exhausted = backoffs.is_exhausted(),
             "not retrying read session"
         );
-        false
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use futures_util::{StreamExt, poll, stream};
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::UnboundedReceiverStream;
+
+    use super::*;
+    use crate::types::{Header, SequencedRecord};
+
+    fn position(seq_num: u64) -> StreamPosition {
+        StreamPosition {
+            seq_num,
+            timestamp: seq_num,
+        }
+    }
+
+    fn record(seq_num: u64, command: bool) -> SequencedRecord {
+        SequencedRecord {
+            seq_num,
+            timestamp: seq_num,
+            body: Bytes::new(),
+            headers: if command {
+                vec![Header::new("", "fence")]
+            } else {
+                Vec::new()
+            },
+        }
+    }
+
+    fn batch(records: Vec<SequencedRecord>, tail: Option<StreamPosition>) -> ReadBatch {
+        ReadBatch { records, tail }
+    }
+
+    fn test_session(
+        updates: impl futures_core::Stream<Item = Result<ReadUpdate, ReadSessionError>> + Send + 'static,
+    ) -> ReadSession {
+        ReadSession::new(Box::pin(updates))
+    }
+
+    #[tokio::test]
+    async fn caught_up_follows_delivery_and_pins_tail() {
+        let tail = position(2);
+        let mut session = test_session(stream::iter([
+            Ok(ReadUpdate::from_batch(
+                batch(vec![record(0, false), record(1, false)], Some(tail)),
+                false,
+            )),
+            Ok(ReadUpdate::from_batch(
+                batch(vec![record(2, false)], Some(position(5))),
+                false,
+            )),
+        ]));
+        let caught_up = session.caught_up();
+        let mut pending = Box::pin(caught_up.clone());
+
+        assert!(poll!(pending.as_mut()).is_pending());
+        assert!(!session.is_caught_up());
+
+        let first = session.next().await.unwrap().unwrap();
+        assert_eq!(first.records.len(), 2);
+        assert!(session.is_caught_up());
+        let caught_up_while_caught = session.caught_up();
+
+        session.next().await.unwrap().unwrap();
+        assert!(!session.is_caught_up());
+        assert_eq!(caught_up.await.unwrap(), tail);
+        assert_eq!(caught_up_while_caught.await.unwrap(), tail);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_waits_for_visible_batch() {
+        let tail = position(2);
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut session = test_session(UnboundedReceiverStream::new(rx));
+        let caught_up = session.caught_up();
+
+        tx.send(Ok(ReadUpdate::from_batch(
+            batch(vec![record(0, false), record(1, false)], None),
+            false,
+        )))
+        .unwrap();
+        tx.send(Ok(ReadUpdate::from_batch(
+            batch(Vec::new(), Some(tail)),
+            false,
+        )))
+        .unwrap();
+
+        assert_eq!(session.next().await.unwrap().unwrap().records.len(), 2);
+        assert!(!session.is_caught_up());
+
+        let mut next = Box::pin(session.next());
+        assert!(poll!(next.as_mut()).is_pending());
+        drop(next);
+        assert!(session.is_caught_up());
+        assert_eq!(caught_up.await.unwrap(), tail);
+    }
+
+    #[tokio::test]
+    async fn filtered_command_counts_toward_caught_up() {
+        let tail = position(2);
+        let mut session = test_session(stream::iter([
+            Ok(ReadUpdate::from_batch(
+                batch(vec![record(0, false)], None),
+                true,
+            )),
+            Ok(ReadUpdate::from_batch(
+                batch(vec![record(1, true)], Some(tail)),
+                true,
+            )),
+        ]));
+        let caught_up = session.caught_up();
+
+        let delivered = session.next().await.unwrap().unwrap();
+        assert_eq!(delivered.records.len(), 1);
+        assert_eq!(delivered.records[0].seq_num, 0);
+        assert!(!session.is_caught_up());
+
+        assert!(session.next().await.is_none());
+        assert!(session.is_caught_up());
+        assert_eq!(caught_up.await.unwrap(), tail);
+    }
+
+    #[tokio::test]
+    async fn caught_up_wait_survives_retry() {
+        let first_tail = position(1);
+        let tail = position(3);
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut session = test_session(UnboundedReceiverStream::new(rx));
+
+        tx.send(Ok(ReadUpdate::from_batch(
+            batch(Vec::new(), Some(first_tail)),
+            false,
+        )))
+        .unwrap();
+        let mut next = Box::pin(session.next());
+        assert!(poll!(next.as_mut()).is_pending());
+        drop(next);
+        assert!(session.is_caught_up());
+
+        tx.send(Ok(ReadUpdate::behind())).unwrap();
+        let mut next = Box::pin(session.next());
+        assert!(poll!(next.as_mut()).is_pending());
+        drop(next);
+        assert!(!session.is_caught_up());
+        let caught_up = session.caught_up();
+
+        tx.send(Ok(ReadUpdate::behind())).unwrap();
+        tx.send(Ok(ReadUpdate::from_batch(
+            batch(Vec::new(), Some(tail)),
+            false,
+        )))
+        .unwrap();
+        drop(tx);
+        assert!(session.next().await.is_none());
+        assert_eq!(caught_up.await.unwrap(), tail);
+    }
+
+    #[tokio::test]
+    async fn clean_end_rejects_wait() {
+        let mut session = test_session(stream::empty());
+        let caught_up = session.caught_up();
+
+        assert!(session.next().await.is_none());
+        assert!(session.next().await.is_none());
+        assert!(matches!(caught_up.await, Err(CaughtUpError::SessionClosed)));
+    }
+
+    #[tokio::test]
+    async fn read_error_rejects_wait() {
+        let mut session = test_session(stream::iter([Err(ReadSessionError::HeartbeatTimeout)]));
+        let caught_up = session.caught_up();
+
+        let error = session.next().await.unwrap().unwrap_err();
+        assert_eq!(error.to_string(), "heartbeat timeout");
+        assert!(matches!(
+            caught_up.await,
+            Err(CaughtUpError::Read(S2Error::Client(message)))
+                if message == "heartbeat timeout"
+        ));
+    }
+
+    #[tokio::test]
+    async fn dropping_session_rejects_wait() {
+        let caught_up = {
+            let session = test_session(stream::pending());
+            session.caught_up()
+        };
+
+        assert!(matches!(caught_up.await, Err(CaughtUpError::SessionClosed)));
     }
 }

--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -78,20 +78,17 @@ impl From<CaughtUpError> for S2Error {
 type CaughtUpResult = Result<StreamPosition, CaughtUpError>;
 type SharedCaughtUp = Shared<BoxFuture<'static, CaughtUpResult>>;
 
-pin_project_lite::pin_project! {
-    /// A future that returns the next caught-up tail.
-    #[derive(Clone)]
-    pub struct CaughtUp {
-        #[pin]
-        inner: SharedCaughtUp,
-    }
+/// A future that returns the next caught-up tail.
+#[derive(Clone)]
+pub struct CaughtUp {
+    inner: SharedCaughtUp,
 }
 
 impl Future for CaughtUp {
     type Output = CaughtUpResult;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.project().inner.poll(cx)
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.inner).poll(cx)
     }
 }
 
@@ -207,7 +204,6 @@ impl ReadUpdate {
 pub struct ReadSession {
     updates: Streaming<ReadUpdate>,
     state: CaughtUpState,
-    terminated: bool,
 }
 
 impl ReadSession {
@@ -215,7 +211,6 @@ impl ReadSession {
         Self {
             updates,
             state: CaughtUpState::new(),
-            terminated: false,
         }
     }
 
@@ -242,34 +237,25 @@ impl futures_core::Stream for ReadSession {
     type Item = Result<ReadBatch, S2Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if self.terminated {
-            return Poll::Ready(None);
-        }
-
         loop {
             match self.updates.as_mut().poll_next(cx) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Some(Ok(update))) => {
                     self.state.set_behind();
-                    if let Some(batch) = update.batch {
-                        if let Some(tail) = update.caught_up_tail {
-                            self.state.set_caught_up(tail);
-                        }
-                        return Poll::Ready(Some(Ok(batch)));
-                    }
                     if let Some(tail) = update.caught_up_tail {
                         self.state.set_caught_up(tail);
+                    }
+                    if let Some(batch) = update.batch {
+                        return Poll::Ready(Some(Ok(batch)));
                     }
                 }
                 Poll::Ready(Some(Err(error))) => {
                     let error = S2Error::from(error);
                     self.state.end(Some(error.clone()));
-                    self.terminated = true;
                     return Poll::Ready(Some(Err(error)));
                 }
                 Poll::Ready(None) => {
                     self.state.end(None);
-                    self.terminated = true;
                     return Poll::Ready(None);
                 }
             }
@@ -617,7 +603,6 @@ mod tests {
         let mut session = test_session(stream::empty());
         let caught_up = session.caught_up();
 
-        assert!(session.next().await.is_none());
         assert!(session.next().await.is_none());
         assert!(matches!(caught_up.await, Err(CaughtUpError::SessionClosed)));
     }

--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -111,7 +111,7 @@ struct CaughtUpState {
 
 impl CaughtUpState {
     fn new() -> Self {
-        let (tx, future) = pending_caught_up();
+        let (tx, future) = pending_catch_up();
         Self {
             tail: None,
             terminal: false,
@@ -132,7 +132,7 @@ impl CaughtUpState {
         if self.terminal || self.tail.take().is_none() {
             return;
         }
-        let (tx, future) = pending_caught_up();
+        let (tx, future) = pending_catch_up();
         self.tx = Some(tx);
         self.future = future;
     }
@@ -167,7 +167,7 @@ impl CaughtUpState {
     }
 }
 
-fn pending_caught_up() -> (oneshot::Sender<CaughtUpResult>, CaughtUpFuture) {
+fn pending_catch_up() -> (oneshot::Sender<CaughtUpResult>, CaughtUpFuture) {
     let (tx, rx) = oneshot::channel();
     (tx, CaughtUpFuture::Pending(rx.shared()))
 }

--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -8,7 +8,7 @@ use std::{
 use async_stream::{stream, try_stream};
 use futures_util::{
     StreamExt,
-    future::{BoxFuture, FutureExt, Shared, ready},
+    future::{FutureExt, Shared},
 };
 use s2_api::v1::stream::{ReadEnd, ReadStart};
 use tokio::{
@@ -76,19 +76,25 @@ impl From<CaughtUpError> for S2Error {
 }
 
 type CaughtUpResult = Result<StreamPosition, CaughtUpError>;
-type CaughtUpFuture = Shared<BoxFuture<'static, CaughtUpResult>>;
 
-/// A future that returns the current or next caught-up tail.
 #[derive(Clone)]
-pub struct CaughtUp {
-    inner: CaughtUpFuture,
+enum CaughtUpFuture {
+    Pending(Shared<oneshot::Receiver<CaughtUpResult>>),
+    Ready(CaughtUpResult),
 }
 
-impl Future for CaughtUp {
+impl Future for CaughtUpFuture {
     type Output = CaughtUpResult;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Pin::new(&mut self.inner).poll(cx)
+        match &mut *self {
+            Self::Pending(future) => match Pin::new(future).poll(cx) {
+                Poll::Ready(Ok(result)) => Poll::Ready(result),
+                Poll::Ready(Err(_)) => Poll::Ready(Err(CaughtUpError::SessionClosed)),
+                Poll::Pending => Poll::Pending,
+            },
+            Self::Ready(result) => Poll::Ready(result.clone()),
+        }
     }
 }
 
@@ -97,7 +103,7 @@ struct CaughtUpState {
     tail: Option<StreamPosition>,
     /// Once set, the session has ended.
     terminal: bool,
-    /// Fires the current `CaughtUp` future.
+    /// Fires the current caught-up future.
     tx: Option<oneshot::Sender<CaughtUpResult>>,
     /// The future handed out by `caught_up()`.
     future: CaughtUpFuture,
@@ -118,10 +124,8 @@ impl CaughtUpState {
         self.tail.is_some()
     }
 
-    fn future(&self) -> CaughtUp {
-        CaughtUp {
-            inner: self.future.clone(),
-        }
+    fn future(&self) -> CaughtUpFuture {
+        self.future.clone()
     }
 
     fn set_behind(&mut self) {
@@ -134,7 +138,7 @@ impl CaughtUpState {
     }
 
     fn set_caught_up(&mut self, tail: StreamPosition) {
-        if self.terminal {
+        if self.terminal || self.tail == Some(tail) {
             return;
         }
         self.tail = Some(tail);
@@ -158,17 +162,14 @@ impl CaughtUpState {
         if let Some(tx) = self.tx.take() {
             let _ = tx.send(result);
         } else {
-            self.future = ready(result).boxed().shared();
+            self.future = CaughtUpFuture::Ready(result);
         }
     }
 }
 
 fn pending_caught_up() -> (oneshot::Sender<CaughtUpResult>, CaughtUpFuture) {
     let (tx, rx) = oneshot::channel();
-    let future = async move { rx.await.unwrap_or(Err(CaughtUpError::SessionClosed)) }
-        .boxed()
-        .shared();
-    (tx, future)
+    (tx, CaughtUpFuture::Pending(rx.shared()))
 }
 
 struct ReadUpdate {
@@ -233,7 +234,14 @@ impl ReadSession {
     /// Once resolved, it keeps that tail if the session later falls behind.
     /// Keep reading batches while waiting. Call again after falling behind. Returns
     /// [`CaughtUpError`] if the read fails or ends first.
-    pub fn caught_up(&self) -> CaughtUp {
+    pub fn caught_up(
+        &self,
+    ) -> impl Future<Output = Result<StreamPosition, CaughtUpError>>
+    + Clone
+    + Send
+    + Sync
+    + Unpin
+    + 'static {
         self.state.future()
     }
 }
@@ -246,9 +254,10 @@ impl futures_core::Stream for ReadSession {
             match self.updates.as_mut().poll_next(cx) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Some(Ok(update))) => {
-                    self.state.set_behind();
                     if let Some(tail) = update.caught_up_tail {
                         self.state.set_caught_up(tail);
+                    } else {
+                        self.state.set_behind();
                     }
                     if let Some(batch) = update.batch {
                         return Poll::Ready(Some(Ok(batch)));
@@ -541,6 +550,38 @@ mod tests {
         drop(next);
         assert!(session.is_caught_up());
         assert_eq!(caught_up.await.unwrap(), tail);
+    }
+
+    #[tokio::test]
+    async fn unchanged_heartbeat_reuses_caught_up_future() {
+        let tail = position(1);
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut session = test_session(UnboundedReceiverStream::new(rx));
+
+        tx.send(Ok(ReadUpdate::from_batch(
+            batch(vec![record(0, false)], Some(tail)),
+            false,
+        )))
+        .unwrap();
+        session.next().await.unwrap().unwrap();
+        let caught_up = session.state.future();
+
+        tx.send(Ok(ReadUpdate::from_batch(
+            batch(Vec::new(), Some(tail)),
+            false,
+        )))
+        .unwrap();
+        let mut next = Box::pin(session.next());
+        assert!(poll!(next.as_mut()).is_pending());
+        drop(next);
+
+        let CaughtUpFuture::Pending(caught_up) = caught_up else {
+            panic!("initial caught-up future should use the pending epoch");
+        };
+        let CaughtUpFuture::Pending(current) = session.state.future() else {
+            panic!("unchanged heartbeat should preserve the pending epoch");
+        };
+        assert!(caught_up.ptr_eq(&current));
     }
 
     #[tokio::test]

--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -234,6 +234,37 @@ impl ReadSession {
     /// Once resolved, it keeps that tail if the session later falls behind.
     /// Keep reading batches while waiting. Call again after falling behind. Returns
     /// [`CaughtUpError`] if the read fails or ends first.
+    ///
+    /// # Example
+    ///
+    /// Drive the session stream while waiting for the caught-up signal:
+    ///
+    /// ```rust
+    /// use futures_util::StreamExt;
+    /// use s2_sdk::read_session::{CaughtUpError, ReadSession};
+    ///
+    /// # async fn consume(mut session: ReadSession) -> Result<(), CaughtUpError> {
+    /// let mut caught_up = session.caught_up();
+    /// loop {
+    ///     tokio::select! {
+    ///         tail = &mut caught_up => {
+    ///             println!("Caught up through {}", tail?);
+    ///             break;
+    ///         }
+    ///         Some(batch) = session.next() => {
+    ///             let batch = batch?;
+    ///             println!("Read {} records", batch.records.len());
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// while let Some(batch) = session.next().await {
+    ///     let batch = batch?;
+    ///     println!("Read {} records", batch.records.len());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn caught_up(
         &self,
     ) -> impl Future<Output = Result<StreamPosition, CaughtUpError>>

--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -78,7 +78,7 @@ impl From<CaughtUpError> for S2Error {
 type CaughtUpResult = Result<StreamPosition, CaughtUpError>;
 type CaughtUpFuture = Shared<BoxFuture<'static, CaughtUpResult>>;
 
-/// A future that returns the next caught-up tail.
+/// A future that returns the current or next caught-up tail.
 #[derive(Clone)]
 pub struct CaughtUp {
     inner: CaughtUpFuture,
@@ -227,9 +227,10 @@ impl ReadSession {
         self.state.is_caught_up()
     }
 
-    /// Return a future for the next caught-up tail.
+    /// Return a future for the current or next caught-up tail.
     ///
     /// It is ready immediately when already caught up and remains pending across retries.
+    /// Once resolved, it keeps that tail if the session later falls behind.
     /// Keep reading batches while waiting. Call again after falling behind. Returns
     /// [`CaughtUpError`] if the read fails or ends first.
     pub fn caught_up(&self) -> CaughtUp {
@@ -620,6 +621,31 @@ mod tests {
         assert_eq!(error.to_string(), "heartbeat timeout");
         assert!(matches!(
             caught_up.await,
+            Err(CaughtUpError::Read(S2Error::Client(message)))
+                if message == "heartbeat timeout"
+        ));
+    }
+
+    #[tokio::test]
+    async fn read_error_after_caught_up_preserves_resolved_future() {
+        let tail = position(1);
+        let mut session = test_session(stream::iter([
+            Ok(ReadUpdate::from_batch(
+                batch(vec![record(0, false)], Some(tail)),
+                false,
+            )),
+            Err(ReadSessionError::HeartbeatTimeout),
+        ]));
+
+        session.next().await.unwrap().unwrap();
+        assert!(session.is_caught_up());
+        let caught_up = session.caught_up();
+
+        session.next().await.unwrap().unwrap_err();
+        assert!(!session.is_caught_up());
+        assert_eq!(caught_up.await.unwrap(), tail);
+        assert!(matches!(
+            session.caught_up().await,
             Err(CaughtUpError::Read(S2Error::Client(message)))
                 if message == "heartbeat timeout"
         ));

--- a/sdk/tests/stream_ops.rs
+++ b/sdk/tests/stream_ops.rs
@@ -778,23 +778,25 @@ async fn read_session_reports_caught_up_after_tail_delivery(
             ReadInput::new().with_start(ReadStart::new().with_from(ReadFrom::TailOffset(2))),
         )
         .await?;
-    let caught_up = session.caught_up();
+    let mut caught_up = session.caught_up();
     let mut seq_nums = Vec::new();
 
     assert!(!session.is_caught_up());
     let caught_up_tail = tokio::time::timeout(Duration::from_secs(30), async {
-        while !session.is_caught_up() {
-            let batch = session
-                .next()
-                .await
-                .expect("session should reach the tail")?;
-            seq_nums.extend(batch.records.into_iter().map(|record| record.seq_num));
+        loop {
+            tokio::select! {
+                tail = &mut caught_up => break tail.map_err(S2Error::from),
+                batch = session.next() => {
+                    let batch = batch.expect("session should reach the tail")?;
+                    seq_nums.extend(batch.records.into_iter().map(|record| record.seq_num));
+                }
+            }
         }
-        caught_up.await.map_err(S2Error::from)
     })
     .await
     .expect("session should reach the tail within 30 seconds")?;
 
+    assert!(session.is_caught_up());
     assert_eq!(seq_nums, [ack.tail.seq_num - 2, ack.tail.seq_num - 1]);
     assert_eq!(caught_up_tail, ack.tail);
 

--- a/sdk/tests/stream_ops.rs
+++ b/sdk/tests/stream_ops.rs
@@ -800,6 +800,27 @@ async fn read_session_reports_caught_up_after_tail_delivery(
     assert_eq!(seq_nums, [ack.tail.seq_num - 2, ack.tail.seq_num - 1]);
     assert_eq!(caught_up_tail, ack.tail);
 
+    let next_ack = stream
+        .append(AppendInput::new(AppendRecordBatch::try_from_iter([
+            AppendRecord::new("third")?,
+        ])?))
+        .await?;
+    let next_batch = tokio::time::timeout(Duration::from_secs(30), session.next())
+        .await
+        .expect("session should keep reading after catching up")
+        .expect("session should remain open")?;
+
+    assert_eq!(
+        next_batch
+            .records
+            .iter()
+            .map(|record| record.seq_num)
+            .collect::<Vec<_>>(),
+        [ack.tail.seq_num]
+    );
+    assert!(session.is_caught_up());
+    assert_eq!(next_batch.tail, Some(next_ack.tail));
+
     Ok(())
 }
 

--- a/sdk/tests/stream_ops.rs
+++ b/sdk/tests/stream_ops.rs
@@ -764,6 +764,45 @@ async fn read_session_beyond_tail_with_clamp_to_tail(stream: &S2Stream) -> Resul
 
 #[test_context(S2Stream)]
 #[tokio_shared_rt::test(shared)]
+async fn read_session_reports_caught_up_after_tail_delivery(
+    stream: &S2Stream,
+) -> Result<(), S2Error> {
+    let ack = stream
+        .append(AppendInput::new(AppendRecordBatch::try_from_iter([
+            AppendRecord::new("first")?,
+            AppendRecord::new("second")?,
+        ])?))
+        .await?;
+    let mut session = stream
+        .read_session(
+            ReadInput::new().with_start(ReadStart::new().with_from(ReadFrom::TailOffset(2))),
+        )
+        .await?;
+    let caught_up = session.caught_up();
+    let mut seq_nums = Vec::new();
+
+    assert!(!session.is_caught_up());
+    let caught_up_tail = tokio::time::timeout(Duration::from_secs(30), async {
+        while !session.is_caught_up() {
+            let batch = session
+                .next()
+                .await
+                .expect("session should reach the tail")?;
+            seq_nums.extend(batch.records.into_iter().map(|record| record.seq_num));
+        }
+        caught_up.await.map_err(S2Error::from)
+    })
+    .await
+    .expect("session should reach the tail within 30 seconds")?;
+
+    assert_eq!(seq_nums, [ack.tail.seq_num - 2, ack.tail.seq_num - 1]);
+    assert_eq!(caught_up_tail, ack.tail);
+
+    Ok(())
+}
+
+#[test_context(S2Stream)]
+#[tokio_shared_rt::test(shared)]
 async fn append_with_empty_header_value(stream: &S2Stream) -> Result<(), S2Error> {
     let input = AppendInput::new(AppendRecordBatch::try_from_iter([AppendRecord::new(
         "lorem",

--- a/sim/Cargo.lock
+++ b/sim/Cargo.lock
@@ -3840,7 +3840,7 @@ dependencies = [
 [[package]]
 name = "s2-verification"
 version = "0.4.0"
-source = "git+https://github.com/s2-streamstore/s2-verification?rev=050063e2573e2769c60ed24f71767db1c289e745#050063e2573e2769c60ed24f71767db1c289e745"
+source = "git+https://github.com/s2-streamstore/s2-verification?rev=113770a40f96cba9c5bfd4eb1f1a46989c813283#113770a40f96cba9c5bfd4eb1f1a46989c813283"
 dependencies = [
  "antithesis_sdk",
  "clap",

--- a/sim/Cargo.lock
+++ b/sim/Cargo.lock
@@ -133,7 +133,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1439,7 +1439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2697,7 +2697,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3562,7 +3562,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3620,7 +3620,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3655,7 +3655,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s2-api"
-version = "0.30.6"
+version = "0.30.9"
 dependencies = [
  "axum",
  "base64ct",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "s2-common"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "axum",
  "base64ct",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "s2-lite"
-version = "0.38.0"
+version = "0.39.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "s2-resource-spec"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "humantime",
  "s2-common",
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "s2-sdk"
-version = "0.31.8"
+version = "0.31.10"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "s2-storage"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "aegis",
  "aes-gcm",
@@ -3840,7 +3840,7 @@ dependencies = [
 [[package]]
 name = "s2-verification"
 version = "0.4.0"
-source = "git+https://github.com/s2-streamstore/s2-verification?rev=394929f199480fd3a2d49ec1992779a9772e77fe#394929f199480fd3a2d49ec1992779a9772e77fe"
+source = "git+https://github.com/s2-streamstore/s2-verification?rev=050063e2573e2769c60ed24f71767db1c289e745#050063e2573e2769c60ed24f71767db1c289e745"
 dependencies = [
  "antithesis_sdk",
  "clap",
@@ -4303,7 +4303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5152,7 +5152,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -45,7 +45,7 @@ s2-lite = { path = "../lite" }
 s2-sdk = { path = "../sdk", features = ["_hidden"] }
 # The Go checker built in CI must be pinned to the same rev (see the
 # S2_VERIFICATION_REV env in .github/workflows/ci.yml).
-s2-verification = { git = "https://github.com/s2-streamstore/s2-verification", rev = "394929f199480fd3a2d49ec1992779a9772e77fe" }
+s2-verification = { git = "https://github.com/s2-streamstore/s2-verification", rev = "050063e2573e2769c60ed24f71767db1c289e745" }
 s3s = "0.14.1"
 serde_json = "1.0"
 slatedb = { version = "0.14.1", features = ["lz4", "zstd"] }

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -45,7 +45,7 @@ s2-lite = { path = "../lite" }
 s2-sdk = { path = "../sdk", features = ["_hidden"] }
 # The Go checker built in CI must be pinned to the same rev (see the
 # S2_VERIFICATION_REV env in .github/workflows/ci.yml).
-s2-verification = { git = "https://github.com/s2-streamstore/s2-verification", rev = "050063e2573e2769c60ed24f71767db1c289e745" }
+s2-verification = { git = "https://github.com/s2-streamstore/s2-verification", rev = "113770a40f96cba9c5bfd4eb1f1a46989c813283" }
 s3s = "0.14.1"
 serde_json = "1.0"
 slatedb = { version = "0.14.1", features = ["lz4", "zstd"] }


### PR DESCRIPTION
## Summary

- expose caught-up state and an awaitable tail on Rust read sessions
- update the signal when the matching batch is delivered, including heartbeats, filtered commands, and retries
- preserve the CLI stream interface and add focused unit and live correctness coverage

## Validation

- `cargo +stable nextest run --workspace --all-features --exclude s2-testcontainers -E 'not ((package(s2-cli) & binary(integration)) or (package(s2-sdk) & (binary(account_ops) or binary(basin_ops) or binary(metrics_ops) or binary(stream_ops))))'` (673 passed)
- `cargo +stable clippy --workspace --all-features --all-targets --exclude s2-testcontainers -- -D warnings --allow deprecated`
- `RUSTDOCFLAGS='-D warnings' cargo +stable doc -p s2-sdk --all-features --no-deps`
- `just fmt`