### PR TITLE
fix(cli): clarify access token migration output

### DIFF
--- a/cli/src/access_token.rs
+++ b/cli/src/access_token.rs
@@ -216,7 +216,11 @@ pub async fn migrate(args: &AuthAccessTokenMigrateArgs) -> Result<TokenChange, A
     }
 
     validate_token(&token)?;
-    store_with_config(config, token.into(), requested_store(args.insecure_storage))
+    let mut change =
+        store_with_config(config, token.into(), requested_store(args.insecure_storage))?;
+    // Migration moves the existing token; it does not replace it with another token.
+    change.replaced = false;
+    Ok(change)
 }
 
 pub async fn remove() -> Result<TokenRemoval, AccessTokenError> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -109,41 +109,44 @@ fn print_legacy_access_token_deprecation(config: &config::CliConfig) {
 fn print_token_change(message: &str, change: &access_token::TokenChange) {
     eprintln!("{}", format!("✓ {message}").green().bold());
     if change.replaced {
-        eprintln!("  Previous access token replaced.");
+        eprintln!("  - Previous access token replaced.");
     }
     match change.credential_store {
         CredentialStore::Keyring => {
-            eprintln!("  Access token saved to: {}", "OS credential store".cyan());
+            eprintln!(
+                "  - Access token saved to: {}",
+                "OS credential store".cyan()
+            );
         }
         CredentialStore::File => {
             #[cfg(unix)]
             eprintln!(
                 "{}",
-                "  Warning: the access token is stored in a plaintext file with user-only permissions."
+                "  - Warning: the access token is stored in a plaintext file with user-only permissions."
                     .yellow()
             );
             #[cfg(not(unix))]
             eprintln!(
                 "{}",
-                "  Warning: the access token is stored in a plaintext file using the platform's default user-directory permissions."
+                "  - Warning: the access token is stored in a plaintext file using the platform's default user-directory permissions."
                     .yellow()
             );
             if let Some(path) = change.credential_path.as_ref() {
                 eprintln!(
-                    "  Access token saved to: {}",
+                    "  - Access token saved to: {}",
                     path.display().to_string().cyan()
                 );
             }
         }
     }
     eprintln!(
-        "  Configuration saved to: {}",
+        "  - Configuration saved to: {}",
         change.config_path.display().to_string().cyan()
     );
     if let Some(error) = change.cleanup_warning.as_ref() {
         eprintln!(
             "{}",
-            format!("  Warning: an older local credential remains queued for cleanup: {error}")
+            format!("  - Warning: an older local credential remains queued for cleanup: {error}")
                 .yellow()
         );
     }
@@ -154,7 +157,7 @@ fn print_token_change(message: &str, change: &access_token::TokenChange) {
     {
         eprintln!(
             "{}",
-            "  Warning: S2_ACCESS_TOKEN is set and takes precedence over stored credentials."
+            "  - Warning: S2_ACCESS_TOKEN is set and takes precedence over stored credentials."
                 .yellow()
         );
     }
@@ -163,20 +166,20 @@ fn print_token_change(message: &str, change: &access_token::TokenChange) {
 fn print_token_removal(removal: access_token::TokenRemoval) {
     if removal.removed {
         eprintln!("{}", "✓ Access token removed".green().bold());
-        eprintln!("{}", "  This does not revoke the access token.".yellow());
+        eprintln!("{}", "  - This does not revoke the access token.".yellow());
     } else {
         eprintln!("{}", "✓ No access token to remove".green().bold());
     }
     if let Some(path) = removal.config_path {
         eprintln!(
-            "  Configuration saved to: {}",
+            "  - Configuration saved to: {}",
             path.display().to_string().cyan()
         );
     }
     if let Some(error) = removal.cleanup_warning {
         eprintln!(
             "{}",
-            format!("  Warning: an older local credential remains queued for cleanup: {error}")
+            format!("  - Warning: an older local credential remains queued for cleanup: {error}")
                 .yellow()
         );
     }
@@ -187,7 +190,7 @@ fn print_token_removal(removal: access_token::TokenRemoval) {
     {
         eprintln!(
             "{}",
-            "  Warning: S2_ACCESS_TOKEN remains set and is still active.".yellow()
+            "  - Warning: S2_ACCESS_TOKEN remains set and is still active.".yellow()
         );
     }
 }

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -218,6 +218,9 @@ fn legacy_plaintext_access_token_can_be_migrated_to_a_private_file() {
         .success()
         .stderr(
             predicate::str::contains("Legacy access token migrated")
+                .and(predicate::str::contains("  - Access token saved to:"))
+                .and(predicate::str::contains("  - Configuration saved to:"))
+                .and(predicate::str::contains("Previous access token replaced").not())
                 .and(predicate::str::contains("legacy-secret").not()),
         );
 


### PR DESCRIPTION
## What changed

- stop reporting that migration replaced an access token
- format access-token command details as indented list items
- keep warnings and credential locations consistent with the new output style

## Why

Migration moves the existing plaintext token into credential storage; it does not replace it with a different token. The previous output was therefore misleading. List markers also make multi-line command results easier to scan.

## User impact

`s2 auth access-token migrate` now reports only the migration and its destinations. Other access-token mutation commands use the same compact list formatting for supporting details.

## Validation

- `just fmt`
- `cargo test -p s2-cli --test cli legacy_plaintext_access_token_can_be_migrated_to_a_private_file`
