### PR TITLE
fix(cli): overwrite --output file instead of appending across runs

### DIFF
--- a/cli/src/record_format.rs
+++ b/cli/src/record_format.rs
@@ -399,7 +399,6 @@ mod tests {
     use futures::{StreamExt, executor::block_on};
     use proptest::{prelude::*, test_runner::TestCaseResult};
     use s2_sdk::types::Header;
-    use tokio::io::AsyncWriteExt as _;
 
     use super::*;
 
@@ -516,23 +515,6 @@ mod tests {
         let lines = futures::stream::iter(vec![Err(io::Error::other("io error"))]);
         let mut stream = <JsonFormatter as RecordParser<_>>::parse_records(lines);
         assert!(stream.next().await.unwrap().is_err());
-    }
-
-    // -- RecordsOut: file writer --
-
-    #[tokio::test]
-    async fn records_out_file_writer_truncates_existing_file() {
-        let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("output.txt");
-        let output = RecordsOut::File(path.clone());
-
-        for contents in [b"first".as_slice(), b"second".as_slice()] {
-            let mut writer = output.writer().await.unwrap();
-            writer.write_all(contents).await.unwrap();
-            writer.flush().await.unwrap();
-        }
-
-        assert_eq!(std::fs::read(&path).unwrap(), b"second");
     }
 
     proptest! {

--- a/cli/src/record_format.rs
+++ b/cli/src/record_format.rs
@@ -67,7 +67,7 @@ impl RecordsOut {
                 let file = OpenOptions::new()
                     .write(true)
                     .create(true)
-                    .append(true)
+                    .truncate(true)
                     .open(path)
                     .await?;
 
@@ -399,6 +399,7 @@ mod tests {
     use futures::{StreamExt, executor::block_on};
     use proptest::{prelude::*, test_runner::TestCaseResult};
     use s2_sdk::types::Header;
+    use tokio::io::AsyncWriteExt as _;
 
     use super::*;
 
@@ -515,6 +516,23 @@ mod tests {
         let lines = futures::stream::iter(vec![Err(io::Error::other("io error"))]);
         let mut stream = <JsonFormatter as RecordParser<_>>::parse_records(lines);
         assert!(stream.next().await.unwrap().is_err());
+    }
+
+    // -- RecordsOut: file writer --
+
+    #[tokio::test]
+    async fn records_out_file_writer_truncates_existing_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("output.txt");
+        let output = RecordsOut::File(path.clone());
+
+        for contents in [b"first".as_slice(), b"second".as_slice()] {
+            let mut writer = output.writer().await.unwrap();
+            writer.write_all(contents).await.unwrap();
+            writer.flush().await.unwrap();
+        }
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"second");
     }
 
     proptest! {


### PR DESCRIPTION
Fixes #636

Re-running `s2 read -o file` or `s2 tail -o file` silently appended to the existing output file, duplicating records across invocations with no error signal — the output still looked valid (e.g. well-formed JSONL), so there was nothing to tip users off.

`RecordsOut::writer()` now opens the file with `truncate(true)` instead of `append(true)`:

- The writer is opened exactly once per invocation and never reopened mid-stream, so truncating cannot drop data within a run.
- The `--output` help text says nothing about appending, and the standard `-o file` convention is overwrite.
- This matches the truncate semantics used everywhere else in the CLI (config writes, TUI output).
- Accumulation across runs remains available via stdout and shell redirection (`s2 tail >> file`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)