### PR TITLE
feat(cli): improve authentication UX

### DIFF
--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -1,0 +1,254 @@
+use std::process::ExitCode;
+
+use colored::Colorize as _;
+use s2_sdk::{S2, error::ErrorCode, types::ListBasinsInput};
+
+use crate::{
+    config::{CliConfig, CredentialStore, DEFAULT_ACCOUNT_ENDPOINT, sdk_config},
+    error::{CliConfigError, CliError, TokenSource},
+    login::{LoginError, effective_endpoints, resolve_access_token, uses_loopback_endpoints},
+    update,
+};
+
+pub async fn status() -> Result<ExitCode, CliError> {
+    let (config, credential) = match resolve_access_token().await {
+        Ok(resolved) => resolved,
+        Err(LoginError::Config(CliConfigError::MissingAccessToken)) => {
+            let config = crate::config::load_cli_config()?;
+            print_heading(&config);
+            eprintln!("  {}", "✗ Not logged in".red().bold());
+            eprintln!("  - Run `s2 login`.");
+            print_configured_credentials(&config, None);
+            return Ok(ExitCode::FAILURE);
+        }
+        Err(error) => {
+            let config = crate::config::load_cli_config()?;
+            print_heading(&config);
+            print_unverified(&configured_credential_label(&config), &error);
+            print_configured_credentials(&config, configured_source(&config));
+            return Ok(ExitCode::FAILURE);
+        }
+    };
+
+    print_heading(&config);
+    let label = credential_label(&config, credential.source());
+    if let Err(error) = credential.validate_destination(&config) {
+        print_unverified(&label, &error);
+        print_configured_credentials(&config, Some(credential.source()));
+        return Ok(ExitCode::FAILURE);
+    }
+
+    let sdk = match sdk_config(&config, credential.access_token(), update::user_agent()) {
+        Ok(sdk) => credential.configure_sdk(sdk),
+        Err(error) => {
+            print_unverified(&label, &error);
+            print_configured_credentials(&config, Some(credential.source()));
+            return Ok(ExitCode::FAILURE);
+        }
+    };
+    let s2 = match S2::new(sdk) {
+        Ok(s2) => s2,
+        Err(error) => {
+            print_unverified(&label, &error);
+            print_configured_credentials(&config, Some(credential.source()));
+            return Ok(ExitCode::FAILURE);
+        }
+    };
+    let result = s2.list_basins(ListBasinsInput::new().with_limit(1)).await;
+
+    let exit_code = match result {
+        Ok(_) => {
+            if uses_loopback_endpoints(&config) {
+                print_local_connection();
+            } else {
+                print_authenticated(&label);
+            }
+            ExitCode::SUCCESS
+        }
+        Err(error)
+            if error.server_error().and_then(|error| error.known_code())
+                == Some(ErrorCode::PermissionDenied) =>
+        {
+            // The server authenticated the credential before denying this probe.
+            print_authenticated(&label);
+            ExitCode::SUCCESS
+        }
+        Err(error)
+            if matches!(
+                error.server_error().and_then(|error| error.known_code()),
+                Some(ErrorCode::Authn | ErrorCode::AccessTokenNotFound)
+            ) =>
+        {
+            eprintln!(
+                "  {}",
+                format!("✗ Authentication failed for {label}").red().bold()
+            );
+            eprintln!("  - {}", recovery_command(credential.source()));
+            ExitCode::FAILURE
+        }
+        Err(error) => {
+            print_unverified(&label, &error);
+            ExitCode::FAILURE
+        }
+    };
+
+    print_configured_credentials(&config, Some(credential.source()));
+    Ok(exit_code)
+}
+
+fn print_authenticated(label: &str) {
+    eprintln!("  {}", format!("✓ Logged in with {label}").green().bold());
+}
+
+fn print_local_connection() {
+    eprintln!("  {}", "✓ Connected to local S2 endpoint".green().bold());
+    eprintln!("  - Credentials are not verified for local endpoints.");
+}
+
+fn print_unverified(label: &str, error: &impl std::fmt::Display) {
+    eprintln!(
+        "  {}",
+        format!("! Could not verify {label}").yellow().bold()
+    );
+    eprintln!("  - {error}");
+}
+
+fn print_heading(config: &CliConfig) {
+    let (account_endpoint, _) = effective_endpoints(config);
+    let heading = if account_endpoint == DEFAULT_ACCOUNT_ENDPOINT {
+        "s2.dev".to_owned()
+    } else {
+        reqwest::Url::parse(&account_endpoint)
+            .ok()
+            .and_then(|url| {
+                let host = url.host_str()?;
+                Some(match url.port() {
+                    Some(port) => format!("{host}:{port}"),
+                    None => host.to_owned(),
+                })
+            })
+            .unwrap_or_else(|| account_endpoint.clone())
+    };
+    eprintln!("{}", heading.bold());
+}
+
+fn configured_credential_label(config: &CliConfig) -> String {
+    configured_source(config).map_or_else(
+        || "authentication".to_owned(),
+        |source| credential_label(config, source),
+    )
+}
+
+fn configured_source(config: &CliConfig) -> Option<TokenSource> {
+    if std::env::var_os("S2_ACCESS_TOKEN").is_some_and(|value| !value.is_empty()) {
+        return Some(TokenSource::Environment);
+    }
+    match config.auth_method {
+        Some(crate::config::AuthMethod::BrowserLogin) if config.oauth.is_some() => {
+            Some(TokenSource::BrowserLogin)
+        }
+        Some(crate::config::AuthMethod::AccessToken) if config.has_stored_access_token() => {
+            Some(stored_access_token_source(config))
+        }
+        Some(_) => None,
+        None if config.has_stored_access_token() => Some(stored_access_token_source(config)),
+        None if config.oauth.is_some() => Some(TokenSource::BrowserLogin),
+        None => None,
+    }
+}
+
+fn stored_access_token_source(config: &CliConfig) -> TokenSource {
+    if config.stored_access_token.is_some() {
+        TokenSource::StoredAccessToken
+    } else {
+        TokenSource::ConfigFile
+    }
+}
+
+fn credential_label(config: &CliConfig, source: TokenSource) -> String {
+    match source {
+        TokenSource::Environment => "S2_ACCESS_TOKEN".to_owned(),
+        TokenSource::BrowserLogin => browser_login_label(config),
+        TokenSource::StoredAccessToken | TokenSource::ConfigFile => access_token_label(config),
+    }
+}
+
+fn browser_login_label(config: &CliConfig) -> String {
+    let storage = config
+        .oauth
+        .as_ref()
+        .map(|session| storage_label(session.credential_store));
+    storage.map_or_else(
+        || "browser login".to_owned(),
+        |storage| format!("browser login ({storage})"),
+    )
+}
+
+fn access_token_label(config: &CliConfig) -> String {
+    if let Some(reference) = config.stored_access_token.as_ref() {
+        format!(
+            "access token ({})",
+            storage_label(reference.credential_store)
+        )
+    } else if config.has_legacy_access_token() {
+        "access token (config.toml)".to_owned()
+    } else {
+        "access token".to_owned()
+    }
+}
+
+fn storage_label(store: CredentialStore) -> &'static str {
+    match store {
+        CredentialStore::Keyring => "keyring",
+        CredentialStore::File => "private file",
+    }
+}
+
+fn print_configured_credentials(config: &CliConfig, active: Option<TokenSource>) {
+    let browser_active = matches!(active, Some(TokenSource::BrowserLogin));
+    let access_token_active = matches!(
+        active,
+        Some(TokenSource::StoredAccessToken | TokenSource::ConfigFile)
+    );
+
+    if !browser_active && config.oauth.is_some() {
+        eprintln!("  - Also configured: {}", browser_login_label(config));
+    }
+
+    if !access_token_active && config.has_stored_access_token() {
+        eprintln!("  - Also configured: {}", access_token_label(config));
+    }
+
+    if config.has_legacy_access_token() {
+        eprintln!(
+            "{}",
+            "  ! The access token is stored in plaintext in config.toml.\n    Run `s2 auth access-token migrate` to secure it."
+                .yellow()
+        );
+    }
+
+    let has_file_storage = config
+        .oauth
+        .as_ref()
+        .is_some_and(|session| session.credential_store == CredentialStore::File)
+        || config
+            .stored_access_token
+            .as_ref()
+            .is_some_and(|reference| reference.credential_store == CredentialStore::File);
+    if has_file_storage {
+        eprintln!(
+            "{}",
+            "  ! Credentials are stored in a private plaintext file.".yellow()
+        );
+    }
+}
+
+fn recovery_command(source: TokenSource) -> &'static str {
+    match source {
+        TokenSource::BrowserLogin => "Run `s2 login` again.",
+        TokenSource::Environment => "Set S2_ACCESS_TOKEN to a valid access token.",
+        TokenSource::StoredAccessToken | TokenSource::ConfigFile => {
+            "Run `s2 auth access-token set` to replace it."
+        }
+    }
+}

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -238,6 +238,15 @@ pub struct UpdateArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum AuthCommand {
+    /// Log in to S2 through your browser.
+    Login(LoginArgs),
+
+    /// Log out of the browser-authenticated S2 session.
+    Logout(LogoutArgs),
+
+    /// Show the active authentication method and verify it with S2.
+    Status,
+
     /// Switch authentication methods without deleting either credential.
     Use {
         /// Authentication method to select.

--- a/cli/src/credential_store.rs
+++ b/cli/src/credential_store.rs
@@ -1,5 +1,7 @@
+#[cfg(unix)]
+use std::fs::File;
 use std::{
-    fs::{self, File},
+    fs,
     io::Write as _,
     path::{Path, PathBuf},
 };
@@ -58,6 +60,7 @@ pub enum CredentialStoreError {
     #[error("Invalid credential path")]
     InvalidPath,
 
+    #[cfg(unix)]
     #[error("The private credential file is not safely protected: {0}")]
     #[diagnostic(help(
         "Restrict the credential directory to the current user and the file to mode 0600, or remove it and authenticate again."

--- a/cli/src/login.rs
+++ b/cli/src/login.rs
@@ -46,7 +46,8 @@ use crate::{
 
 mod destination;
 
-use destination::{effective_endpoints, validate_endpoint_binding};
+use destination::validate_endpoint_binding;
+pub(crate) use destination::{effective_endpoints, uses_loopback_endpoints};
 
 const DEFAULT_OAUTH_ISSUER: &str = "https://clerk.s2.dev";
 const DEFAULT_OAUTH_CLIENT_ID: &str = "9zTKDS3tHSmaWl33";
@@ -192,6 +193,7 @@ pub enum LoginError {
         revocation: Box<LoginError>,
     },
 
+    #[cfg(unix)]
     #[error("Failed to {action} the OAuth credentials file")]
     CredentialFile {
         action: &'static str,
@@ -229,7 +231,12 @@ impl LoginError {
                         StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_MANY_REQUESTS
                     )
             }
-            Self::CredentialFile { source, .. } | Self::RefreshLock(source) => matches!(
+            #[cfg(unix)]
+            Self::CredentialFile { source, .. } => matches!(
+                source.kind(),
+                std::io::ErrorKind::Interrupted | std::io::ErrorKind::WouldBlock
+            ),
+            Self::RefreshLock(source) => matches!(
                 source.kind(),
                 std::io::ErrorKind::Interrupted | std::io::ErrorKind::WouldBlock
             ),

--- a/cli/src/login/destination.rs
+++ b/cli/src/login/destination.rs
@@ -10,7 +10,7 @@ fn is_production_issuer(issuer: &str) -> bool {
     }
 }
 
-pub(super) fn effective_endpoints(config: &CliConfig) -> (String, String) {
+pub(crate) fn effective_endpoints(config: &CliConfig) -> (String, String) {
     match (&config.account_endpoint, &config.basin_endpoint) {
         (Some(account), Some(basin)) => (normalize_endpoint(account), normalize_endpoint(basin)),
         // The SDK ignores an incomplete custom-endpoint pair and uses its defaults.
@@ -19,6 +19,11 @@ pub(super) fn effective_endpoints(config: &CliConfig) -> (String, String) {
             DEFAULT_BASIN_ENDPOINT.to_owned(),
         ),
     }
+}
+
+pub(crate) fn uses_loopback_endpoints(config: &CliConfig) -> bool {
+    let (account, basin) = effective_endpoints(config);
+    endpoint_environment(&account, &basin) == Some(EndpointEnvironment::Loopback)
 }
 
 fn normalize_endpoint(endpoint: &str) -> String {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,6 +2,7 @@
 
 mod access_token;
 mod apply;
+mod auth;
 mod bench;
 mod cli;
 mod config;
@@ -96,7 +97,15 @@ fn parse_cli() -> Cli {
 fn allows_passive_update_check(command: Option<&Command>) -> bool {
     !matches!(
         command,
-        Some(Command::Lite(_) | Command::Login(_) | Command::Logout(_) | Command::Update(_))
+        Some(
+            Command::Lite(_)
+                | Command::Login(_)
+                | Command::Logout(_)
+                | Command::Auth(
+                    AuthCommand::Login(_) | AuthCommand::Logout(_) | AuthCommand::Status,
+                )
+                | Command::Update(_)
+        )
     )
 }
 
@@ -239,6 +248,9 @@ async fn run(cli: Cli) -> Result<ExitCode, CliError> {
 
     if let Command::Auth(auth_cmd) = &command {
         match auth_cmd {
+            AuthCommand::Login(args) => login::login(args).await?,
+            AuthCommand::Logout(args) => login::logout(args).await?,
+            AuthCommand::Status => return auth::status().await,
             AuthCommand::Use { method } => {
                 let saved_path = select_auth_method(*method).await?;
                 let message = match method {

--- a/cli/src/update/apply.rs
+++ b/cli/src/update/apply.rs
@@ -55,6 +55,7 @@ pub enum UpdateError {
     Archive(String),
     #[error("release archive did not contain {0}")]
     BinaryNotInArchive(String),
+    #[cfg(not(windows))]
     #[error(
         "could not replace {path}: {source}\n\
          (need write access to its directory; re-run with sufficient permissions)"


### PR DESCRIPTION
## Summary

- add `s2 auth login` and `s2 auth logout` while retaining the existing top-level commands
- add a concise, GitHub-style `s2 auth status` that verifies the active credential without exposing user or organization IDs
- report inactive configured credentials and actionable warnings for plaintext storage
- return script-friendly success or failure exit codes
- target-gate platform-specific code to eliminate Windows release warnings

## Behavior

- preserves the existing credential precedence, including `S2_ACCESS_TOKEN`
- verifies authentication with a read-only, one-item basin-list probe
- treats permission denial as authenticated, because the server validated the credential before authorization
- distinguishes invalid credentials from connectivity or configuration failures
- avoids JSON mode and keeps passive update notices out of auth command output

## Validation

- `just fmt`
- `cargo +stable clippy -p s2-cli --all-features --all-targets -- -D warnings --allow deprecated`
- `cargo +stable sort --workspace --check`
- 744 tests passed with stable nextest
- manually verified no-login, unavailable-keyring, environment-token, alias help, and local S2 Lite flows