### PR TITLE
chore(deps): finalize s2-verification revision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
       RUSTFLAGS: --cfg tokio_unstable
       # The Go linearizability checker must be built from the same rev as the
       # s2-verification dependency pinned in sim/Cargo.toml.
-      S2_VERIFICATION_REV: 6616b1de63923d9d2db32718e81b2dd8aba717bc
+      S2_VERIFICATION_REV: b4af8c8ef4965d9b335101c422eadb33f3169004
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/sim/Cargo.lock
+++ b/sim/Cargo.lock
@@ -133,7 +133,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -909,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "bytesize"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
+checksum = "351a3e803ee3c6eaeee6b00076b767514b37c32a73d326c3ec7abddb7d6c3493"
 
 [[package]]
 name = "bytestring"
@@ -1438,7 +1438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2696,7 +2696,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3561,7 +3561,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3619,7 +3619,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3654,7 +3654,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s2-api"
-version = "0.30.10"
+version = "0.31.0"
 dependencies = [
  "axum",
  "base64ct",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "s2-lite"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "s2-sdk"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -3839,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "s2-verification"
 version = "0.4.0"
-source = "git+https://github.com/s2-streamstore/s2-verification?rev=6616b1de63923d9d2db32718e81b2dd8aba717bc#6616b1de63923d9d2db32718e81b2dd8aba717bc"
+source = "git+https://github.com/s2-streamstore/s2-verification?rev=b4af8c8ef4965d9b335101c422eadb33f3169004#b4af8c8ef4965d9b335101c422eadb33f3169004"
 dependencies = [
  "antithesis_sdk",
  "clap",
@@ -4302,7 +4302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5151,7 +5151,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -45,7 +45,7 @@ s2-lite = { path = "../lite" }
 s2-sdk = { path = "../sdk", features = ["_hidden"] }
 # The Go checker built in CI must be pinned to the same rev (see the
 # S2_VERIFICATION_REV env in .github/workflows/ci.yml).
-s2-verification = { git = "https://github.com/s2-streamstore/s2-verification", rev = "6616b1de63923d9d2db32718e81b2dd8aba717bc" }
+s2-verification = { git = "https://github.com/s2-streamstore/s2-verification", rev = "b4af8c8ef4965d9b335101c422eadb33f3169004" }
 s3s = "0.14.1"
 serde_json = "1.0"
 slatedb = { version = "0.15.0", features = ["lz4", "zstd"] }


### PR DESCRIPTION
## Summary

- repin the simulator's Rust `s2-verification` dependency from `6616b1d` to final commit `b4af8c8`
- repin the Go Porcupine checker to the same revision
- refresh the simulator lockfile after the SDK 0.34 release

Depends on s2-streamstore/s2-verification#39.

## Changelog notes

- `s2-verification 6616b1d -> b4af8c8`: removes the temporary SDK git patch, raises the supported SDK floor to 0.34, and resolves `s2-sdk 0.34.0`, `s2-api 0.31.0`, and `s2-common 0.41.1` from crates.io. Source: [verification PR #39](https://github.com/s2-streamstore/s2-verification/pull/39).
- Local simulator package metadata now reflects the released workspace versions: `s2-api 0.31.0`, `s2-lite 0.42.0`, and `s2-sdk 0.34.0`. Source: [release PR #672](https://github.com/s2-streamstore/s2/pull/672).
- `bytesize 2.4.0 -> 2.6.0` (lockfile-only): includes parsing/rounding fixes, no-allocation support, and IEC/SI bit display styles; MSRV remains 1.85. Source: [upstream changelog](https://github.com/bytesize-rs/bytesize/blob/bytesize-v2.6.0/CHANGELOG.md).

## Risk notes

- The simulator continues patching verification's SDK dependency to the local `sdk` crate, now version 0.34.0, so SDK types remain unified across the simulation workspace.
- Lockfile re-resolution consolidates several Windows-only `windows-sys` edges onto 0.61.2; there are no source changes associated with that movement.
- The Rust and Go verification consumers remain pinned to the exact same commit.

## Validation

- `cargo metadata --locked --manifest-path sim/Cargo.toml --format-version 1`: passed
- `just fmt`: passed
- `just sim-clippy`: passed
- `RUSTFLAGS="--cfg tokio_unstable" cargo build --manifest-path sim/Cargo.toml --profile sim`: passed
- `just test`: 714 tests passed