### PR TITLE
feat(sdk): support refreshable access token providers

### DIFF
--- a/sdk/src/api.rs
+++ b/sdk/src/api.rs
@@ -44,8 +44,8 @@ use crate::{
     frame_signal::FrameSignal,
     retry::{RetryBackoff, RetryBackoffBuilder},
     types::{
-        AccessTokenId, AppendRetryPolicy, BasinAuthority, BasinName, Compression, EncryptionKey,
-        LocationName, RetryConfig, S2Config, S2Endpoints, StreamName,
+        AccessToken, AccessTokenId, AppendRetryPolicy, BasinAuthority, BasinName, Compression,
+        EncryptionKey, LocationName, RetryConfig, S2Config, S2Endpoints, StreamName,
     },
 };
 const CONTENT_TYPE_S2S: &str = "s2s/proto";
@@ -474,13 +474,17 @@ impl BasinClient {
             add_basin_header_if_required(request_builder, &self.config.endpoints, &self.name);
         let mut request = request_builder.build()?;
         set_encryption_header(&mut request, encryption);
-        let response = self
-            .client
-            .init_streaming(request)
-            .await?
-            .into_result()
-            .await?;
+        let (response, access_token) = self.client.init_streaming_authorized(request).await?;
+        let response = match response.into_result().await {
+            Ok(response) => response,
+            Err(error) => {
+                self.client
+                    .invalidate_access_token_if_rejected(&error, access_token.as_deref());
+                return Err(error);
+            }
+        };
         let mut bytes_stream = response.stream();
+        let auth_client = self.client.clone();
 
         let mut buffer = BytesMut::new();
         let mut decoder = FrameDecoder;
@@ -496,7 +500,12 @@ impl BasinClient {
                             yield msg.try_into_proto()?;
                         }
                         Ok(Some(SessionMessage::Terminal(msg))) => {
-                            Err::<(), ApiError>(msg.into())?;
+                            let error: ApiError = msg.into();
+                            auth_client.invalidate_access_token_if_rejected(
+                                &error,
+                                access_token.as_deref(),
+                            );
+                            Err::<(), ApiError>(error)?;
                         }
                         Ok(None) => break,
                         Err(err) => Err(err)?,
@@ -531,13 +540,17 @@ impl BasinClient {
             add_basin_header_if_required(request_builder, &self.config.endpoints, &self.name);
         let mut request = request_builder.build()?;
         set_encryption_header(&mut request, encryption);
-        let response = self
-            .client
-            .init_streaming(request)
-            .await?
-            .into_result()
-            .await?;
+        let (response, access_token) = self.client.init_streaming_authorized(request).await?;
+        let response = match response.into_result().await {
+            Ok(response) => response,
+            Err(error) => {
+                self.client
+                    .invalidate_access_token_if_rejected(&error, access_token.as_deref());
+                return Err(error);
+            }
+        };
         let mut bytes_stream = response.stream();
+        let auth_client = self.client.clone();
 
         let mut buffer = BytesMut::new();
         let mut decoder = FrameDecoder;
@@ -553,7 +566,12 @@ impl BasinClient {
                             yield msg.try_into_proto()?;
                         }
                         Ok(Some(SessionMessage::Terminal(msg))) => {
-                            Err::<(), ApiError>(msg.into())?;
+                            let error: ApiError = msg.into();
+                            auth_client.invalidate_access_token_if_rejected(
+                                &error,
+                                access_token.as_deref(),
+                            );
+                            Err::<(), ApiError>(error)?;
                         }
                         Ok(None) => break,
                         Err(err) => Err(err)?,
@@ -608,6 +626,9 @@ pub(crate) enum ApiError {
     TerminalDecode(#[from] TerminalDecodeError),
     #[error("malformed access token: {0}")]
     MalformedAccessToken(String),
+    #[cfg(feature = "_hidden")]
+    #[error("access token provider failed: {0}")]
+    AccessTokenProvider(crate::types::AccessTokenProviderError),
     #[error(transparent)]
     Compression(#[from] std::io::Error),
     #[error("append condition check failed")]
@@ -623,8 +644,17 @@ impl ApiError {
         match self {
             Self::Server(status, err_resp) => server_error_is_retryable(*status, &err_resp.code),
             Self::Client(err) => err.is_retryable(),
+            #[cfg(feature = "_hidden")]
+            Self::AccessTokenProvider(error) => error.is_retryable(),
             _ => false,
         }
+    }
+
+    pub(crate) fn is_authentication_error(&self) -> bool {
+        matches!(
+            self,
+            Self::Server(StatusCode::UNAUTHORIZED, response) if response.code == "authn"
+        )
     }
 
     pub fn has_no_side_effects(&self) -> bool {
@@ -633,6 +663,8 @@ impl ApiError {
                 server_error_has_no_side_effects(*status, &err_resp.code)
             }
             Self::Client(err) => err.has_no_side_effects(),
+            #[cfg(feature = "_hidden")]
+            Self::AccessTokenProvider(_) => true,
             _ => false,
         }
     }
@@ -688,10 +720,19 @@ impl From<TerminalMessage> for ApiError {
 
 pub type Streaming<R> = Pin<Box<dyn Send + Stream<Item = Result<R, ApiError>>>>;
 
+fn authorization_header(access_token: &str) -> Result<HeaderValue, ApiError> {
+    let mut header = HeaderValue::try_from(format!("Bearer {access_token}"))
+        .map_err(|error| ApiError::MalformedAccessToken(error.to_string()))?;
+    header.set_sensitive(true);
+    Ok(header)
+}
+
 #[derive(Clone)]
 pub struct BaseClient {
     client: Arc<dyn client::RequestExecutor>,
     default_headers: HeaderMap,
+    #[cfg(feature = "_hidden")]
+    access_token_provider: Option<Arc<dyn crate::types::AccessTokenProvider>>,
     request_timeout: Duration,
     retry_builder: RetryBackoffBuilder,
     compression: Compression,
@@ -721,11 +762,20 @@ impl BaseClient {
         C: client::Connect + Clone + Send + Sync + 'static,
     {
         let mut default_headers = HeaderMap::new();
-        default_headers.insert(
-            AUTHORIZATION,
-            HeaderValue::try_from(format!("Bearer {}", config.access_token.expose_secret()))
-                .map_err(|e| ApiError::MalformedAccessToken(e.to_string()))?,
-        );
+        #[cfg(feature = "_hidden")]
+        let mut access_token_provider = None;
+        match &config.access_token {
+            AccessToken::Static(access_token) => {
+                default_headers.insert(
+                    AUTHORIZATION,
+                    authorization_header(access_token.expose_secret())?,
+                );
+            }
+            #[cfg(feature = "_hidden")]
+            AccessToken::Provider(provider) => {
+                access_token_provider = Some(provider.clone());
+            }
+        }
         default_headers.insert(http::header::USER_AGENT, config.user_agent.clone());
         match config.compression {
             Compression::Gzip => {
@@ -748,6 +798,8 @@ impl BaseClient {
         Ok(Self {
             client: Arc::new(client),
             default_headers,
+            #[cfg(feature = "_hidden")]
+            access_token_provider,
             request_timeout: config.request_timeout,
             retry_builder: retry_builder(&config.retry),
             compression: config.compression,
@@ -794,11 +846,68 @@ impl BaseClient {
         self.client.init_streaming(request).await
     }
 
-    async fn execute_unary(
+    #[cfg(not(feature = "_hidden"))]
+    async fn init_streaming_authorized(
         &self,
         request: client::Request,
-    ) -> Result<UnaryResponse, client::HttpError> {
-        self.client.execute_unary(request).await
+    ) -> Result<(StreamingResponse, Option<String>), ApiError> {
+        self.init_streaming(request)
+            .await
+            .map(|response| (response, None))
+            .map_err(ApiError::from)
+    }
+
+    #[cfg(feature = "_hidden")]
+    async fn init_streaming_authorized(
+        &self,
+        mut request: client::Request,
+    ) -> Result<(StreamingResponse, Option<String>), ApiError> {
+        let access_token = self.authorize(&mut request).await?;
+        let response = self.init_streaming(request).await.map_err(ApiError::from)?;
+        Ok((response, access_token))
+    }
+
+    async fn execute_unary(
+        &self,
+        mut request: client::Request,
+    ) -> Result<(UnaryResponse, Option<String>), ApiError> {
+        let access_token = self.authorize(&mut request).await?;
+        let response = self
+            .client
+            .execute_unary(request)
+            .await
+            .map_err(ApiError::from)?;
+        Ok((response, access_token))
+    }
+
+    async fn authorize(&self, _request: &mut client::Request) -> Result<Option<String>, ApiError> {
+        #[cfg(feature = "_hidden")]
+        if let Some(provider) = self.access_token_provider.as_ref() {
+            let access_token = provider
+                .access_token()
+                .await
+                .map_err(ApiError::AccessTokenProvider)?;
+            _request
+                .headers_mut()
+                .insert(AUTHORIZATION, authorization_header(&access_token)?);
+            return Ok(Some(access_token));
+        }
+        Ok(None)
+    }
+
+    fn invalidate_access_token(&self, _access_token: Option<&str>) {
+        #[cfg(feature = "_hidden")]
+        if let (Some(provider), Some(access_token)) =
+            (self.access_token_provider.as_ref(), _access_token)
+        {
+            provider.invalidate_access_token(access_token);
+        }
+    }
+
+    fn invalidate_access_token_if_rejected(&self, error: &ApiError, access_token: Option<&str>) {
+        if error.is_authentication_error() {
+            self.invalidate_access_token(access_token);
+        }
     }
 
     fn request(&self, request: client::Request) -> RequestBuilder<'_> {
@@ -887,8 +996,8 @@ impl<'a> RequestBuilder<'a> {
 
             let response = self.client.execute_unary(attempt_request).await;
 
-            let (err, retry_after) = match response {
-                Ok(resp) => {
+            let (err, retry_after, access_token) = match response {
+                Ok((resp, access_token)) => {
                     let retry_after: Option<Duration> = resp
                         .headers()
                         .get(RETRY_AFTER_MS_HEADER)
@@ -921,15 +1030,24 @@ impl<'a> RequestBuilder<'a> {
                         Ok(resp) => {
                             return Ok(resp);
                         }
-                        Err(err) if err.is_retryable() => (err, retry_after),
-                        Err(err) => return Err(err),
+                        Err(err) => (err, retry_after, access_token),
                     }
                 }
-                Err(err) => (ApiError::from(err), None),
+                Err(err) => (err, None, None),
             };
 
-            if is_safe_to_retry(&err, self.append_retry_policy, self.frame_signal.as_ref())
-                && let Some(backoff) = retry_backoff.as_mut().and_then(|b| b.next())
+            let refreshable_authentication_error =
+                access_token.is_some() && err.is_authentication_error();
+            if refreshable_authentication_error {
+                self.client.invalidate_access_token(access_token.as_deref());
+            }
+
+            if is_safe_to_retry(
+                &err,
+                self.append_retry_policy,
+                self.frame_signal.as_ref(),
+                refreshable_authentication_error,
+            ) && let Some(backoff) = retry_backoff.as_mut().and_then(|b| b.next())
             {
                 let backoff = retry_after.map_or(backoff, |ra| ra.max(backoff));
                 debug!(
@@ -942,7 +1060,7 @@ impl<'a> RequestBuilder<'a> {
             } else {
                 debug!(
                     %err,
-                    is_retryable = err.is_retryable(),
+                    is_retryable = err.is_retryable() || refreshable_authentication_error,
                     retry_enabled = self.retry_enabled,
                     retries_exhausted = retry_backoff.as_ref().is_none_or(|b| b.is_exhausted()),
                     "not retrying request"
@@ -957,6 +1075,7 @@ fn is_safe_to_retry(
     err: &ApiError,
     policy: Option<AppendRetryPolicy>,
     frame_signal: Option<&FrameSignal>,
+    refreshable_authentication_error: bool,
 ) -> bool {
     let policy_compliant = match policy {
         None | Some(AppendRetryPolicy::All) => true,
@@ -964,7 +1083,7 @@ fn is_safe_to_retry(
             !frame_signal.is_none_or(|s| s.is_signalled()) || err.has_no_side_effects()
         }
     };
-    policy_compliant && err.is_retryable()
+    policy_compliant && (err.is_retryable() || refreshable_authentication_error)
 }
 
 fn add_basin_header_if_required(
@@ -1100,7 +1219,103 @@ fn provision_result_from_parts<T>(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "_hidden")]
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
+
+    #[cfg(feature = "_hidden")]
+    use async_trait::async_trait;
+    #[cfg(feature = "_hidden")]
+    use hyper_util::client::legacy::connect::HttpConnector;
+
     use super::*;
+
+    #[cfg(feature = "_hidden")]
+    #[derive(Debug)]
+    struct RotatingTokenProvider {
+        generation: AtomicUsize,
+    }
+
+    #[cfg(feature = "_hidden")]
+    #[async_trait]
+    impl crate::types::AccessTokenProvider for RotatingTokenProvider {
+        async fn access_token(&self) -> Result<String, crate::types::AccessTokenProviderError> {
+            let generation = self.generation.fetch_add(1, Ordering::Relaxed);
+            Ok(format!("token-{generation}"))
+        }
+    }
+
+    #[cfg(feature = "_hidden")]
+    #[derive(Debug)]
+    struct RejectAwareTokenProvider {
+        invalidated: AtomicBool,
+        rejected: Mutex<Vec<String>>,
+    }
+
+    #[cfg(feature = "_hidden")]
+    #[async_trait]
+    impl crate::types::AccessTokenProvider for RejectAwareTokenProvider {
+        async fn access_token(&self) -> Result<String, crate::types::AccessTokenProviderError> {
+            Ok(if self.invalidated.load(Ordering::Acquire) {
+                "new-token"
+            } else {
+                "old-token"
+            }
+            .to_owned())
+        }
+
+        fn invalidate_access_token(&self, rejected_access_token: &str) {
+            self.rejected
+                .lock()
+                .expect("rejected token mutex poisoned")
+                .push(rejected_access_token.to_owned());
+            self.invalidated.store(true, Ordering::Release);
+        }
+    }
+
+    #[cfg(feature = "_hidden")]
+    #[derive(Debug, Default)]
+    struct RejectOldTokenExecutor {
+        authorization_headers: Mutex<Vec<String>>,
+    }
+
+    #[cfg(feature = "_hidden")]
+    #[async_trait]
+    impl client::RequestExecutor for RejectOldTokenExecutor {
+        async fn execute_unary(
+            &self,
+            mut request: client::Request,
+        ) -> Result<UnaryResponse, client::HttpError> {
+            let authorization = request
+                .headers_mut()
+                .get(AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned();
+            self.authorization_headers
+                .lock()
+                .expect("authorization header mutex poisoned")
+                .push(authorization.clone());
+
+            if authorization == "Bearer old-token" {
+                Ok(UnaryResponse::new_for_test(
+                    StatusCode::UNAUTHORIZED,
+                    br#"{"code":"authn","message":"rejected"}"#.to_vec(),
+                ))
+            } else {
+                Ok(UnaryResponse::new_for_test(StatusCode::OK, "ok"))
+            }
+        }
+
+        async fn init_streaming(
+            &self,
+            _request: client::Request,
+        ) -> Result<StreamingResponse, client::HttpError> {
+            unreachable!("unary retry test does not initialize a stream")
+        }
+    }
 
     fn server_error(status: StatusCode, code: &str) -> ApiError {
         ApiError::Server(
@@ -1118,8 +1333,8 @@ mod tests {
         let non_retryable = server_error(StatusCode::BAD_REQUEST, "bad_request");
 
         // Non-append requests (no policy) — retry if retryable.
-        assert!(is_safe_to_retry(&retryable, None, None));
-        assert!(!is_safe_to_retry(&non_retryable, None, None));
+        assert!(is_safe_to_retry(&retryable, None, None, false));
+        assert!(!is_safe_to_retry(&non_retryable, None, None, false));
     }
 
     #[test]
@@ -1129,8 +1344,8 @@ mod tests {
         let policy = Some(AppendRetryPolicy::All);
 
         // All policy — retry if retryable, no frame signal checks.
-        assert!(is_safe_to_retry(&retryable, policy, None));
-        assert!(!is_safe_to_retry(&non_retryable, policy, None));
+        assert!(is_safe_to_retry(&retryable, policy, None, false));
+        assert!(!is_safe_to_retry(&non_retryable, policy, None, false));
     }
 
     #[test]
@@ -1138,28 +1353,122 @@ mod tests {
         let retryable = server_error(StatusCode::INTERNAL_SERVER_ERROR, "internal");
         let non_retryable = server_error(StatusCode::BAD_REQUEST, "bad_request");
         let no_side_effect = server_error(StatusCode::TOO_MANY_REQUESTS, "rate_limited");
-        let transaction_conflict =
-            server_error(StatusCode::CONFLICT, "transaction_conflict");
+        let transaction_conflict = server_error(StatusCode::CONFLICT, "transaction_conflict");
         let policy = Some(AppendRetryPolicy::NoSideEffects);
         let signal = FrameSignal::new();
 
         // Signal not set — safe to retry.
-        assert!(is_safe_to_retry(&retryable, policy, Some(&signal)));
+        assert!(is_safe_to_retry(&retryable, policy, Some(&signal), false));
 
         // Signal set + error with possible side effects — not safe.
         signal.signal();
-        assert!(!is_safe_to_retry(&retryable, policy, Some(&signal)));
+        assert!(!is_safe_to_retry(&retryable, policy, Some(&signal), false));
 
         // Signal set + no-side-effect error — safe.
-        assert!(is_safe_to_retry(&no_side_effect, policy, Some(&signal)));
+        assert!(is_safe_to_retry(
+            &no_side_effect,
+            policy,
+            Some(&signal),
+            false,
+        ));
         assert!(is_safe_to_retry(
             &transaction_conflict,
             policy,
-            Some(&signal)
+            Some(&signal),
+            false,
         ));
 
         // Signal set + non-retryable — never safe.
-        assert!(!is_safe_to_retry(&non_retryable, policy, Some(&signal)));
+        assert!(!is_safe_to_retry(
+            &non_retryable,
+            policy,
+            Some(&signal),
+            false,
+        ));
+    }
+
+    #[cfg(feature = "_hidden")]
+    #[tokio::test]
+    async fn dynamic_access_token_is_loaded_for_each_attempt_and_marked_sensitive() {
+        let config = S2Config::new("unused").with_access_token_provider(RotatingTokenProvider {
+            generation: AtomicUsize::new(1),
+        });
+        let client = BaseClient::init_with_connector(&config, HttpConnector::new()).unwrap();
+        let uri = "http://example.test/v1/basins".parse().unwrap();
+        let mut request = client.get(uri).build().unwrap();
+
+        assert!(request.headers_mut().get(AUTHORIZATION).is_none());
+
+        client.authorize(&mut request).await.unwrap();
+        let first = request.headers_mut().get(AUTHORIZATION).unwrap();
+        assert_eq!(first, "Bearer token-1");
+        assert!(first.is_sensitive());
+
+        client.authorize(&mut request).await.unwrap();
+        let second = request.headers_mut().get(AUTHORIZATION).unwrap();
+        assert_eq!(second, "Bearer token-2");
+        assert!(second.is_sensitive());
+    }
+
+    #[cfg(feature = "_hidden")]
+    #[tokio::test]
+    async fn rejected_token_is_invalidated_and_replaced_on_unary_retry() {
+        let provider = Arc::new(RejectAwareTokenProvider {
+            invalidated: AtomicBool::new(false),
+            rejected: Mutex::new(Vec::new()),
+        });
+        let executor = Arc::new(RejectOldTokenExecutor::default());
+        let client = BaseClient {
+            client: executor.clone(),
+            default_headers: HeaderMap::new(),
+            access_token_provider: Some(provider.clone()),
+            request_timeout: Duration::from_secs(1),
+            retry_builder: RetryBackoffBuilder::default()
+                .with_min_base_delay(Duration::ZERO)
+                .with_max_base_delay(Duration::ZERO)
+                .with_max_retries(1),
+            compression: Compression::None,
+        };
+        let request = client
+            .get("http://example.test/v1/basins".parse().unwrap())
+            .build()
+            .unwrap();
+
+        let response = client.request(request).send().await.unwrap();
+
+        assert_eq!(response.into_bytes(), bytes::Bytes::from_static(b"ok"));
+        assert_eq!(
+            executor
+                .authorization_headers
+                .lock()
+                .expect("authorization header mutex poisoned")
+                .as_slice(),
+            ["Bearer old-token", "Bearer new-token"]
+        );
+        assert_eq!(
+            provider
+                .rejected
+                .lock()
+                .expect("rejected token mutex poisoned")
+                .as_slice(),
+            ["old-token"]
+        );
+    }
+
+    #[cfg(feature = "_hidden")]
+    #[test]
+    fn transient_provider_failures_are_retryable_without_side_effects() {
+        let transient = ApiError::AccessTokenProvider(
+            crate::types::AccessTokenProviderError::transient("temporarily unavailable"),
+        );
+        assert!(transient.is_retryable());
+        assert!(transient.has_no_side_effects());
+
+        let permanent = ApiError::AccessTokenProvider(
+            crate::types::AccessTokenProviderError::permanent("login required"),
+        );
+        assert!(!permanent.is_retryable());
+        assert!(permanent.has_no_side_effects());
     }
 
     #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]

--- a/sdk/src/api.rs
+++ b/sdk/src/api.rs
@@ -44,8 +44,8 @@ use crate::{
     frame_signal::FrameSignal,
     retry::{RetryBackoff, RetryBackoffBuilder},
     types::{
-        AccessToken, AccessTokenId, AppendRetryPolicy, BasinAuthority, BasinName, Compression,
-        EncryptionKey, LocationName, RetryConfig, S2Config, S2Endpoints, StreamName,
+        AccessToken, AccessTokenId, AccessTokenMode, AppendRetryPolicy, BasinAuthority, BasinName,
+        Compression, EncryptionKey, LocationName, RetryConfig, S2Config, S2Endpoints, StreamName,
     },
 };
 const CONTENT_TYPE_S2S: &str = "s2s/proto";
@@ -731,6 +731,7 @@ fn authorization_header(access_token: &str) -> Result<HeaderValue, ApiError> {
 pub struct BaseClient {
     client: Arc<dyn client::RequestExecutor>,
     default_headers: HeaderMap,
+    access_token_mode: AccessTokenMode,
     #[cfg(feature = "_hidden")]
     access_token_provider: Option<Arc<dyn crate::types::AccessTokenProvider>>,
     request_timeout: Duration,
@@ -761,6 +762,7 @@ impl BaseClient {
     where
         C: client::Connect + Clone + Send + Sync + 'static,
     {
+        let access_token_mode = config.access_token.mode();
         let mut default_headers = HeaderMap::new();
         #[cfg(feature = "_hidden")]
         let mut access_token_provider = None;
@@ -798,6 +800,7 @@ impl BaseClient {
         Ok(Self {
             client: Arc::new(client),
             default_headers,
+            access_token_mode,
             #[cfg(feature = "_hidden")]
             access_token_provider,
             request_timeout: config.request_timeout,
@@ -1037,7 +1040,7 @@ impl<'a> RequestBuilder<'a> {
             };
 
             let refreshable_authentication_error =
-                access_token.is_some() && err.is_authentication_error();
+                self.client.access_token_mode.is_refreshable() && err.is_authentication_error();
             if refreshable_authentication_error {
                 self.client.invalidate_access_token(access_token.as_deref());
             }
@@ -1046,7 +1049,7 @@ impl<'a> RequestBuilder<'a> {
                 &err,
                 self.append_retry_policy,
                 self.frame_signal.as_ref(),
-                refreshable_authentication_error,
+                self.client.access_token_mode,
             ) && let Some(backoff) = retry_backoff.as_mut().and_then(|b| b.next())
             {
                 let backoff = retry_after.map_or(backoff, |ra| ra.max(backoff));
@@ -1075,7 +1078,7 @@ fn is_safe_to_retry(
     err: &ApiError,
     policy: Option<AppendRetryPolicy>,
     frame_signal: Option<&FrameSignal>,
-    refreshable_authentication_error: bool,
+    access_token_mode: AccessTokenMode,
 ) -> bool {
     let policy_compliant = match policy {
         None | Some(AppendRetryPolicy::All) => true,
@@ -1083,7 +1086,9 @@ fn is_safe_to_retry(
             !frame_signal.is_none_or(|s| s.is_signalled()) || err.has_no_side_effects()
         }
     };
-    policy_compliant && (err.is_retryable() || refreshable_authentication_error)
+    policy_compliant
+        && (err.is_retryable()
+            || (access_token_mode.is_refreshable() && err.is_authentication_error()))
 }
 
 fn add_basin_header_if_required(
@@ -1331,10 +1336,11 @@ mod tests {
     fn safe_to_retry_unary_no_policy() {
         let retryable = server_error(StatusCode::INTERNAL_SERVER_ERROR, "internal");
         let non_retryable = server_error(StatusCode::BAD_REQUEST, "bad_request");
+        let mode = AccessTokenMode::Static;
 
         // Non-append requests (no policy) — retry if retryable.
-        assert!(is_safe_to_retry(&retryable, None, None, false));
-        assert!(!is_safe_to_retry(&non_retryable, None, None, false));
+        assert!(is_safe_to_retry(&retryable, None, None, mode));
+        assert!(!is_safe_to_retry(&non_retryable, None, None, mode));
     }
 
     #[test]
@@ -1342,10 +1348,11 @@ mod tests {
         let retryable = server_error(StatusCode::INTERNAL_SERVER_ERROR, "internal");
         let non_retryable = server_error(StatusCode::BAD_REQUEST, "bad_request");
         let policy = Some(AppendRetryPolicy::All);
+        let mode = AccessTokenMode::Static;
 
         // All policy — retry if retryable, no frame signal checks.
-        assert!(is_safe_to_retry(&retryable, policy, None, false));
-        assert!(!is_safe_to_retry(&non_retryable, policy, None, false));
+        assert!(is_safe_to_retry(&retryable, policy, None, mode));
+        assert!(!is_safe_to_retry(&non_retryable, policy, None, mode));
     }
 
     #[test]
@@ -1356,26 +1363,27 @@ mod tests {
         let transaction_conflict = server_error(StatusCode::CONFLICT, "transaction_conflict");
         let policy = Some(AppendRetryPolicy::NoSideEffects);
         let signal = FrameSignal::new();
+        let mode = AccessTokenMode::Static;
 
         // Signal not set — safe to retry.
-        assert!(is_safe_to_retry(&retryable, policy, Some(&signal), false));
+        assert!(is_safe_to_retry(&retryable, policy, Some(&signal), mode));
 
         // Signal set + error with possible side effects — not safe.
         signal.signal();
-        assert!(!is_safe_to_retry(&retryable, policy, Some(&signal), false));
+        assert!(!is_safe_to_retry(&retryable, policy, Some(&signal), mode));
 
         // Signal set + no-side-effect error — safe.
         assert!(is_safe_to_retry(
             &no_side_effect,
             policy,
             Some(&signal),
-            false,
+            mode,
         ));
         assert!(is_safe_to_retry(
             &transaction_conflict,
             policy,
             Some(&signal),
-            false,
+            mode,
         ));
 
         // Signal set + non-retryable — never safe.
@@ -1383,7 +1391,7 @@ mod tests {
             &non_retryable,
             policy,
             Some(&signal),
-            false,
+            mode,
         ));
     }
 
@@ -1421,6 +1429,7 @@ mod tests {
         let client = BaseClient {
             client: executor.clone(),
             default_headers: HeaderMap::new(),
+            access_token_mode: AccessTokenMode::Refreshable,
             access_token_provider: Some(provider.clone()),
             request_timeout: Duration::from_secs(1),
             retry_builder: RetryBackoffBuilder::default()

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -343,6 +343,15 @@ pub struct UnaryResponse {
 }
 
 impl UnaryResponse {
+    #[cfg(all(test, feature = "_hidden"))]
+    pub(crate) fn new_for_test(status: StatusCode, bytes: impl Into<Bytes>) -> Self {
+        Self {
+            status,
+            headers: HeaderMap::new(),
+            bytes: bytes.into(),
+        }
+    }
+
     pub fn status(&self) -> StatusCode {
         self.status
     }

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -190,6 +190,10 @@ pub enum RequestError {
     /// The access token could not be used as an HTTP header value.
     #[error("malformed access token: {0}")]
     MalformedAccessToken(String),
+    #[cfg(feature = "_hidden")]
+    #[doc(hidden)]
+    #[error("access token provider failed: {0}")]
+    AccessTokenProvider(crate::types::AccessTokenProviderError),
     /// Input validation failed.
     #[error(transparent)]
     Validation(#[from] ValidationError),
@@ -201,6 +205,8 @@ impl RequestError {
         match self {
             Self::Client(error) => error.is_retryable(),
             Self::Server(error) => error.is_retryable(),
+            #[cfg(feature = "_hidden")]
+            Self::AccessTokenProvider(error) => error.is_retryable(),
             Self::MalformedAccessToken(_) | Self::Validation(_) => false,
         }
     }
@@ -210,6 +216,8 @@ impl RequestError {
         match self {
             Self::Client(error) => error.has_no_side_effects(),
             Self::Server(error) => error.has_no_side_effects(),
+            #[cfg(feature = "_hidden")]
+            Self::AccessTokenProvider(_) => true,
             Self::MalformedAccessToken(_) | Self::Validation(_) => true,
         }
     }
@@ -220,6 +228,14 @@ impl RequestError {
             Self::Server(error) => Some(error),
             _ => None,
         }
+    }
+
+    pub(crate) fn is_authentication_error(&self) -> bool {
+        matches!(
+            self,
+            Self::Server(error)
+                if error.status == StatusCode::UNAUTHORIZED && error.code == "authn"
+        )
     }
 }
 
@@ -234,6 +250,8 @@ impl From<ApiError> for RequestError {
                 Self::Client(ClientError::SessionProtocol(error.to_string()))
             }
             ApiError::MalformedAccessToken(error) => Self::MalformedAccessToken(error),
+            #[cfg(feature = "_hidden")]
+            ApiError::AccessTokenProvider(error) => Self::AccessTokenProvider(error),
             ApiError::Compression(error) => {
                 Self::Client(ClientError::ResponseCompression(error.to_string()))
             }

--- a/sdk/src/session/append.rs
+++ b/sdk/src/session/append.rs
@@ -24,8 +24,8 @@ use crate::{
     frame_signal::FrameSignal,
     retry::RetryBackoffBuilder,
     types::{
-        AppendAck, AppendInput, AppendRetryPolicy, EncryptionKey, MeteredBytes, ONE_MIB,
-        StreamName, StreamPosition, ValidationError,
+        AccessTokenMode, AppendAck, AppendInput, AppendRetryPolicy, EncryptionKey, MeteredBytes,
+        ONE_MIB, StreamName, StreamPosition, ValidationError,
     },
 };
 
@@ -463,7 +463,7 @@ async fn run_session_with_retry(
     buffer_size: usize,
     terminal_err: Arc<OnceLock<AppendSessionError>>,
 ) {
-    let refreshable_auth = client.config.access_token.is_dynamic();
+    let access_token_mode = client.config.access_token.mode();
     let frame_signal = match client.config.retry.append_retry_policy {
         AppendRetryPolicy::NoSideEffects => Some(FrameSignal::new()),
         AppendRetryPolicy::All => None,
@@ -508,7 +508,7 @@ async fn run_session_with_retry(
                     client.config.retry.append_retry_policy,
                     !state.inflight_appends.is_empty(),
                     frame_signal.as_ref(),
-                    refreshable_auth,
+                    access_token_mode,
                 ) && let Some(backoff) = retry_backoff.next()
                 {
                     debug!(
@@ -897,7 +897,7 @@ fn is_safe_to_retry(
     policy: AppendRetryPolicy,
     has_inflight: bool,
     frame_signal: Option<&FrameSignal>,
-    refreshable_auth: bool,
+    access_token_mode: AccessTokenMode,
 ) -> bool {
     let policy_compliant = match policy {
         AppendRetryPolicy::All => true,
@@ -907,7 +907,9 @@ fn is_safe_to_retry(
                 || err.has_no_side_effects()
         }
     };
-    policy_compliant && (err.is_retryable() || (refreshable_auth && err.is_authentication_error()))
+    policy_compliant
+        && (err.is_retryable()
+            || (access_token_mode.is_refreshable() && err.is_authentication_error()))
 }
 
 const DEFAULT_CHANNEL_BUFFER_SIZE: usize = 100;
@@ -945,7 +947,7 @@ mod tests {
         api::{ApiError, ServerErrorBody},
         error::{AppendError, RequestError},
         frame_signal::FrameSignal,
-        types::AppendRetryPolicy,
+        types::{AccessTokenMode, AppendRetryPolicy},
     };
 
     fn server_error(status: StatusCode, code: &str) -> AppendSessionError {
@@ -963,22 +965,50 @@ mod tests {
         let retryable = server_error(StatusCode::INTERNAL_SERVER_ERROR, "internal");
         let non_retryable = server_error(StatusCode::BAD_REQUEST, "bad_request");
         let policy = AppendRetryPolicy::All;
+        let static_mode = AccessTokenMode::Static;
 
         // All policy — always policy-compliant, just needs retryable.
-        assert!(is_safe_to_retry(&retryable, policy, true, None, false));
-        assert!(!is_safe_to_retry(&non_retryable, policy, true, None, false,));
+        assert!(is_safe_to_retry(
+            &retryable,
+            policy,
+            true,
+            None,
+            static_mode
+        ));
+        assert!(!is_safe_to_retry(
+            &non_retryable,
+            policy,
+            true,
+            None,
+            static_mode,
+        ));
 
         let unauthorized = server_error(StatusCode::UNAUTHORIZED, "authn");
-        assert!(is_safe_to_retry(&unauthorized, policy, true, None, true,));
-        assert!(!is_safe_to_retry(&unauthorized, policy, true, None, false,));
+        #[cfg(feature = "_hidden")]
+        assert!(is_safe_to_retry(
+            &unauthorized,
+            policy,
+            true,
+            None,
+            AccessTokenMode::Refreshable,
+        ));
+        assert!(!is_safe_to_retry(
+            &unauthorized,
+            policy,
+            true,
+            None,
+            static_mode,
+        ));
 
+        #[cfg(feature = "_hidden")]
         let unrelated_unauthorized = server_error(StatusCode::UNAUTHORIZED, "other");
+        #[cfg(feature = "_hidden")]
         assert!(!is_safe_to_retry(
             &unrelated_unauthorized,
             policy,
             true,
             None,
-            true,
+            AccessTokenMode::Refreshable,
         ));
     }
 
@@ -988,6 +1018,7 @@ mod tests {
         let no_side_effect = server_error(StatusCode::TOO_MANY_REQUESTS, "rate_limited");
         let policy = AppendRetryPolicy::NoSideEffects;
         let signal = FrameSignal::new();
+        let mode = AccessTokenMode::Static;
 
         // No inflight — always safe.
         signal.signal();
@@ -996,7 +1027,7 @@ mod tests {
             policy,
             false,
             Some(&signal),
-            false,
+            mode,
         ));
 
         // Inflight + signal not set — safe (no data sent this attempt).
@@ -1006,7 +1037,7 @@ mod tests {
             policy,
             true,
             Some(&signal),
-            false,
+            mode,
         ));
 
         // Inflight + signal set + error with possible side effects — not safe.
@@ -1016,7 +1047,7 @@ mod tests {
             policy,
             true,
             Some(&signal),
-            false,
+            mode,
         ));
 
         // Inflight + signal set + no-side-effect error — safe.
@@ -1025,7 +1056,7 @@ mod tests {
             policy,
             true,
             Some(&signal),
-            false,
+            mode,
         ));
 
         // AckTimeout — retryable but has possible side effects.
@@ -1034,7 +1065,7 @@ mod tests {
             policy,
             true,
             Some(&signal),
-            false,
+            mode,
         ));
     }
 }

--- a/sdk/src/session/append.rs
+++ b/sdk/src/session/append.rs
@@ -99,6 +99,13 @@ impl AppendSessionError {
             | Self::InvalidAck(_) => None,
         }
     }
+
+    fn is_authentication_error(&self) -> bool {
+        matches!(
+            self,
+            Self::Append(AppendError::Request(error)) if error.is_authentication_error()
+        )
+    }
 }
 
 impl From<ApiError> for AppendSessionError {
@@ -456,6 +463,7 @@ async fn run_session_with_retry(
     buffer_size: usize,
     terminal_err: Arc<OnceLock<AppendSessionError>>,
 ) {
+    let refreshable_auth = client.config.access_token.is_dynamic();
     let frame_signal = match client.config.retry.append_retry_policy {
         AppendRetryPolicy::NoSideEffects => Some(FrameSignal::new()),
         AppendRetryPolicy::All => None,
@@ -500,6 +508,7 @@ async fn run_session_with_retry(
                     client.config.retry.append_retry_policy,
                     !state.inflight_appends.is_empty(),
                     frame_signal.as_ref(),
+                    refreshable_auth,
                 ) && let Some(backoff) = retry_backoff.next()
                 {
                     debug!(
@@ -888,6 +897,7 @@ fn is_safe_to_retry(
     policy: AppendRetryPolicy,
     has_inflight: bool,
     frame_signal: Option<&FrameSignal>,
+    refreshable_auth: bool,
 ) -> bool {
     let policy_compliant = match policy {
         AppendRetryPolicy::All => true,
@@ -897,7 +907,7 @@ fn is_safe_to_retry(
                 || err.has_no_side_effects()
         }
     };
-    policy_compliant && err.is_retryable()
+    policy_compliant && (err.is_retryable() || (refreshable_auth && err.is_authentication_error()))
 }
 
 const DEFAULT_CHANNEL_BUFFER_SIZE: usize = 100;
@@ -955,8 +965,21 @@ mod tests {
         let policy = AppendRetryPolicy::All;
 
         // All policy — always policy-compliant, just needs retryable.
-        assert!(is_safe_to_retry(&retryable, policy, true, None));
-        assert!(!is_safe_to_retry(&non_retryable, policy, true, None));
+        assert!(is_safe_to_retry(&retryable, policy, true, None, false));
+        assert!(!is_safe_to_retry(&non_retryable, policy, true, None, false,));
+
+        let unauthorized = server_error(StatusCode::UNAUTHORIZED, "authn");
+        assert!(is_safe_to_retry(&unauthorized, policy, true, None, true,));
+        assert!(!is_safe_to_retry(&unauthorized, policy, true, None, false,));
+
+        let unrelated_unauthorized = server_error(StatusCode::UNAUTHORIZED, "other");
+        assert!(!is_safe_to_retry(
+            &unrelated_unauthorized,
+            policy,
+            true,
+            None,
+            true,
+        ));
     }
 
     #[test]
@@ -968,22 +991,41 @@ mod tests {
 
         // No inflight — always safe.
         signal.signal();
-        assert!(is_safe_to_retry(&retryable, policy, false, Some(&signal)));
+        assert!(is_safe_to_retry(
+            &retryable,
+            policy,
+            false,
+            Some(&signal),
+            false,
+        ));
 
         // Inflight + signal not set — safe (no data sent this attempt).
         signal.reset();
-        assert!(is_safe_to_retry(&retryable, policy, true, Some(&signal)));
+        assert!(is_safe_to_retry(
+            &retryable,
+            policy,
+            true,
+            Some(&signal),
+            false,
+        ));
 
         // Inflight + signal set + error with possible side effects — not safe.
         signal.signal();
-        assert!(!is_safe_to_retry(&retryable, policy, true, Some(&signal)));
+        assert!(!is_safe_to_retry(
+            &retryable,
+            policy,
+            true,
+            Some(&signal),
+            false,
+        ));
 
         // Inflight + signal set + no-side-effect error — safe.
         assert!(is_safe_to_retry(
             &no_side_effect,
             policy,
             true,
-            Some(&signal)
+            Some(&signal),
+            false,
         ));
 
         // AckTimeout — retryable but has possible side effects.
@@ -992,6 +1034,7 @@ mod tests {
             policy,
             true,
             Some(&signal),
+            false,
         ));
     }
 }

--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -22,7 +22,7 @@ use crate::{
     error::{ReadError, RequestError},
     retry::RetryBackoff,
     types::{
-        EncryptionKey, MeteredBytes, ReadBatch, ReadInput, ReadSessionConfig,
+        AccessTokenMode, EncryptionKey, MeteredBytes, ReadBatch, ReadInput, ReadSessionConfig,
         ReadSessionRetryPolicy, StreamName, StreamPosition,
     },
 };
@@ -365,7 +365,7 @@ pub async fn read_session(
     let mut end: ReadEnd = stop.into();
     let retry_policy = config.retry_policy;
     let mut retry_backoff = retry_builder(&client.config.retry).build();
-    let refreshable_auth = client.config.access_token.is_dynamic();
+    let access_token_mode = client.config.access_token.mode();
     let baseline_wait = end.wait;
     let mut last_tail_at: Option<Instant> = None;
     let initial_resume_seq_num = if start.clamp == Some(true) {
@@ -391,7 +391,7 @@ pub async fn read_session(
             }
             Err(err) => {
                 if let Some(backoff) =
-                    retry_delay(&err, &mut retry_backoff, retry_policy, refreshable_auth)
+                    retry_delay(&err, &mut retry_backoff, retry_policy, access_token_mode)
                 {
                     tokio::time::sleep(backoff).await;
                     continue;
@@ -421,7 +421,7 @@ pub async fn read_session(
                                 &err,
                                 &mut retry_backoff,
                                 retry_policy,
-                                refreshable_auth,
+                                access_token_mode,
                             )
                         {
                             tokio::time::sleep(backoff).await;
@@ -467,7 +467,7 @@ pub async fn read_session(
                             &err,
                             &mut retry_backoff,
                             retry_policy,
-                            refreshable_auth,
+                            access_token_mode,
                         )
                     {
                         yield Ok(ReadUpdate::behind());
@@ -547,9 +547,10 @@ fn retry_delay(
     err: &ReadSessionFailure,
     backoffs: &mut RetryBackoff,
     retry_policy: ReadSessionRetryPolicy,
-    refreshable_auth: bool,
+    access_token_mode: AccessTokenMode,
 ) -> Option<Duration> {
-    let is_retryable = is_retryable_with_auth_refresh(err, refreshable_auth);
+    let is_retryable =
+        err.is_retryable() || (access_token_mode.is_refreshable() && err.is_authentication_error());
     if !is_retryable {
         debug!(
             %err,
@@ -584,46 +585,15 @@ fn retry_delay(
     }
 }
 
-fn is_retryable_with_auth_refresh(error: &ReadSessionFailure, refreshable_auth: bool) -> bool {
-    error.is_retryable() || (refreshable_auth && error.is_authentication_error())
-}
-
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
     use futures_util::{StreamExt, poll, stream};
-    use http::StatusCode;
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::UnboundedReceiverStream;
 
     use super::*;
-    use crate::{
-        api::ServerErrorBody,
-        types::{Header, SequencedRecord},
-    };
-
-    #[test]
-    fn authentication_error_is_retryable_only_with_dynamic_credentials() {
-        let error = ReadSessionFailure::Api(ApiError::Server(
-            StatusCode::UNAUTHORIZED,
-            ServerErrorBody {
-                code: "authn".to_owned(),
-                message: "expired".to_owned(),
-            },
-        ));
-
-        assert!(is_retryable_with_auth_refresh(&error, true));
-        assert!(!is_retryable_with_auth_refresh(&error, false));
-
-        let unrelated = ReadSessionFailure::Api(ApiError::Server(
-            StatusCode::UNAUTHORIZED,
-            ServerErrorBody {
-                code: "other".to_owned(),
-                message: "not refreshable".to_owned(),
-            },
-        ));
-        assert!(!is_retryable_with_auth_refresh(&unrelated, true));
-    }
+    use crate::types::{Header, SequencedRecord};
 
     fn position(seq_num: u64) -> StreamPosition {
         StreamPosition {

--- a/sdk/src/session/read.rs
+++ b/sdk/src/session/read.rs
@@ -42,6 +42,10 @@ impl ReadSessionFailure {
             Self::HeartbeatTimeout => true,
         }
     }
+
+    fn is_authentication_error(&self) -> bool {
+        matches!(self, Self::Api(error) if error.is_authentication_error())
+    }
 }
 
 /// Errors returned by a read session.
@@ -361,6 +365,7 @@ pub async fn read_session(
     let mut end: ReadEnd = stop.into();
     let retry_policy = config.retry_policy;
     let mut retry_backoff = retry_builder(&client.config.retry).build();
+    let refreshable_auth = client.config.access_token.is_dynamic();
     let baseline_wait = end.wait;
     let mut last_tail_at: Option<Instant> = None;
     let initial_resume_seq_num = if start.clamp == Some(true) {
@@ -385,7 +390,9 @@ pub async fn read_session(
                 break batches;
             }
             Err(err) => {
-                if let Some(backoff) = retry_delay(&err, &mut retry_backoff, retry_policy) {
+                if let Some(backoff) =
+                    retry_delay(&err, &mut retry_backoff, retry_policy, refreshable_auth)
+                {
                     tokio::time::sleep(backoff).await;
                     continue;
                 }
@@ -410,7 +417,12 @@ pub async fn read_session(
                     Ok(b) => batches = Some(b),
                     Err(err) => {
                         if let Some(backoff) =
-                            retry_delay(&err, &mut retry_backoff, retry_policy)
+                            retry_delay(
+                                &err,
+                                &mut retry_backoff,
+                                retry_policy,
+                                refreshable_auth,
+                            )
                         {
                             tokio::time::sleep(backoff).await;
                             continue;
@@ -451,7 +463,12 @@ pub async fn read_session(
                 Some(Err(err)) => {
                     batches = None;
                     if let Some(backoff) =
-                        retry_delay(&err, &mut retry_backoff, retry_policy)
+                        retry_delay(
+                            &err,
+                            &mut retry_backoff,
+                            retry_policy,
+                            refreshable_auth,
+                        )
                     {
                         yield Ok(ReadUpdate::behind());
                         tokio::time::sleep(backoff).await;
@@ -530,8 +547,10 @@ fn retry_delay(
     err: &ReadSessionFailure,
     backoffs: &mut RetryBackoff,
     retry_policy: ReadSessionRetryPolicy,
+    refreshable_auth: bool,
 ) -> Option<Duration> {
-    if !err.is_retryable() {
+    let is_retryable = is_retryable_with_auth_refresh(err, refreshable_auth);
+    if !is_retryable {
         debug!(
             %err,
             is_retryable = false,
@@ -557,7 +576,7 @@ fn retry_delay(
     } else {
         debug!(
             %err,
-            is_retryable = err.is_retryable(),
+            is_retryable,
             retries_exhausted = backoffs.is_exhausted(),
             "not retrying read session"
         );
@@ -565,15 +584,46 @@ fn retry_delay(
     }
 }
 
+fn is_retryable_with_auth_refresh(error: &ReadSessionFailure, refreshable_auth: bool) -> bool {
+    error.is_retryable() || (refreshable_auth && error.is_authentication_error())
+}
+
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
     use futures_util::{StreamExt, poll, stream};
+    use http::StatusCode;
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::UnboundedReceiverStream;
 
     use super::*;
-    use crate::types::{Header, SequencedRecord};
+    use crate::{
+        api::ServerErrorBody,
+        types::{Header, SequencedRecord},
+    };
+
+    #[test]
+    fn authentication_error_is_retryable_only_with_dynamic_credentials() {
+        let error = ReadSessionFailure::Api(ApiError::Server(
+            StatusCode::UNAUTHORIZED,
+            ServerErrorBody {
+                code: "authn".to_owned(),
+                message: "expired".to_owned(),
+            },
+        ));
+
+        assert!(is_retryable_with_auth_refresh(&error, true));
+        assert!(!is_retryable_with_auth_refresh(&error, false));
+
+        let unrelated = ReadSessionFailure::Api(ApiError::Server(
+            StatusCode::UNAUTHORIZED,
+            ServerErrorBody {
+                code: "other".to_owned(),
+                message: "not refreshable".to_owned(),
+            },
+        ));
+        assert!(!is_retryable_with_auth_refresh(&unrelated, true));
+    }
 
     fn position(seq_num: u64) -> StreamPosition {
         StreamPosition {

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -119,12 +119,29 @@ pub(crate) enum AccessToken {
     Provider(Arc<dyn AccessTokenProvider>),
 }
 
-impl AccessToken {
-    pub(crate) fn is_dynamic(&self) -> bool {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AccessTokenMode {
+    Static,
+    #[cfg(feature = "_hidden")]
+    Refreshable,
+}
+
+impl AccessTokenMode {
+    pub(crate) fn is_refreshable(self) -> bool {
         match self {
-            Self::Static(_) => false,
+            Self::Static => false,
             #[cfg(feature = "_hidden")]
-            Self::Provider(_) => true,
+            Self::Refreshable => true,
+        }
+    }
+}
+
+impl AccessToken {
+    pub(crate) fn mode(&self) -> AccessTokenMode {
+        match self {
+            Self::Static(_) => AccessTokenMode::Static,
+            #[cfg(feature = "_hidden")]
+            Self::Provider(_) => AccessTokenMode::Refreshable,
         }
     }
 }

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -12,6 +12,8 @@ use std::{
     time::Duration,
 };
 
+#[cfg(feature = "_hidden")]
+use async_trait::async_trait;
 use bytes::Bytes;
 use http::{
     header::HeaderValue,
@@ -66,6 +68,76 @@ use s2_common::{
 use secrecy::SecretString;
 
 use crate::error::RequestError;
+
+#[cfg(feature = "_hidden")]
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{message}")]
+#[doc(hidden)]
+pub struct AccessTokenProviderError {
+    message: String,
+    retryable: bool,
+}
+
+#[cfg(feature = "_hidden")]
+impl AccessTokenProviderError {
+    /// Create a provider error that should be retried with normal SDK backoff.
+    pub fn transient(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            retryable: true,
+        }
+    }
+
+    /// Create a provider error that should be returned immediately.
+    pub fn permanent(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            retryable: false,
+        }
+    }
+
+    pub(crate) fn is_retryable(&self) -> bool {
+        self.retryable
+    }
+}
+
+#[cfg(feature = "_hidden")]
+#[async_trait]
+#[doc(hidden)]
+pub trait AccessTokenProvider: fmt::Debug + Send + Sync {
+    /// Return an access token for the next request attempt.
+    async fn access_token(&self) -> Result<String, AccessTokenProviderError>;
+
+    /// Notify the provider that S2 rejected an access token.
+    fn invalidate_access_token(&self, _rejected_access_token: &str) {}
+}
+
+#[derive(Clone)]
+pub(crate) enum AccessToken {
+    Static(SecretString),
+    #[cfg(feature = "_hidden")]
+    Provider(Arc<dyn AccessTokenProvider>),
+}
+
+impl AccessToken {
+    pub(crate) fn is_dynamic(&self) -> bool {
+        match self {
+            Self::Static(_) => false,
+            #[cfg(feature = "_hidden")]
+            Self::Provider(_) => true,
+        }
+    }
+}
+
+impl fmt::Debug for AccessToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Static(_) => formatter.write_str("Static(<redacted>)"),
+            #[cfg(feature = "_hidden")]
+            Self::Provider(_) => formatter.write_str("Provider(<redacted>)"),
+        }
+    }
+}
 
 /// An RFC 3339 datetime.
 ///
@@ -413,7 +485,7 @@ impl RetryConfig {
 #[non_exhaustive]
 /// Configuration for [`S2`](crate::S2).
 pub struct S2Config {
-    pub(crate) access_token: SecretString,
+    pub(crate) access_token: AccessToken,
     pub(crate) endpoints: S2Endpoints,
     pub(crate) connection_timeout: Duration,
     pub(crate) request_timeout: Duration,
@@ -428,7 +500,7 @@ impl S2Config {
     /// Create a new [`S2Config`] with the given access token and default settings.
     pub fn new(access_token: impl Into<String>) -> Self {
         Self {
-            access_token: access_token.into().into(),
+            access_token: AccessToken::Static(access_token.into().into()),
             endpoints: S2Endpoints::for_cloud(),
             connection_timeout: Duration::from_secs(3),
             request_timeout: Duration::from_secs(5),
@@ -439,6 +511,15 @@ impl S2Config {
                 .expect("valid user agent"),
             insecure_skip_cert_verification: false,
             rustls_crypto_provider: default_rustls_crypto_provider(),
+        }
+    }
+
+    #[cfg(feature = "_hidden")]
+    #[doc(hidden)]
+    pub fn with_access_token_provider(self, provider: impl AccessTokenProvider + 'static) -> Self {
+        Self {
+            access_token: AccessToken::Provider(Arc::new(provider)),
+            ..self
         }
     }
 


### PR DESCRIPTION
## Summary

- add an internal, feature-gated access token provider to the SDK
- resolve and mark bearer credentials as sensitive for each request attempt
- invalidate the exact credential rejected by an S2 `401/authn` response and retry within the existing retry budget
- reconnect read and append sessions with refreshed credentials while preserving their existing resume and append retry policies
- preserve the existing static access-token API and behavior

## Why

The SDK currently installs one bearer token when a client is constructed. Browser OAuth access tokens expire, but request retries and streaming reconnects are owned by the SDK. This change introduces a small internal callback so the CLI can supply a current opaque bearer token without teaching the SDK about OAuth, Clerk, JWTs, expiration, or refresh tokens.

The provider API is behind the existing `_hidden` feature and marked `#[doc(hidden)]`; it is not part of the supported public SDK surface.

## Safety

- refresh is triggered only for `401` responses whose S2 error code is exactly `authn`
- invalidation includes the exact rejected token, avoiding stale responses invalidating newer credentials
- provider retries remain bounded by the existing SDK retry configuration
- append retries continue to respect `AppendRetryPolicy`
- authorization headers and credential debug output are redacted
- transient provider failures are retryable; permanent failures return immediately

## Validation

- `just fmt`
- `cargo clippy --locked -p s2-sdk --lib --features _hidden -- -D warnings --allow deprecated`
- `cargo nextest run --locked -p s2-sdk --all-features -E 'not (binary(account_ops) or binary(basin_ops) or binary(metrics_ops) or binary(stream_ops))'` — 109 passed
- `cargo test --locked -p s2-sdk --lib` — 106 passed on the normal static-token build
- `cargo check --locked -p s2-cli`

The repository-wide `just clippy` / `just test -p s2-sdk` wrappers currently hit an unrelated nightly compiler ICE while compiling `cli/tests/integration.rs:51`. Live SDK integration tests were not run because they require `S2_ACCESS_TOKEN`.