### PR TITLE
fix(cli): recognize all loopback addresses in browser-login host checks

### DIFF
--- a/cli/src/login.rs
+++ b/cli/src/login.rs
@@ -2022,7 +2022,17 @@ fn now_unix_seconds() -> Result<u64, LoginError> {
 }
 
 fn is_loopback_host(host: &str) -> bool {
-    matches!(host, "127.0.0.1" | "::1" | "localhost")
+    if host == "localhost" {
+        return true;
+    }
+    // `Url::host_str()` serializes IPv6 hosts in brackets (e.g. `[::1]`),
+    // which `IpAddr` parsing does not accept.
+    let host = host
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host);
+    host.parse::<std::net::IpAddr>()
+        .is_ok_and(|ip| ip.is_loopback())
 }
 
 pub(crate) fn has_access_token_environment_variable() -> bool {


### PR DESCRIPTION
Fixes #696

`is_loopback_host` only matched the literal `127.0.0.1`, rejecting the rest of the `127.0.0.0/8` loopback range — so `s2 login` against a local instance on e.g. `127.0.0.2` failed with `HTTPS is required unless the issuer is on loopback` / `unsafe browser destination`.

The issue's report also surfaced a second latent bug while verifying: the `::1` match arm was dead code. `Url::host_str()` serializes IPv6 hosts in brackets (`[::1]`), so IPv6 loopback URLs were rejected as well — the arm could never match what callers pass in (all call sites feed `host_str()`).

The function now parses the host as an IP address (stripping the URL brackets first) and uses the standard library's loopback classification, keeping `localhost` as the only recognized hostname. No DNS resolution is involved, so a non-literal hostname that happens to resolve to loopback still does not qualify.

Verified with a local repro against `oauth_issuer`: the old code rejects `http://127.0.0.2:3000` and `http://[::1]:3000`; the new code accepts the full loopback range plus bracketed IPv6, and still rejects `http://128.0.0.1`, `http://126.255.255.255`, `http://[::2]`, and non-loopback hostnames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)