### PR TITLE
fix(lite): close SlateDB on graceful shutdown

### DIFF
--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -71,6 +71,13 @@ impl Backend {
         }
     }
 
+    /// Fold the memtable (L0) and close the writer. Planned stops must call
+    /// this after HTTP drain; SlateDB has no Drop close, so skipping it leaves
+    /// an un-folded WAL chain for the next fence/replay.
+    pub async fn close(&self) -> Result<(), slatedb::Error> {
+        self.db.close().await
+    }
+
     pub(super) fn bgtask_trigger(&self, trigger: BgtaskTrigger) {
         let _ = self.bgtask_trigger_tx.send(trigger);
     }

--- a/lite/src/backend/core.rs
+++ b/lite/src/backend/core.rs
@@ -71,9 +71,10 @@ impl Backend {
         }
     }
 
-    /// Fold the memtable (L0) and close the writer. Planned stops must call
-    /// this after HTTP drain; SlateDB has no Drop close, so skipping it leaves
-    /// an un-folded WAL chain for the next fence/replay.
+    /// Flush memtables to L0 and close the database.
+    ///
+    /// Call after draining HTTP requests to reduce WAL replay on restart.
+    /// Dropping the backend does not close SlateDB.
     pub async fn close(&self) -> Result<(), slatedb::Error> {
         self.db.close().await
     }

--- a/lite/src/server.rs
+++ b/lite/src/server.rs
@@ -199,6 +199,7 @@ pub async fn run(args: LiteArgs) -> eyre::Result<()> {
 
     info!(%args.append_inflight_bytes, "starting backend");
     let backend = Backend::new(db, args.append_inflight_bytes);
+    let shutdown_backend = backend.clone();
     crate::backend::bgtasks::spawn(&backend);
 
     if let Some(init_file) = &args.init_file {
@@ -277,6 +278,17 @@ pub async fn run(args: LiteArgs) -> eyre::Result<()> {
             return Err(eyre::eyre!("Invalid TLS configuration"));
         }
     }
+
+    info!("http server stopped; folding SlateDB");
+    let fold_started = Instant::now();
+    shutdown_backend
+        .close()
+        .await
+        .map_err(|error| eyre::eyre!("SlateDB close: {error}"))?;
+    info!(
+        elapsed_ms = fold_started.elapsed().as_millis(),
+        "SlateDB closed"
+    );
 
     Ok(())
 }

--- a/lite/src/server.rs
+++ b/lite/src/server.rs
@@ -279,14 +279,14 @@ pub async fn run(args: LiteArgs) -> eyre::Result<()> {
         }
     }
 
-    info!("http server stopped; folding SlateDB");
-    let fold_started = Instant::now();
+    info!("http server stopped; closing SlateDB");
+    let close_started = Instant::now();
     shutdown_backend
         .close()
         .await
         .map_err(|error| eyre::eyre!("SlateDB close: {error}"))?;
     info!(
-        elapsed_ms = fold_started.elapsed().as_millis(),
+        elapsed_ms = close_started.elapsed().as_millis(),
         "SlateDB closed"
     );
 


### PR DESCRIPTION
Lite previously returned after draining HTTP requests without closing SlateDB, leaving memtables to be recovered from the WAL on the next startup.

Call `Backend::close()` after HTTP shutdown, delegating to SlateDB 0.15's `Db::close()` to flush memtables to L0 and shut down the database. Log the elapsed close time and propagate close errors. This reduces WAL replay on restart; Lite's existing `manifest_poll_interval` startup wait remains.

Shutdown awaits the database close without an application timeout. Deployments should allow enough termination grace for the final flush; an interrupted close may still leave WAL data to replay on the next startup.

Validation:

- `just fmt` and `just test` (744 tests passed).
- Local filesystem SIGTERM/reopen checks over HTTP and self-signed HTTPS preserved all 512 acknowledged records per scenario and accepted subsequent appends.
- The contributor reported restart-to-ready times of 2–6 seconds on Fly.io/Tigris, down from 106 seconds when quiet and 251–332 seconds after a burst, with a 1–2 second close and all 352 acknowledged records plus the seed record present after reopening. These remote-store timings were not independently reproduced during review.
