### PR TITLE
ci: lock simulator dependency resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,9 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - name: Verify Cargo.lock is up-to-date
-        run: cargo metadata --locked --format-version 1 >/dev/null
+        run: |
+          cargo metadata --locked --format-version 1 >/dev/null
+          cargo metadata --locked --manifest-path sim/Cargo.toml --format-version 1 >/dev/null
 
   sort:
     name: Cargo Sort
@@ -103,7 +105,7 @@ jobs:
       - name: Clippy (simulator)
         env:
           RUSTFLAGS: --cfg tokio_unstable
-        run: cargo clippy --manifest-path sim/Cargo.toml --all-targets -- -D warnings --allow deprecated
+        run: cargo clippy --locked --manifest-path sim/Cargo.toml --all-targets -- -D warnings --allow deprecated
 
   test:
     name: Tests
@@ -184,7 +186,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build simulator
-        run: cargo build --manifest-path sim/Cargo.toml --profile sim
+        run: cargo build --locked --manifest-path sim/Cargo.toml --profile sim
 
       # Determinism first: a broken meta test means seeds are not reproducible
       # and any linearizability failure would not be debuggable. Children

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -27,13 +27,45 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Run release-plz
+        id: release-plz
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
         with:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Refresh simulator lockfile in release PR
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          RELEASE_PR: ${{ steps.release-plz.outputs.pr }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$RELEASE_PR" || "$RELEASE_PR" == "null" ]]; then
+            exit 0
+          fi
+
+          pr_number="$(jq -r '.number // empty' <<<"$RELEASE_PR")"
+          if [[ -z "$pr_number" ]]; then
+            exit 0
+          fi
+
+          gh pr checkout "$pr_number"
+          cargo metadata --manifest-path sim/Cargo.toml --format-version 1 >/dev/null
+          cargo metadata --locked --manifest-path sim/Cargo.toml --format-version 1 >/dev/null
+
+          if git diff --quiet -- sim/Cargo.lock; then
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add sim/Cargo.lock
+          git commit -m "chore: refresh simulator lockfile"
+          git push

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ clippy *args: sync
 
 # Run clippy on the simulator (separate workspace)
 sim-clippy *args:
-    RUSTFLAGS="--cfg tokio_unstable" cargo clippy --manifest-path sim/Cargo.toml --all-targets {{args}} -- -D warnings --allow deprecated
+    RUSTFLAGS="--cfg tokio_unstable" cargo clippy --locked --manifest-path sim/Cargo.toml --all-targets {{args}} -- -D warnings --allow deprecated
 
 # Ensure cargo-deny is installed
 _ensure-deny:
@@ -55,6 +55,7 @@ test-sdk-integration: sync _ensure-nextest
 # Verify Cargo.lock is up-to-date
 check-locked:
     cargo metadata --locked --format-version 1 >/dev/null
+    cargo metadata --locked --manifest-path sim/Cargo.toml --format-version 1 >/dev/null
 
 # Install git hooks from hooks/
 install-hooks:
@@ -75,4 +76,4 @@ lite *args:
 # dependencies (getrandom fork, etc.) from the main workspace.
 # tokio_unstable is required so turmoil can seed tokio's internal RNG.
 sim *args:
-    RUSTFLAGS="--cfg tokio_unstable" cargo run --manifest-path sim/Cargo.toml --profile sim -- {{args}}
+    RUSTFLAGS="--cfg tokio_unstable" cargo run --locked --manifest-path sim/Cargo.toml --profile sim -- {{args}}

--- a/sim/Cargo.lock
+++ b/sim/Cargo.lock
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "s2-lite"
-version = "0.42.6"
+version = "0.42.7"
 dependencies = [
  "async-stream",
  "async-trait",


### PR DESCRIPTION
Keep the simulator lockfile synchronized with release-plz version bumps, and require locked dependency resolution for simulator CI and developer commands.

Validation: `just check-locked`.