### PR TITLE
fix(lite): fsync local object store writes

### DIFF
--- a/lite/src/server.rs
+++ b/lite/src/server.rs
@@ -342,9 +342,11 @@ async fn init_object_store(
                 root = %local_root.display(),
                 "using local filesystem object store"
             );
-            Arc::new(object_store::local::LocalFileSystem::new_with_prefix(
-                local_root,
-            )?)
+            Arc::new(
+                // Match the durability contract of remote object stores: an
+                // acknowledged SlateDB write must survive a host crash.
+                object_store::local::LocalFileSystem::new_with_prefix(local_root)?.with_fsync(true),
+            )
         }
         StoreType::InMemory => {
             info!("using in-memory object store");


### PR DESCRIPTION
## What changed

Enable `LocalFileSystem::with_fsync(true)` for `s2-lite --local-root` so a successful SlateDB put includes durable file contents and directory publication.

## Why

A Fly rehearsal stopped a filesystem-backed Lite Machine after acknowledged appends. Reopening the clean ext4 volume failed permanently because one 484-byte WAL SST was entirely zero-filled and decoded with SST format version 0. The local object-store adapter defaults fsync off, so its successful put did not provide the durable-object contract SlateDB expects.

This makes filesystem-backed Lite acknowledgements comparable to durable remote-object-store acknowledgements rather than page-cache acknowledgements.

Closes #669.

## Validation

- `just fmt`
- `cargo test -p s2-lite` — 228 tests passed
- all GitHub CI checks passed, including s2-lite, SDK integration, simulation, and testcontainers
- an exact source image from commit `a26806e5` survived repeated abrupt Fly Machine stops and reopened the same ext4 volume without an invalid-SST diagnostic
- a Komputer journal-outage canary withheld its post-timer output while Lite was down, then completed with each output boundary exactly once after recovery
- 2,000 serial 128-byte appends after 50 warmups at `SL8_FLUSH_INTERVAL=5ms` measured p50 12.29 ms, p95 17.67 ms, p99 18.23 ms, and mean 13.19 ms in `sjc`

The latency sample crosses two Fly Machines and includes the batching cadence, filesystem work, and fsync. It is deployment evidence, not an S2 service SLO.
