### PR TITLE
feat(sdk): expose read session resume sequence number

### DIFF
--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -216,7 +216,7 @@ fn pending_catch_up() -> (oneshot::Sender<CaughtUpResult>, CaughtUpFuture) {
 struct ReadUpdate {
     batch: Option<ReadBatch>,
     caught_up_tail: Option<StreamPosition>,
-    resume_point: Option<u64>,
+    resume_seq_num: Option<u64>,
 }
 
 impl ReadUpdate {
@@ -224,12 +224,12 @@ impl ReadUpdate {
         Self {
             batch: None,
             caught_up_tail: None,
-            resume_point: None,
+            resume_seq_num: None,
         }
     }
 
     fn from_batch(mut batch: ReadBatch, ignore_command_records: bool) -> Self {
-        let resume_point = resume_point_after_batch(&batch);
+        let resume_seq_num = resume_seq_num_after_batch(&batch);
         let caught_up_tail = batch.tail.filter(|tail| {
             batch.records.is_empty()
                 || batch
@@ -245,7 +245,7 @@ impl ReadUpdate {
         Self {
             batch: (!batch.records.is_empty()).then_some(batch),
             caught_up_tail,
-            resume_point,
+            resume_seq_num,
         }
     }
 }
@@ -254,27 +254,27 @@ impl ReadUpdate {
 pub struct ReadSession {
     updates: InternalStreaming<ReadUpdate>,
     state: CaughtUpState,
-    resume_point: Option<u64>,
+    resume_seq_num: Option<u64>,
 }
 
 impl ReadSession {
-    fn new(updates: InternalStreaming<ReadUpdate>, resume_point: Option<u64>) -> Self {
+    fn new(updates: InternalStreaming<ReadUpdate>, resume_seq_num: Option<u64>) -> Self {
         Self {
             updates,
             state: CaughtUpState::new(),
-            resume_point,
+            resume_seq_num,
         }
     }
 
     /// Return the absolute sequence number from which the session would resume after a retry.
     ///
-    /// An unclamped absolute starting point is available immediately. A timestamp,
-    /// tail-relative, or clamped starting point returns `None` until the session receives a
-    /// record or a reported tail. The returned point is the sequence number of the next record
-    /// the session expects. It advances as the session is polled, including across records hidden
-    /// by [`ReadInput::ignore_command_records`](crate::types::ReadInput::ignore_command_records).
-    pub fn resume_point(&self) -> Option<u64> {
-        self.resume_point
+    /// An unclamped absolute starting sequence number is available immediately. A timestamp,
+    /// tail-relative, or clamped start returns `None` until the session receives a record or a
+    /// reported tail. The returned value is the sequence number of the next record the session
+    /// expects. It advances as the session is polled, including across records hidden by
+    /// [`ReadInput::ignore_command_records`](crate::types::ReadInput::ignore_command_records).
+    pub fn resume_seq_num(&self) -> Option<u64> {
+        self.resume_seq_num
     }
 
     /// Return whether all records through the latest reported tail were delivered.
@@ -313,8 +313,8 @@ impl futures_core::Stream for ReadSession {
             match self.updates.as_mut().poll_next(cx) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Some(Ok(update))) => {
-                    if let Some(resume_point) = update.resume_point {
-                        self.resume_point = Some(resume_point);
+                    if let Some(resume_seq_num) = update.resume_seq_num {
+                        self.resume_seq_num = Some(resume_seq_num);
                     }
                     if let Some(tail) = update.caught_up_tail {
                         self.state.set_caught_up(tail);
@@ -363,7 +363,7 @@ pub async fn read_session(
     let mut retry_backoff = retry_builder(&client.config.retry).build();
     let baseline_wait = end.wait;
     let mut last_tail_at: Option<Instant> = None;
-    let initial_resume_point = if start.clamp == Some(true) {
+    let initial_resume_seq_num = if start.clamp == Some(true) {
         None
     } else {
         start.seq_num
@@ -464,10 +464,10 @@ pub async fn read_session(
             }
         }
     });
-    Ok(ReadSession::new(updates, initial_resume_point))
+    Ok(ReadSession::new(updates, initial_resume_seq_num))
 }
 
-fn resume_point_after_batch(batch: &ReadBatch) -> Option<u64> {
+fn resume_seq_num_after_batch(batch: &ReadBatch) -> Option<u64> {
     batch
         .records
         .last()
@@ -480,7 +480,7 @@ fn resume_point_after_batch(batch: &ReadBatch) -> Option<u64> {
 /// An empty batch with a reported tail still resolves a relative or timestamp start. Anchoring it
 /// prevents a reconnect from evaluating the original start against a newer tail.
 fn update_resume_start(start: &mut ReadStart, batch: &ReadBatch) {
-    if let Some(seq_num) = resume_point_after_batch(batch) {
+    if let Some(seq_num) = resume_seq_num_after_batch(batch) {
         *start = ReadStart {
             seq_num: Some(seq_num),
             timestamp: None,
@@ -625,11 +625,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn empty_tail_exposes_absolute_resume_point() {
+    async fn empty_tail_exposes_absolute_resume_seq_num() {
         let (tx, rx) = mpsc::unbounded_channel();
         let mut session = test_session(UnboundedReceiverStream::new(rx));
 
-        assert_eq!(session.resume_point(), None);
+        assert_eq!(session.resume_seq_num(), None);
         tx.send(Ok(ReadUpdate::from_batch(
             batch(Vec::new(), Some(position(42))),
             false,
@@ -640,7 +640,7 @@ mod tests {
         assert!(poll!(next.as_mut()).is_pending());
         drop(next);
 
-        assert_eq!(session.resume_point(), Some(42));
+        assert_eq!(session.resume_seq_num(), Some(42));
     }
 
     #[tokio::test]
@@ -665,12 +665,12 @@ mod tests {
         let first = session.next().await.unwrap().unwrap();
         assert_eq!(first.records.len(), 2);
         assert!(session.is_caught_up());
-        assert_eq!(session.resume_point(), Some(2));
+        assert_eq!(session.resume_seq_num(), Some(2));
         let caught_up_while_caught = session.caught_up();
 
         session.next().await.unwrap().unwrap();
         assert!(!session.is_caught_up());
-        assert_eq!(session.resume_point(), Some(3));
+        assert_eq!(session.resume_seq_num(), Some(3));
         assert_eq!(caught_up.await.unwrap(), tail);
         assert_eq!(caught_up_while_caught.await.unwrap(), tail);
     }
@@ -757,7 +757,7 @@ mod tests {
 
         assert!(session.next().await.is_none());
         assert!(session.is_caught_up());
-        assert_eq!(session.resume_point(), Some(2));
+        assert_eq!(session.resume_seq_num(), Some(2));
         assert_eq!(caught_up.await.unwrap(), tail);
     }
 

--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -411,14 +411,7 @@ pub async fn read_session(
                         last_tail_at = Some(Instant::now());
                     }
 
-                    if let Some(record) = batch.records.last() {
-                        start = ReadStart {
-                            seq_num: Some(record.seq_num + 1),
-                            timestamp: None,
-                            tail_offset: None,
-                            clamp: start.clamp,
-                        };
-                    }
+                    update_resume_start(&mut start, &batch);
                     if let Some(count) = end.count.as_mut() {
                         *count = count.saturating_sub(batch.records.len())
                     }
@@ -447,6 +440,27 @@ pub async fn read_session(
         }
     });
     Ok(ReadSession::new(updates))
+}
+
+/// Advance the absolute start used when reconnecting the read session.
+///
+/// An empty batch with a reported tail still resolves a relative or timestamp start. Anchoring it
+/// prevents a reconnect from evaluating the original start against a newer tail.
+fn update_resume_start(start: &mut ReadStart, batch: &ReadBatch) {
+    let next_seq_num = batch
+        .records
+        .last()
+        .map(|record| record.seq_num + 1)
+        .or_else(|| batch.tail.as_ref().map(|tail| tail.seq_num));
+
+    if let Some(seq_num) = next_seq_num {
+        *start = ReadStart {
+            seq_num: Some(seq_num),
+            timestamp: None,
+            tail_offset: None,
+            clamp: start.clamp,
+        };
+    }
 }
 
 async fn session_inner(
@@ -556,6 +570,23 @@ mod tests {
 
     fn batch(records: Vec<SequencedRecord>, tail: Option<StreamPosition>) -> ReadBatch {
         ReadBatch { records, tail }
+    }
+
+    #[test]
+    fn empty_tail_anchors_relative_resume_start() {
+        let mut start = ReadStart {
+            seq_num: None,
+            timestamp: None,
+            tail_offset: Some(0),
+            clamp: Some(true),
+        };
+
+        update_resume_start(&mut start, &batch(Vec::new(), Some(position(42))));
+
+        assert_eq!(start.seq_num, Some(42));
+        assert_eq!(start.timestamp, None);
+        assert_eq!(start.tail_offset, None);
+        assert_eq!(start.clamp, Some(true));
     }
 
     fn test_session(

--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -216,7 +216,7 @@ fn pending_catch_up() -> (oneshot::Sender<CaughtUpResult>, CaughtUpFuture) {
 struct ReadUpdate {
     batch: Option<ReadBatch>,
     caught_up_tail: Option<StreamPosition>,
-    resume_position: Option<u64>,
+    resume_point: Option<u64>,
 }
 
 impl ReadUpdate {
@@ -224,12 +224,12 @@ impl ReadUpdate {
         Self {
             batch: None,
             caught_up_tail: None,
-            resume_position: None,
+            resume_point: None,
         }
     }
 
     fn from_batch(mut batch: ReadBatch, ignore_command_records: bool) -> Self {
-        let resume_position = resume_position_after_batch(&batch);
+        let resume_point = resume_point_after_batch(&batch);
         let caught_up_tail = batch.tail.filter(|tail| {
             batch.records.is_empty()
                 || batch
@@ -245,7 +245,7 @@ impl ReadUpdate {
         Self {
             batch: (!batch.records.is_empty()).then_some(batch),
             caught_up_tail,
-            resume_position,
+            resume_point,
         }
     }
 }
@@ -254,27 +254,27 @@ impl ReadUpdate {
 pub struct ReadSession {
     updates: InternalStreaming<ReadUpdate>,
     state: CaughtUpState,
-    resume_position: Option<u64>,
+    resume_point: Option<u64>,
 }
 
 impl ReadSession {
-    fn new(updates: InternalStreaming<ReadUpdate>, resume_position: Option<u64>) -> Self {
+    fn new(updates: InternalStreaming<ReadUpdate>, resume_point: Option<u64>) -> Self {
         Self {
             updates,
             state: CaughtUpState::new(),
-            resume_position,
+            resume_point,
         }
     }
 
     /// Return the absolute sequence number from which the session would resume after a retry.
     ///
-    /// An unclamped absolute starting position is available immediately. A timestamp,
-    /// tail-relative, or clamped starting position returns `None` until the session receives a
-    /// record or a reported tail. The returned sequence number is the position of the next record
+    /// An unclamped absolute starting point is available immediately. A timestamp,
+    /// tail-relative, or clamped starting point returns `None` until the session receives a
+    /// record or a reported tail. The returned point is the sequence number of the next record
     /// the session expects. It advances as the session is polled, including across records hidden
     /// by [`ReadInput::ignore_command_records`](crate::types::ReadInput::ignore_command_records).
-    pub fn resume_position(&self) -> Option<u64> {
-        self.resume_position
+    pub fn resume_point(&self) -> Option<u64> {
+        self.resume_point
     }
 
     /// Return whether all records through the latest reported tail were delivered.
@@ -313,8 +313,8 @@ impl futures_core::Stream for ReadSession {
             match self.updates.as_mut().poll_next(cx) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Some(Ok(update))) => {
-                    if let Some(resume_position) = update.resume_position {
-                        self.resume_position = Some(resume_position);
+                    if let Some(resume_point) = update.resume_point {
+                        self.resume_point = Some(resume_point);
                     }
                     if let Some(tail) = update.caught_up_tail {
                         self.state.set_caught_up(tail);
@@ -363,7 +363,7 @@ pub async fn read_session(
     let mut retry_backoff = retry_builder(&client.config.retry).build();
     let baseline_wait = end.wait;
     let mut last_tail_at: Option<Instant> = None;
-    let initial_resume_position = if start.clamp == Some(true) {
+    let initial_resume_point = if start.clamp == Some(true) {
         None
     } else {
         start.seq_num
@@ -464,10 +464,10 @@ pub async fn read_session(
             }
         }
     });
-    Ok(ReadSession::new(updates, initial_resume_position))
+    Ok(ReadSession::new(updates, initial_resume_point))
 }
 
-fn resume_position_after_batch(batch: &ReadBatch) -> Option<u64> {
+fn resume_point_after_batch(batch: &ReadBatch) -> Option<u64> {
     batch
         .records
         .last()
@@ -480,7 +480,7 @@ fn resume_position_after_batch(batch: &ReadBatch) -> Option<u64> {
 /// An empty batch with a reported tail still resolves a relative or timestamp start. Anchoring it
 /// prevents a reconnect from evaluating the original start against a newer tail.
 fn update_resume_start(start: &mut ReadStart, batch: &ReadBatch) {
-    if let Some(seq_num) = resume_position_after_batch(batch) {
+    if let Some(seq_num) = resume_point_after_batch(batch) {
         *start = ReadStart {
             seq_num: Some(seq_num),
             timestamp: None,
@@ -625,11 +625,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn empty_tail_exposes_absolute_resume_position() {
+    async fn empty_tail_exposes_absolute_resume_point() {
         let (tx, rx) = mpsc::unbounded_channel();
         let mut session = test_session(UnboundedReceiverStream::new(rx));
 
-        assert_eq!(session.resume_position(), None);
+        assert_eq!(session.resume_point(), None);
         tx.send(Ok(ReadUpdate::from_batch(
             batch(Vec::new(), Some(position(42))),
             false,
@@ -640,7 +640,7 @@ mod tests {
         assert!(poll!(next.as_mut()).is_pending());
         drop(next);
 
-        assert_eq!(session.resume_position(), Some(42));
+        assert_eq!(session.resume_point(), Some(42));
     }
 
     #[tokio::test]
@@ -665,12 +665,12 @@ mod tests {
         let first = session.next().await.unwrap().unwrap();
         assert_eq!(first.records.len(), 2);
         assert!(session.is_caught_up());
-        assert_eq!(session.resume_position(), Some(2));
+        assert_eq!(session.resume_point(), Some(2));
         let caught_up_while_caught = session.caught_up();
 
         session.next().await.unwrap().unwrap();
         assert!(!session.is_caught_up());
-        assert_eq!(session.resume_position(), Some(3));
+        assert_eq!(session.resume_point(), Some(3));
         assert_eq!(caught_up.await.unwrap(), tail);
         assert_eq!(caught_up_while_caught.await.unwrap(), tail);
     }
@@ -757,7 +757,7 @@ mod tests {
 
         assert!(session.next().await.is_none());
         assert!(session.is_caught_up());
-        assert_eq!(session.resume_position(), Some(2));
+        assert_eq!(session.resume_point(), Some(2));
         assert_eq!(caught_up.await.unwrap(), tail);
     }
 

--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -216,6 +216,7 @@ fn pending_catch_up() -> (oneshot::Sender<CaughtUpResult>, CaughtUpFuture) {
 struct ReadUpdate {
     batch: Option<ReadBatch>,
     caught_up_tail: Option<StreamPosition>,
+    resume_position: Option<u64>,
 }
 
 impl ReadUpdate {
@@ -223,10 +224,12 @@ impl ReadUpdate {
         Self {
             batch: None,
             caught_up_tail: None,
+            resume_position: None,
         }
     }
 
     fn from_batch(mut batch: ReadBatch, ignore_command_records: bool) -> Self {
+        let resume_position = resume_position_after_batch(&batch);
         let caught_up_tail = batch.tail.filter(|tail| {
             batch.records.is_empty()
                 || batch
@@ -242,6 +245,7 @@ impl ReadUpdate {
         Self {
             batch: (!batch.records.is_empty()).then_some(batch),
             caught_up_tail,
+            resume_position,
         }
     }
 }
@@ -250,14 +254,27 @@ impl ReadUpdate {
 pub struct ReadSession {
     updates: InternalStreaming<ReadUpdate>,
     state: CaughtUpState,
+    resume_position: Option<u64>,
 }
 
 impl ReadSession {
-    fn new(updates: InternalStreaming<ReadUpdate>) -> Self {
+    fn new(updates: InternalStreaming<ReadUpdate>, resume_position: Option<u64>) -> Self {
         Self {
             updates,
             state: CaughtUpState::new(),
+            resume_position,
         }
+    }
+
+    /// Return the absolute sequence number from which the session would resume after a retry.
+    ///
+    /// An unclamped absolute starting position is available immediately. A timestamp,
+    /// tail-relative, or clamped starting position returns `None` until the session receives a
+    /// record or a reported tail. The returned sequence number is the position of the next record
+    /// the session expects. It advances as the session is polled, including across records hidden
+    /// by [`ReadInput::ignore_command_records`](crate::types::ReadInput::ignore_command_records).
+    pub fn resume_position(&self) -> Option<u64> {
+        self.resume_position
     }
 
     /// Return whether all records through the latest reported tail were delivered.
@@ -296,6 +313,9 @@ impl futures_core::Stream for ReadSession {
             match self.updates.as_mut().poll_next(cx) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Some(Ok(update))) => {
+                    if let Some(resume_position) = update.resume_position {
+                        self.resume_position = Some(resume_position);
+                    }
                     if let Some(tail) = update.caught_up_tail {
                         self.state.set_caught_up(tail);
                     } else {
@@ -343,6 +363,11 @@ pub async fn read_session(
     let mut retry_backoff = retry_builder(&client.config.retry).build();
     let baseline_wait = end.wait;
     let mut last_tail_at: Option<Instant> = None;
+    let initial_resume_position = if start.clamp == Some(true) {
+        None
+    } else {
+        start.seq_num
+    };
 
     let batches = loop {
         end.wait = remaining_wait(baseline_wait, last_tail_at);
@@ -439,7 +464,15 @@ pub async fn read_session(
             }
         }
     });
-    Ok(ReadSession::new(updates))
+    Ok(ReadSession::new(updates, initial_resume_position))
+}
+
+fn resume_position_after_batch(batch: &ReadBatch) -> Option<u64> {
+    batch
+        .records
+        .last()
+        .map(|record| record.seq_num + 1)
+        .or_else(|| batch.tail.as_ref().map(|tail| tail.seq_num))
 }
 
 /// Advance the absolute start used when reconnecting the read session.
@@ -447,13 +480,7 @@ pub async fn read_session(
 /// An empty batch with a reported tail still resolves a relative or timestamp start. Anchoring it
 /// prevents a reconnect from evaluating the original start against a newer tail.
 fn update_resume_start(start: &mut ReadStart, batch: &ReadBatch) {
-    let next_seq_num = batch
-        .records
-        .last()
-        .map(|record| record.seq_num + 1)
-        .or_else(|| batch.tail.as_ref().map(|tail| tail.seq_num));
-
-    if let Some(seq_num) = next_seq_num {
+    if let Some(seq_num) = resume_position_after_batch(batch) {
         *start = ReadStart {
             seq_num: Some(seq_num),
             timestamp: None,
@@ -594,7 +621,26 @@ mod tests {
         + Send
         + 'static,
     ) -> ReadSession {
-        ReadSession::new(Box::pin(updates))
+        ReadSession::new(Box::pin(updates), None)
+    }
+
+    #[tokio::test]
+    async fn empty_tail_exposes_absolute_resume_position() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut session = test_session(UnboundedReceiverStream::new(rx));
+
+        assert_eq!(session.resume_position(), None);
+        tx.send(Ok(ReadUpdate::from_batch(
+            batch(Vec::new(), Some(position(42))),
+            false,
+        )))
+        .unwrap();
+
+        let mut next = Box::pin(session.next());
+        assert!(poll!(next.as_mut()).is_pending());
+        drop(next);
+
+        assert_eq!(session.resume_position(), Some(42));
     }
 
     #[tokio::test]
@@ -619,10 +665,12 @@ mod tests {
         let first = session.next().await.unwrap().unwrap();
         assert_eq!(first.records.len(), 2);
         assert!(session.is_caught_up());
+        assert_eq!(session.resume_position(), Some(2));
         let caught_up_while_caught = session.caught_up();
 
         session.next().await.unwrap().unwrap();
         assert!(!session.is_caught_up());
+        assert_eq!(session.resume_position(), Some(3));
         assert_eq!(caught_up.await.unwrap(), tail);
         assert_eq!(caught_up_while_caught.await.unwrap(), tail);
     }
@@ -709,6 +757,7 @@ mod tests {
 
         assert!(session.next().await.is_none());
         assert!(session.is_caught_up());
+        assert_eq!(session.resume_position(), Some(2));
         assert_eq!(caught_up.await.unwrap(), tail);
     }
 

--- a/sdk/tests/stream_ops.rs
+++ b/sdk/tests/stream_ops.rs
@@ -782,7 +782,7 @@ async fn read_session_beyond_tail_with_clamp_to_tail(
     assert_eq!(ack.start.seq_num, 0);
     assert_eq!(ack.end.seq_num, 1);
 
-    let mut batches = stream
+    let mut session = stream
         .read_session(
             ReadInput::new().with_start(
                 ReadStart::new()
@@ -793,8 +793,10 @@ async fn read_session_beyond_tail_with_clamp_to_tail(
         )
         .await?;
 
-    let result = tokio::time::timeout(Duration::from_secs(1), batches.next()).await;
+    assert_eq!(session.resume_position(), None);
+    let result = tokio::time::timeout(Duration::from_secs(1), session.next()).await;
     assert_matches!(result, Err(tokio::time::error::Elapsed { .. }));
+    assert_eq!(session.resume_position(), Some(ack.tail.seq_num));
 
     Ok(())
 }
@@ -820,6 +822,7 @@ async fn read_session_reports_caught_up_after_tail_delivery(
     let mut seq_nums = Vec::new();
 
     assert!(!session.is_caught_up());
+    assert_eq!(session.resume_position(), None);
     let caught_up_tail = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             tokio::select! {
@@ -837,6 +840,7 @@ async fn read_session_reports_caught_up_after_tail_delivery(
     assert!(session.is_caught_up());
     assert_eq!(seq_nums, [ack.tail.seq_num - 2, ack.tail.seq_num - 1]);
     assert_eq!(caught_up_tail, ack.tail);
+    assert_eq!(session.resume_position(), Some(ack.tail.seq_num));
 
     let next_ack = stream
         .append(AppendInput::new(AppendRecordBatch::try_from_iter([

--- a/sdk/tests/stream_ops.rs
+++ b/sdk/tests/stream_ops.rs
@@ -793,10 +793,10 @@ async fn read_session_beyond_tail_with_clamp_to_tail(
         )
         .await?;
 
-    assert_eq!(session.resume_point(), None);
+    assert_eq!(session.resume_seq_num(), None);
     let result = tokio::time::timeout(Duration::from_secs(1), session.next()).await;
     assert_matches!(result, Err(tokio::time::error::Elapsed { .. }));
-    assert_eq!(session.resume_point(), Some(ack.tail.seq_num));
+    assert_eq!(session.resume_seq_num(), Some(ack.tail.seq_num));
 
     Ok(())
 }
@@ -822,7 +822,7 @@ async fn read_session_reports_caught_up_after_tail_delivery(
     let mut seq_nums = Vec::new();
 
     assert!(!session.is_caught_up());
-    assert_eq!(session.resume_point(), None);
+    assert_eq!(session.resume_seq_num(), None);
     let caught_up_tail = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             tokio::select! {
@@ -840,7 +840,7 @@ async fn read_session_reports_caught_up_after_tail_delivery(
     assert!(session.is_caught_up());
     assert_eq!(seq_nums, [ack.tail.seq_num - 2, ack.tail.seq_num - 1]);
     assert_eq!(caught_up_tail, ack.tail);
-    assert_eq!(session.resume_point(), Some(ack.tail.seq_num));
+    assert_eq!(session.resume_seq_num(), Some(ack.tail.seq_num));
 
     let next_ack = stream
         .append(AppendInput::new(AppendRecordBatch::try_from_iter([

--- a/sdk/tests/stream_ops.rs
+++ b/sdk/tests/stream_ops.rs
@@ -793,10 +793,10 @@ async fn read_session_beyond_tail_with_clamp_to_tail(
         )
         .await?;
 
-    assert_eq!(session.resume_position(), None);
+    assert_eq!(session.resume_point(), None);
     let result = tokio::time::timeout(Duration::from_secs(1), session.next()).await;
     assert_matches!(result, Err(tokio::time::error::Elapsed { .. }));
-    assert_eq!(session.resume_position(), Some(ack.tail.seq_num));
+    assert_eq!(session.resume_point(), Some(ack.tail.seq_num));
 
     Ok(())
 }
@@ -822,7 +822,7 @@ async fn read_session_reports_caught_up_after_tail_delivery(
     let mut seq_nums = Vec::new();
 
     assert!(!session.is_caught_up());
-    assert_eq!(session.resume_position(), None);
+    assert_eq!(session.resume_point(), None);
     let caught_up_tail = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             tokio::select! {
@@ -840,7 +840,7 @@ async fn read_session_reports_caught_up_after_tail_delivery(
     assert!(session.is_caught_up());
     assert_eq!(seq_nums, [ack.tail.seq_num - 2, ack.tail.seq_num - 1]);
     assert_eq!(caught_up_tail, ack.tail);
-    assert_eq!(session.resume_position(), Some(ack.tail.seq_num));
+    assert_eq!(session.resume_point(), Some(ack.tail.seq_num));
 
     let next_ack = stream
         .append(AppendInput::new(AppendRecordBatch::try_from_iter([


### PR DESCRIPTION
## Summary

- anchor read-session retries to the reported absolute tail even when the initial batch is empty
- expose ReadSession::resume_seq_num() as the next absolute sequence number the SDK will use on reconnect
- keep the cursor unresolved for timestamp, tail-relative, and clamped starts until the server resolves them
- advance the cursor across filtered command records and empty tail heartbeats

## Why

A tail-relative session that reached an empty tail could retain its original relative start. If the connection then retried after new records arrived, that relative start was evaluated against the newer tail and could skip data.

The same absolute sequence number is useful to callers that need to checkpoint a live session without reconstructing progress from visible batches. Naming it resume_seq_num makes the raw u64 explicit and reserves StreamPosition for the sequence-number/timestamp pair. This follows up on the integration pain surfaced in feldera/feldera#5728.

## Validation

- just fmt
- just test (716 passed)
- cargo clippy -p s2-sdk --all-features --all-targets -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc -p s2-sdk --all-features --no-deps
