### PR TITLE
fix: update s2-verification revision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
       RUSTFLAGS: --cfg tokio_unstable
       # The Go linearizability checker must be built from the same rev as the
       # s2-verification dependency pinned in sim/Cargo.toml.
-      S2_VERIFICATION_REV: c7d0487b3d5482450653944cc5b7cca8aaa94ed5
+      S2_VERIFICATION_REV: 6616b1de63923d9d2db32718e81b2dd8aba717bc
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/sim/Cargo.lock
+++ b/sim/Cargo.lock
@@ -3839,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "s2-verification"
 version = "0.4.0"
-source = "git+https://github.com/s2-streamstore/s2-verification?rev=c7d0487b3d5482450653944cc5b7cca8aaa94ed5#c7d0487b3d5482450653944cc5b7cca8aaa94ed5"
+source = "git+https://github.com/s2-streamstore/s2-verification?rev=6616b1de63923d9d2db32718e81b2dd8aba717bc#6616b1de63923d9d2db32718e81b2dd8aba717bc"
 dependencies = [
  "antithesis_sdk",
  "clap",

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -45,7 +45,7 @@ s2-lite = { path = "../lite" }
 s2-sdk = { path = "../sdk", features = ["_hidden"] }
 # The Go checker built in CI must be pinned to the same rev (see the
 # S2_VERIFICATION_REV env in .github/workflows/ci.yml).
-s2-verification = { git = "https://github.com/s2-streamstore/s2-verification", rev = "c7d0487b3d5482450653944cc5b7cca8aaa94ed5" }
+s2-verification = { git = "https://github.com/s2-streamstore/s2-verification", rev = "6616b1de63923d9d2db32718e81b2dd8aba717bc" }
 s3s = "0.14.1"
 serde_json = "1.0"
 slatedb = { version = "0.15.0", features = ["lz4", "zstd"] }


### PR DESCRIPTION
## Summary
- pin the simulator's Rust `s2-verification` dependency to `6616b1d`
- pin the Go Porcupine checker to the same revision
- refresh only the matching `sim/Cargo.lock` source entry

## Why

The SDK changes in #653 and #658 broke the pinned verification crate in two ways: the `S2Error` umbrella was replaced with surface-specific errors, and `S2Stream::read_session` now requires `ReadSessionConfig`. This caused the simulator Clippy and Simulation Tests jobs to fail on `main` and the release PR.

The new revision is the head of s2-streamstore/s2-verification#39, which temporarily builds against the exact unreleased SDK commit and handles both APIs. Once the SDK is released and verification is updated to use the published version, this repo should be repinned to the final verification commit.

## Testing
- `just fmt`
- `just sim-clippy`
- `RUSTFLAGS="--cfg tokio_unstable" cargo build --manifest-path sim/Cargo.toml --profile sim`
- `just test` (714 tests passed)