### PR TITLE
feat(sdk): add durable producer flush

### DIFF
--- a/sdk/examples/docs_streams.rs
+++ b/sdk/examples/docs_streams.rs
@@ -94,6 +94,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Submit individual records
     let ticket = producer.submit(AppendRecord::new("my event")?).await?;
 
+    // Force the partial batch and wait for durability without closing the producer
+    producer.flush().await?;
+
     // Get the exact sequence number
     let ack = ticket.await?;
     println!("Record durable at seqNum {}", ack.seq_num);

--- a/sdk/examples/producer.rs
+++ b/sdk/examples/producer.rs
@@ -23,6 +23,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ticket1 = producer.submit(AppendRecord::new("lorem")?).await?;
     let ticket2 = producer.submit(AppendRecord::new("ipsum")?).await?;
 
+    producer.flush().await?;
+
     let ack1 = ticket1.await?;
     let ack2 = ticket2.await?;
     println!("Record 1 seq_num: {}", ack1.seq_num);

--- a/sdk/src/producer.rs
+++ b/sdk/src/producer.rs
@@ -182,8 +182,8 @@ impl Producer {
     /// For explicit control, use [`reserve`](Self::reserve) followed by
     /// [`RecordSubmitPermit::submit`].
     ///
-    /// **Note**: After all submits, you must call [`close`](Self::close) to ensure all records are
-    /// appended.
+    /// Use [`flush`](Self::flush) to establish a non-terminal durability boundary, and call
+    /// [`close`](Self::close) when finished to flush remaining records and release resources.
     pub async fn submit(&self, record: AppendRecord) -> Result<RecordSubmitTicket, ProducerError> {
         let permit = self.reserve(record.metered_bytes() as u32).await?;
         Ok(permit.submit(record))
@@ -196,8 +196,8 @@ impl Producer {
     /// Waits when the unacknowledged bytes limit is reached, providing explicit backpressure
     /// control. The returned permit must be used to submit the record.
     ///
-    /// **Note**: After all submits, you must call [`close`](Self::close) to ensure all records are
-    /// appended.
+    /// Reserving capacity does not order a record relative to [`flush`](Self::flush); the record is
+    /// ordered when [`RecordSubmitPermit::submit`] is called.
     ///
     /// # Cancel safety
     ///
@@ -218,6 +218,24 @@ impl Producer {
             cmd_tx_permit,
             terminal_err: self.terminal_err.clone(),
         })
+    }
+
+    /// Flush all records ordered before this call and wait for them to become durable.
+    ///
+    /// This immediately emits the current partial batch without waiting for the configured linger
+    /// duration. The producer remains open and can be used for subsequent submissions and flushes.
+    /// If there is no preceding work, this completes without submitting an empty batch.
+    ///
+    /// A record whose [`submit`](Self::submit) call completed before this method began is covered
+    /// by the flush. Submissions concurrent with the flush may be ordered on either side of the
+    /// boundary; records ordered after it are not included in the durability wait.
+    pub async fn flush(&self) -> Result<(), ProducerError> {
+        let (done_tx, done_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::Flush { done_tx })
+            .await
+            .map_err(|_| self.terminal_err())?;
+        done_rx.await.map_err(|_| self.terminal_err())?
     }
 
     /// Close the producer and wait for all submitted records to be appended.
@@ -243,22 +261,12 @@ impl Producer {
         mut cmd_rx: mpsc::Receiver<Command>,
         terminal_err: Arc<OnceLock<ProducerError>>,
     ) {
-        let (record_tx, record_rx) = mpsc::channel::<AppendRecord>(RECORD_BATCH_MAX.count);
+        let (record_tx, mut inputs) = Self::batcher(&config, config.match_seq_num);
         let mut record_tx = Some(record_tx);
-        let mut inputs = AppendInputs::new(AppendRecordBatches::from_stream(
-            ReceiverStream::new(record_rx),
-            config.batching,
-        ));
-        if let Some(fencing_token) = config.fencing_token {
-            inputs = inputs.with_fencing_token(fencing_token);
-        }
-        if let Some(seq_num) = config.match_seq_num {
-            inputs = inputs.with_match_seq_num(seq_num);
-        }
 
         let mut pending_batch_acks = FuturesUnordered::new();
         let mut pending_record_acks = VecDeque::new();
-        let mut close_tx: Option<oneshot::Sender<Result<(), ProducerError>>> = None;
+        let mut control = PendingControl::default();
         let mut stashed_submission: Option<StashedSubmission> = None;
         let mut submit_fut: Option<SubmitFuture> = None;
         let mut submit_batch_len: Option<usize> = None;
@@ -285,10 +293,10 @@ impl Producer {
                         .send(submission.record);
                 }
 
-                cmd = cmd_rx.recv(), if stashed_submission.is_none() => {
+                cmd = cmd_rx.recv(), if stashed_submission.is_none() && control.flush_tx.is_none() => {
                     match cmd {
                         Some(Command::Submit { record, ack_tx, permit }) => {
-                            if close_tx.is_some() {
+                            if control.close_tx.is_some() {
                                 let _ = ack_tx.send(
                                     Err(ProducerError::ProducerClosing)
                                 );
@@ -297,12 +305,26 @@ impl Producer {
                             }
                         }
                         Some(Command::Close { done_tx }) => {
-                            close_tx = Some(done_tx);
+                            control.close_tx = Some(done_tx);
+                        }
+                        Some(Command::Flush { done_tx }) => {
+                            if control.close_tx.is_some() {
+                                let _ = done_tx.send(Err(ProducerError::ProducerClosing));
+                            } else {
+                                control.flush_tx = Some(done_tx);
+                            }
                         }
                         None => {
-                            for pending in pending_record_acks.drain(..) {
-                                let _ = pending.ack_tx.send(Err(ProducerError::ProducerDropped));
-                            }
+                            terminate_producer(
+                                ProducerError::ProducerDropped,
+                                &terminal_err,
+                                &mut pending_batch_acks,
+                                &mut pending_record_acks,
+                                &mut stashed_submission,
+                                &mut control,
+                                &mut cmd_rx,
+                            )
+                            .await;
                             return;
                         }
                     }
@@ -321,7 +343,7 @@ impl Producer {
                                 &mut pending_batch_acks,
                                 &mut pending_record_acks,
                                 &mut stashed_submission,
-                                &mut close_tx,
+                                &mut control,
                                 &mut cmd_rx,
                             )
                             .await;
@@ -359,7 +381,7 @@ impl Producer {
                                 &mut pending_batch_acks,
                                 &mut pending_record_acks,
                                 &mut stashed_submission,
-                                &mut close_tx,
+                                &mut control,
                                 &mut cmd_rx,
                             )
                             .await;
@@ -368,16 +390,49 @@ impl Producer {
                     }
                 }
 
-                Some((batch_ack, pending_record_acks)) = pending_batch_acks.next() => {
-                    dispatch_acks(batch_ack, pending_record_acks);
+                Some((batch_ack, batch_record_acks)) = pending_batch_acks.next() => {
+                    let terminal_batch_err = batch_ack.as_ref().err().cloned();
+                    dispatch_acks(batch_ack, batch_record_acks);
+                    if let Some(err) = terminal_batch_err {
+                        terminate_producer(
+                            err,
+                            &terminal_err,
+                            &mut pending_batch_acks,
+                            &mut pending_record_acks,
+                            &mut stashed_submission,
+                            &mut control,
+                            &mut cmd_rx,
+                        )
+                        .await;
+                        return;
+                    }
                 }
             }
 
-            if close_tx.is_some() && record_tx.is_some() {
+            if (control.flush_tx.is_some() || control.close_tx.is_some()) && record_tx.is_some() {
                 record_tx = None;
             }
 
-            if close_tx.is_some()
+            if control.flush_tx.is_some()
+                && inputs_exhausted
+                && pending_record_acks.is_empty()
+                && pending_batch_acks.is_empty()
+                && stashed_submission.is_none()
+                && submit_fut.is_none()
+            {
+                let next_match_seq_num = inputs.match_seq_num;
+                let (next_record_tx, next_inputs) = Self::batcher(&config, next_match_seq_num);
+                record_tx = Some(next_record_tx);
+                inputs = next_inputs;
+                inputs_exhausted = false;
+
+                if let Some(done_tx) = control.flush_tx.take() {
+                    let _ = done_tx.send(Ok(()));
+                }
+            }
+
+            if control.close_tx.is_some()
+                && control.flush_tx.is_none()
                 && pending_record_acks.is_empty()
                 && pending_batch_acks.is_empty()
                 && stashed_submission.is_none()
@@ -389,9 +444,27 @@ impl Producer {
 
         let session_close_res = session.close().await;
 
-        if let Some(done_tx) = close_tx.take() {
+        if let Some(done_tx) = control.close_tx.take() {
             let _ = done_tx.send(session_close_res.map_err(Into::into));
         }
+    }
+
+    fn batcher(
+        config: &ProducerConfig,
+        match_seq_num: Option<u64>,
+    ) -> (mpsc::Sender<AppendRecord>, AppendInputs) {
+        let (record_tx, record_rx) = mpsc::channel(RECORD_BATCH_MAX.count);
+        let mut inputs = AppendInputs::new(AppendRecordBatches::from_stream(
+            ReceiverStream::new(record_rx),
+            config.batching.clone(),
+        ));
+        if let Some(fencing_token) = config.fencing_token.as_ref() {
+            inputs = inputs.with_fencing_token(fencing_token.clone());
+        }
+        if let Some(seq_num) = match_seq_num {
+            inputs = inputs.with_match_seq_num(seq_num);
+        }
+        (record_tx, inputs)
     }
 }
 
@@ -426,6 +499,9 @@ enum Command {
         ack_tx: oneshot::Sender<Result<IndexedAppendAck, ProducerError>>,
         permit: AppendPermit,
     },
+    Flush {
+        done_tx: oneshot::Sender<Result<(), ProducerError>>,
+    },
     Close {
         done_tx: oneshot::Sender<Result<(), ProducerError>>,
     },
@@ -436,6 +512,9 @@ impl Command {
         match self {
             Command::Submit { ack_tx, .. } => {
                 let _ = ack_tx.send(Err(err));
+            }
+            Command::Flush { done_tx } => {
+                let _ = done_tx.send(Err(err));
             }
             Command::Close { done_tx } => {
                 let _ = done_tx.send(Err(err));
@@ -448,6 +527,12 @@ struct StashedSubmission {
     record: AppendRecord,
     ack_tx: oneshot::Sender<Result<IndexedAppendAck, ProducerError>>,
     permit: AppendPermit,
+}
+
+#[derive(Default)]
+struct PendingControl {
+    flush_tx: Option<oneshot::Sender<Result<(), ProducerError>>>,
+    close_tx: Option<oneshot::Sender<Result<(), ProducerError>>>,
 }
 
 struct PendingRecordAck {
@@ -504,7 +589,7 @@ async fn terminate_producer(
     pending_batch_acks: &mut FuturesUnordered<PendingBatchAck>,
     pending_record_acks: &mut VecDeque<PendingRecordAck>,
     stashed_submission: &mut Option<StashedSubmission>,
-    close_tx: &mut Option<oneshot::Sender<Result<(), ProducerError>>>,
+    control: &mut PendingControl,
     cmd_rx: &mut mpsc::Receiver<Command>,
 ) {
     while let Some((batch_ack, pending_record_acks)) =
@@ -520,7 +605,10 @@ async fn terminate_producer(
     if let Some(submission) = stashed_submission.take() {
         let _ = submission.ack_tx.send(Err(err.clone()));
     }
-    if let Some(done_tx) = close_tx.take() {
+    if let Some(done_tx) = control.flush_tx.take() {
+        let _ = done_tx.send(Err(err.clone()));
+    }
+    if let Some(done_tx) = control.close_tx.take() {
         let _ = done_tx.send(Err(err.clone()));
     }
     cmd_rx.close();

--- a/sdk/tests/stream_ops.rs
+++ b/sdk/tests/stream_ops.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use assert_matches::assert_matches;
 use common::{S2Stream, SharedS2Basin, s2_config, unique_basin_name, unique_stream_name};
-use futures_util::StreamExt;
+use futures_util::{StreamExt, poll};
 use rstest::rstest;
 use s2_sdk::{
     append_session::AppendSessionConfig,
@@ -1660,6 +1660,181 @@ async fn producer_delivers_all_acks(stream: &S2Stream) -> Result<(), Box<dyn std
     assert_eq!(ack1.seq_num, 0);
     assert_eq!(ack2.seq_num, 1);
     assert_eq!(ack3.seq_num, 2);
+
+    Ok(())
+}
+
+#[test_context(S2Stream)]
+#[tokio_shared_rt::test(shared)]
+async fn producer_flushes_partial_batch_without_waiting_for_linger(
+    stream: &S2Stream,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let producer = stream.producer(
+        ProducerConfig::new()
+            .with_batching(BatchingConfig::new().with_linger(Duration::from_secs(60 * 60))),
+    );
+    let ticket = producer.submit(AppendRecord::new("lorem")?).await?;
+
+    tokio::time::timeout(Duration::from_secs(10), producer.flush())
+        .await
+        .expect("producer flush timed out")?;
+
+    let ack = ticket
+        .now_or_never()
+        .expect("covered ticket should be ready after flush")?;
+    assert_eq!(ack.seq_num, 0);
+
+    producer.close().await?;
+    Ok(())
+}
+
+#[test_context(S2Stream)]
+#[tokio_shared_rt::test(shared)]
+async fn producer_flush_delivers_all_indexed_acks(
+    stream: &S2Stream,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let producer = stream.producer(
+        ProducerConfig::new()
+            .with_batching(BatchingConfig::new().with_linger(Duration::from_secs(60 * 60))),
+    );
+    let ticket1 = producer.submit(AppendRecord::new("lorem")?).await?;
+    let ticket2 = producer.submit(AppendRecord::new("ipsum")?).await?;
+    let ticket3 = producer.submit(AppendRecord::new("dolor")?).await?;
+
+    producer.flush().await?;
+
+    let ack1 = ticket1
+        .now_or_never()
+        .expect("covered ticket1 should be ready after flush")?;
+    let ack2 = ticket2
+        .now_or_never()
+        .expect("covered ticket2 should be ready after flush")?;
+    let ack3 = ticket3
+        .now_or_never()
+        .expect("covered ticket3 should be ready after flush")?;
+
+    assert_eq!(ack1.seq_num, 0);
+    assert_eq!(ack2.seq_num, 1);
+    assert_eq!(ack3.seq_num, 2);
+    assert_eq!(ack1.batch, ack2.batch);
+    assert_eq!(ack2.batch, ack3.batch);
+
+    producer.close().await?;
+    Ok(())
+}
+
+#[test_context(S2Stream)]
+#[tokio_shared_rt::test(shared)]
+async fn producer_flush_is_reusable_and_excludes_later_submission(
+    stream: &S2Stream,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let producer = stream.producer(
+        ProducerConfig::new()
+            .with_match_seq_num(0)
+            .with_batching(BatchingConfig::new().with_linger(Duration::from_secs(60 * 60))),
+    );
+    let ticket1 = producer.submit(AppendRecord::new("lorem")?).await?;
+
+    let record2 = AppendRecord::new("ipsum")?;
+    let permit2 = producer.reserve(record2.metered_bytes() as u32).await?;
+    let mut flush = Box::pin(producer.flush());
+    assert!(poll!(flush.as_mut()).is_pending());
+    let mut ticket2 = Box::pin(permit2.submit(record2));
+
+    tokio::time::timeout(Duration::from_secs(10), flush)
+        .await
+        .expect("first producer flush timed out")?;
+    let ack1 = ticket1
+        .now_or_never()
+        .expect("record before the barrier should be ready")?;
+    assert_eq!(ack1.seq_num, 0);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(25), ticket2.as_mut())
+            .await
+            .is_err(),
+        "record after the barrier should not be included in its durability wait"
+    );
+
+    tokio::time::timeout(Duration::from_secs(10), producer.flush())
+        .await
+        .expect("second producer flush timed out")?;
+    let ack2 = ticket2.await?;
+    assert_eq!(ack2.seq_num, 1);
+    assert_ne!(ack1.batch, ack2.batch);
+
+    producer.close().await?;
+    Ok(())
+}
+
+#[test_context(S2Stream)]
+#[tokio_shared_rt::test(shared)]
+async fn producer_empty_flush_is_immediate_and_reusable(
+    stream: &S2Stream,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let producer = stream.producer(
+        ProducerConfig::new()
+            .with_batching(BatchingConfig::new().with_linger(Duration::from_secs(60 * 60))),
+    );
+
+    tokio::time::timeout(Duration::from_secs(10), producer.flush())
+        .await
+        .expect("empty producer flush timed out")?;
+    assert_eq!(stream.check_tail().await?.seq_num, 0);
+
+    let ticket = producer.submit(AppendRecord::new("lorem")?).await?;
+    producer.flush().await?;
+    let ack = ticket
+        .now_or_never()
+        .expect("ticket should be ready after the second flush")?;
+    assert_eq!(ack.seq_num, 0);
+
+    producer.close().await?;
+    Ok(())
+}
+
+#[test_context(S2Stream)]
+#[tokio_shared_rt::test(shared)]
+async fn producer_flush_propagates_condition_failure_to_covered_ticket(
+    stream: &S2Stream,
+) -> Result<(), Box<dyn std::error::Error>> {
+    stream
+        .append(AppendInput::new(AppendRecordBatch::try_from_iter([
+            AppendRecord::new("lorem")?,
+        ])?))
+        .await?;
+
+    let producer = stream.producer(
+        ProducerConfig::new()
+            .with_match_seq_num(0)
+            .with_batching(BatchingConfig::new().with_linger(Duration::from_secs(60 * 60))),
+    );
+    let ticket = producer.submit(AppendRecord::new("ipsum")?).await?;
+
+    let flush_result = tokio::time::timeout(Duration::from_secs(10), producer.flush())
+        .await
+        .expect("failing producer flush timed out");
+    assert_matches!(
+        flush_result,
+        Err(ProducerError::Append(AppendSessionError::Append(
+            AppendError::ConditionFailed(AppendConditionFailed::SeqNumMismatch(1))
+        )))
+    );
+
+    let ticket_result = ticket
+        .now_or_never()
+        .expect("covered ticket should be ready when flush fails");
+    assert_matches!(
+        ticket_result,
+        Err(ProducerError::Append(AppendSessionError::Append(
+            AppendError::ConditionFailed(AppendConditionFailed::SeqNumMismatch(1))
+        )))
+    );
+    assert_matches!(
+        producer.flush().await,
+        Err(ProducerError::Append(AppendSessionError::Append(
+            AppendError::ConditionFailed(AppendConditionFailed::SeqNumMismatch(1))
+        )))
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- add `Producer::flush()` as a durable, non-terminal prefix barrier
- immediately emit a partial batch without waiting for linger while keeping the same append session open
- exclude commands ordered after the barrier and preserve batching, fencing, and `match_seq_num` state across repeated flushes
- make terminal batch acknowledgement errors sticky across the barrier and affected record tickets
- update Rust SDK examples and add acceptance-focused integration coverage

## Why

Producer previously emitted partial batches only when a batching threshold or linger deadline was reached, or when `close()` terminated the producer. Applications with explicit durability boundaries therefore had to accept linger latency, disable effective batching, recreate the producer/session, or reimplement batching over `AppendSession`.

This change lets callers batch normally, force the complete preceding prefix durable when correctness requires it, and then continue using the producer.

## Validation

- `just fmt`
- `cargo check -p s2-sdk --tests --examples`
- `cargo clippy -p s2-sdk --all-targets --all-features -- -D warnings --allow deprecated`
- `cargo test -p s2-sdk --lib` — 105 passed
- all 11 Producer integration tests against local S2 Lite, including long-linger flush, exact indexed acknowledgements, post-barrier exclusion, repeated use, empty flush, and condition failure propagation

`just test` was also attempted, but the pinned Rust 1.99 nightly compiler crashes while compiling the existing `cli/tests/integration.rs:51` target before the suite runs; SDK-specific checks above pass.

Closes #666