### PR TITLE
feat(sdk): set default request headers (`_hidden` only)

### DIFF
--- a/sdk/src/api.rs
+++ b/sdk/src/api.rs
@@ -794,7 +794,10 @@ impl BaseClient {
         C: client::Connect + Clone + Send + Sync + 'static,
     {
         let access_token_mode = config.access_token.mode();
-        let mut default_headers = HeaderMap::new();
+        let mut default_headers = config.default_headers.clone();
+        // Authorization belongs to the configured token, including when a
+        // refreshable provider supplies it immediately before each attempt.
+        default_headers.remove(AUTHORIZATION);
         #[cfg(feature = "_hidden")]
         let mut access_token_provider = None;
         match &config.access_token {
@@ -1261,18 +1264,202 @@ fn provision_result_from_parts<T>(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
     #[cfg(feature = "_hidden")]
-    use std::sync::{
-        Mutex,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
-    };
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[cfg(feature = "_hidden")]
     use async_trait::async_trait;
-    #[cfg(feature = "_hidden")]
     use hyper_util::client::legacy::connect::HttpConnector;
 
     use super::*;
+
+    #[derive(Default)]
+    struct HeaderCapture {
+        unary: Mutex<Vec<HeaderMap>>,
+        streaming: Mutex<Vec<HeaderMap>>,
+    }
+
+    #[async_trait]
+    impl client::RequestExecutor for HeaderCapture {
+        async fn execute_unary(
+            &self,
+            mut request: client::Request,
+        ) -> Result<UnaryResponse, client::HttpError> {
+            let mut headers = self.unary.lock().unwrap();
+            headers.push(request.headers_mut().clone());
+            // Exercise a real retry through RequestBuilder::send.
+            Ok(if headers.len() == 1 {
+                UnaryResponse::new_for_test(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    br#"{"code":"unavailable","message":"retry"}"#.to_vec(),
+                )
+            } else {
+                UnaryResponse::new_for_test(
+                    StatusCode::OK,
+                    br#"{"basins":[],"streams":[],"has_more":false}"#.to_vec(),
+                )
+            })
+        }
+
+        async fn init_streaming(
+            &self,
+            mut request: client::Request,
+        ) -> Result<StreamingResponse, client::HttpError> {
+            self.streaming
+                .lock()
+                .unwrap()
+                .push(request.headers_mut().clone());
+            // Capturing initiation is sufficient: do not construct a response body.
+            Err(client::HttpError::Timeout)
+        }
+    }
+
+    #[tokio::test]
+    async fn default_headers_reach_account_basin_streaming_and_retry_requests() {
+        let mut session = HeaderValue::from_static("session-1");
+        session.set_sensitive(true);
+        let headers = HeaderMap::from_iter([
+            (
+                http::header::HeaderName::from_static("x-origin-session"),
+                session,
+            ),
+            (
+                AUTHORIZATION,
+                HeaderValue::from_static("Bearer wrong-token"),
+            ),
+            (
+                http::header::USER_AGENT,
+                HeaderValue::from_static("wrong-agent"),
+            ),
+            (
+                http::header::ACCEPT_ENCODING,
+                HeaderValue::from_static("wrong-encoding"),
+            ),
+            (
+                http::header::HeaderName::from_static(S2_BASIN),
+                HeaderValue::from_static("wrong-basin"),
+            ),
+            (CONTENT_TYPE, HeaderValue::from_static("wrong-content-type")),
+        ]);
+        let config = S2Config::new("actual-token")
+            .with_endpoints(S2Endpoints::for_endpoint("http://example.test").unwrap())
+            .with_compression(Compression::Gzip)
+            .with_default_headers(headers);
+        let executor = Arc::new(HeaderCapture::default());
+        let mut base = BaseClient::init_with_connector(&config, HttpConnector::new()).unwrap();
+        base.client = executor.clone();
+        base.retry_builder = RetryBackoffBuilder::default()
+            .with_min_base_delay(Duration::ZERO)
+            .with_max_base_delay(Duration::ZERO)
+            .with_max_retries(1);
+        let account = AccountClient::init(config.clone(), base);
+        account
+            .list_basins(ListBasinsRequest {
+                prefix: None,
+                start_after: None,
+                limit: None,
+            })
+            .await
+            .unwrap();
+        let basin = account.basin_client("test-basin".parse().unwrap());
+        basin
+            .list_streams(ListStreamsRequest {
+                prefix: None,
+                start_after: None,
+                limit: None,
+            })
+            .await
+            .unwrap();
+
+        let stream = "test-stream".parse().unwrap();
+        assert!(
+            basin
+                .read_session(
+                    &stream,
+                    ReadStart {
+                        seq_num: None,
+                        timestamp: None,
+                        tail_offset: None,
+                        clamp: None
+                    },
+                    ReadEnd {
+                        count: None,
+                        bytes: None,
+                        until: None,
+                        wait: None
+                    },
+                    None,
+                    ReconnectAdvice::default(),
+                )
+                .await
+                .is_err()
+        );
+        assert!(
+            basin
+                .append_session(
+                    &stream,
+                    futures_util::stream::empty(),
+                    None,
+                    None,
+                    ReconnectAdvice::default(),
+                )
+                .await
+                .is_err()
+        );
+
+        let unary = executor.unary.lock().unwrap();
+        let streaming = executor.streaming.lock().unwrap();
+        assert_eq!(unary.len(), 3); // account, account retry, basin
+        assert_eq!(streaming.len(), 2); // read and append
+        for headers in unary.iter().chain(streaming.iter()) {
+            assert_eq!(headers["x-origin-session"], "session-1");
+            assert!(headers["x-origin-session"].is_sensitive());
+            assert_eq!(headers[AUTHORIZATION], "Bearer actual-token");
+            assert!(headers[AUTHORIZATION].is_sensitive());
+            assert_eq!(headers[http::header::USER_AGENT], config.user_agent);
+            assert_eq!(headers[http::header::ACCEPT_ENCODING], "gzip");
+        }
+        assert_eq!(unary[2][S2_BASIN], "test-basin");
+        for headers in streaming.iter() {
+            assert_eq!(headers[S2_BASIN], "test-basin");
+            assert_eq!(headers[CONTENT_TYPE], CONTENT_TYPE_S2S);
+        }
+    }
+
+    #[tokio::test]
+    async fn default_headers_are_replaced_and_isolated_between_clients() {
+        let first_headers = HeaderMap::from_iter([
+            (
+                http::header::HeaderName::from_static("x-origin-session"),
+                HeaderValue::from_static("first"),
+            ),
+            (
+                http::header::HeaderName::from_static("x-first-only"),
+                HeaderValue::from_static("present"),
+            ),
+        ]);
+        let first = S2Config::new("token").with_default_headers(first_headers);
+        let second = first.clone().with_default_headers(HeaderMap::from_iter([(
+            http::header::HeaderName::from_static("x-origin-session"),
+            HeaderValue::from_static("second"),
+        )]));
+        for (config, session) in [(&first, "first"), (&second, "second")] {
+            let client = BaseClient::init_with_connector(config, HttpConnector::new()).unwrap();
+            let mut request = client
+                .get("http://example.test".parse().unwrap())
+                .build()
+                .unwrap();
+            assert_eq!(request.headers_mut()["x-origin-session"], session);
+            assert_eq!(
+                request.headers_mut().contains_key("x-first-only"),
+                session == "first"
+            );
+        }
+        let cleared = second.with_default_headers(HeaderMap::new());
+        assert!(cleared.default_headers.is_empty());
+        assert!(S2Config::new("token").default_headers.is_empty());
+    }
 
     #[cfg(feature = "_hidden")]
     #[derive(Debug)]
@@ -1435,9 +1622,14 @@ mod tests {
     #[cfg(feature = "_hidden")]
     #[tokio::test]
     async fn dynamic_access_token_is_loaded_for_each_attempt_and_marked_sensitive() {
-        let config = S2Config::new("unused").with_access_token_provider(RotatingTokenProvider {
-            generation: AtomicUsize::new(1),
-        });
+        let config = S2Config::new("unused")
+            .with_default_headers(HeaderMap::from_iter([(
+                AUTHORIZATION,
+                HeaderValue::from_static("Bearer wrong-token"),
+            )]))
+            .with_access_token_provider(RotatingTokenProvider {
+                generation: AtomicUsize::new(1),
+            });
         let client = BaseClient::init_with_connector(&config, HttpConnector::new()).unwrap();
         let uri = "http://example.test/v1/basins".parse().unwrap();
         let mut request = client.get(uri).build().unwrap();

--- a/sdk/src/api.rs
+++ b/sdk/src/api.rs
@@ -1264,22 +1264,26 @@ fn provision_result_from_parts<T>(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "_hidden")]
     use std::sync::Mutex;
     #[cfg(feature = "_hidden")]
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[cfg(feature = "_hidden")]
     use async_trait::async_trait;
+    #[cfg(feature = "_hidden")]
     use hyper_util::client::legacy::connect::HttpConnector;
 
     use super::*;
 
+    #[cfg(feature = "_hidden")]
     #[derive(Default)]
     struct HeaderCapture {
         unary: Mutex<Vec<HeaderMap>>,
         streaming: Mutex<Vec<HeaderMap>>,
     }
 
+    #[cfg(feature = "_hidden")]
     #[async_trait]
     impl client::RequestExecutor for HeaderCapture {
         async fn execute_unary(
@@ -1315,6 +1319,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "_hidden")]
     #[tokio::test]
     async fn default_headers_reach_account_basin_streaming_and_retry_requests() {
         let mut session = HeaderValue::from_static("session-1");
@@ -1427,6 +1432,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "_hidden")]
     #[tokio::test]
     async fn default_headers_are_replaced_and_isolated_between_clients() {
         let first_headers = HeaderMap::from_iter([

--- a/sdk/src/api.rs
+++ b/sdk/src/api.rs
@@ -798,9 +798,6 @@ impl BaseClient {
         // Authorization belongs to the configured token, including when a
         // refreshable provider supplies it immediately before each attempt.
         default_headers.remove(AUTHORIZATION);
-        // Only the body encoder can set Content-Encoding, including leaving it
-        // absent for uncompressed bodies and streams with per-frame compression.
-        default_headers.remove(http::header::CONTENT_ENCODING);
         #[cfg(feature = "_hidden")]
         let mut access_token_provider = None;
         match &config.access_token {
@@ -1345,10 +1342,6 @@ mod tests {
                 HeaderValue::from_static("wrong-encoding"),
             ),
             (
-                http::header::CONTENT_ENCODING,
-                HeaderValue::from_static("gzip"),
-            ),
-            (
                 http::header::HeaderName::from_static(S2_BASIN),
                 HeaderValue::from_static("wrong-basin"),
             ),
@@ -1357,7 +1350,8 @@ mod tests {
         let config = S2Config::new("actual-token")
             .with_endpoints(S2Endpoints::for_endpoint("http://example.test").unwrap())
             .with_compression(Compression::Gzip)
-            .with_default_headers(headers);
+            .with_default_headers(headers)
+            .unwrap();
         let executor = Arc::new(HeaderCapture::default());
         let mut base = BaseClient::init_with_connector(&config, HttpConnector::new()).unwrap();
         base.client = executor.clone();
@@ -1446,23 +1440,18 @@ mod tests {
     #[case::gzip(Compression::Gzip, Some("gzip"), "gzip")]
     #[case::zstd(Compression::Zstd, Some("zstd"), "zstd")]
     #[tokio::test]
-    async fn default_headers_do_not_override_request_compression(
+    async fn default_accept_encoding_respects_configured_compression(
         #[case] compression: Compression,
         #[case] content_encoding: Option<&str>,
         #[case] accept_encoding: &str,
     ) {
         let config = S2Config::new("token")
             .with_compression(compression)
-            .with_default_headers(HeaderMap::from_iter([
-                (
-                    http::header::CONTENT_ENCODING,
-                    HeaderValue::from_static("wrong-encoding"),
-                ),
-                (
-                    http::header::ACCEPT_ENCODING,
-                    HeaderValue::from_static("gzip, zstd"),
-                ),
-            ]));
+            .with_default_headers(HeaderMap::from_iter([(
+                http::header::ACCEPT_ENCODING,
+                HeaderValue::from_static("gzip, zstd"),
+            )]))
+            .unwrap();
         let client = BaseClient::init_with_connector(&config, HttpConnector::new()).unwrap();
         let mut request = client
             .post("http://example.test/v1/basins".parse().unwrap())
@@ -1495,11 +1484,16 @@ mod tests {
                 HeaderValue::from_static("present"),
             ),
         ]);
-        let first = S2Config::new("token").with_default_headers(first_headers);
-        let second = first.clone().with_default_headers(HeaderMap::from_iter([(
-            http::header::HeaderName::from_static("x-origin-session"),
-            HeaderValue::from_static("second"),
-        )]));
+        let first = S2Config::new("token")
+            .with_default_headers(first_headers)
+            .unwrap();
+        let second = first
+            .clone()
+            .with_default_headers(HeaderMap::from_iter([(
+                http::header::HeaderName::from_static("x-origin-session"),
+                HeaderValue::from_static("second"),
+            )]))
+            .unwrap();
         for (config, session) in [(&first, "first"), (&second, "second")] {
             let client = BaseClient::init_with_connector(config, HttpConnector::new()).unwrap();
             let mut request = client
@@ -1512,7 +1506,7 @@ mod tests {
                 session == "first"
             );
         }
-        let cleared = second.with_default_headers(HeaderMap::new());
+        let cleared = second.with_default_headers(HeaderMap::new()).unwrap();
         assert!(cleared.default_headers.is_empty());
         assert!(S2Config::new("token").default_headers.is_empty());
     }
@@ -1683,6 +1677,7 @@ mod tests {
                 AUTHORIZATION,
                 HeaderValue::from_static("Bearer wrong-token"),
             )]))
+            .unwrap()
             .with_access_token_provider(RotatingTokenProvider {
                 generation: AtomicUsize::new(1),
             });

--- a/sdk/src/api.rs
+++ b/sdk/src/api.rs
@@ -798,6 +798,9 @@ impl BaseClient {
         // Authorization belongs to the configured token, including when a
         // refreshable provider supplies it immediately before each attempt.
         default_headers.remove(AUTHORIZATION);
+        // Only the body encoder can set Content-Encoding, including leaving it
+        // absent for uncompressed bodies and streams with per-frame compression.
+        default_headers.remove(http::header::CONTENT_ENCODING);
         #[cfg(feature = "_hidden")]
         let mut access_token_provider = None;
         match &config.access_token {
@@ -1342,6 +1345,10 @@ mod tests {
                 HeaderValue::from_static("wrong-encoding"),
             ),
             (
+                http::header::CONTENT_ENCODING,
+                HeaderValue::from_static("gzip"),
+            ),
+            (
                 http::header::HeaderName::from_static(S2_BASIN),
                 HeaderValue::from_static("wrong-basin"),
             ),
@@ -1424,12 +1431,55 @@ mod tests {
             assert!(headers[AUTHORIZATION].is_sensitive());
             assert_eq!(headers[http::header::USER_AGENT], config.user_agent);
             assert_eq!(headers[http::header::ACCEPT_ENCODING], "gzip");
+            assert!(!headers.contains_key(http::header::CONTENT_ENCODING));
         }
         assert_eq!(unary[2][S2_BASIN], "test-basin");
         for headers in streaming.iter() {
             assert_eq!(headers[S2_BASIN], "test-basin");
             assert_eq!(headers[CONTENT_TYPE], CONTENT_TYPE_S2S);
         }
+    }
+
+    #[cfg(feature = "_hidden")]
+    #[rstest::rstest]
+    #[case::none(Compression::None, None, "gzip, zstd")]
+    #[case::gzip(Compression::Gzip, Some("gzip"), "gzip")]
+    #[case::zstd(Compression::Zstd, Some("zstd"), "zstd")]
+    #[tokio::test]
+    async fn default_headers_do_not_override_request_compression(
+        #[case] compression: Compression,
+        #[case] content_encoding: Option<&str>,
+        #[case] accept_encoding: &str,
+    ) {
+        let config = S2Config::new("token")
+            .with_compression(compression)
+            .with_default_headers(HeaderMap::from_iter([
+                (
+                    http::header::CONTENT_ENCODING,
+                    HeaderValue::from_static("wrong-encoding"),
+                ),
+                (
+                    http::header::ACCEPT_ENCODING,
+                    HeaderValue::from_static("gzip, zstd"),
+                ),
+            ]));
+        let client = BaseClient::init_with_connector(&config, HttpConnector::new()).unwrap();
+        let mut request = client
+            .post("http://example.test/v1/basins".parse().unwrap())
+            .json(&serde_json::json!({"name": "test-basin"}))
+            .build()
+            .unwrap()
+            .compress()
+            .await
+            .unwrap();
+        let headers = request.headers_mut();
+        assert_eq!(
+            headers
+                .get(http::header::CONTENT_ENCODING)
+                .map(|value| value.to_str().unwrap()),
+            content_encoding
+        );
+        assert_eq!(headers[http::header::ACCEPT_ENCODING], accept_encoding);
     }
 
     #[cfg(feature = "_hidden")]

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -341,7 +341,7 @@ pub struct UnaryResponse {
 }
 
 impl UnaryResponse {
-    #[cfg(test)]
+    #[cfg(all(test, feature = "_hidden"))]
     pub(crate) fn new_for_test(status: StatusCode, bytes: impl Into<Bytes>) -> Self {
         Self {
             status,

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -304,6 +304,7 @@ impl RequestBuilder {
     }
 
     pub fn headers(mut self, headers: &HeaderMap) -> Self {
+        // An owned HeaderMap replaces each key's existing values while preserving duplicates.
         self.headers.extend(headers.clone());
         self
     }
@@ -572,7 +573,7 @@ fn build_http_request(
     let mut builder = http::Request::builder().method(method).uri(uri.clone());
 
     if let Some(req_headers) = builder.headers_mut() {
-        req_headers.extend(headers);
+        *req_headers = headers;
         if let Some(encoding) = content_encoding {
             req_headers.insert(CONTENT_ENCODING, encoding);
         }

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -304,9 +304,7 @@ impl RequestBuilder {
     }
 
     pub fn headers(mut self, headers: &HeaderMap) -> Self {
-        for (key, value) in headers {
-            self.headers.insert(key.clone(), value.clone());
-        }
+        self.headers.extend(headers.clone());
         self
     }
 
@@ -343,7 +341,7 @@ pub struct UnaryResponse {
 }
 
 impl UnaryResponse {
-    #[cfg(all(test, feature = "_hidden"))]
+    #[cfg(test)]
     pub(crate) fn new_for_test(status: StatusCode, bytes: impl Into<Bytes>) -> Self {
         Self {
             status,
@@ -574,11 +572,7 @@ fn build_http_request(
     let mut builder = http::Request::builder().method(method).uri(uri.clone());
 
     if let Some(req_headers) = builder.headers_mut() {
-        for (key, value) in headers {
-            if let Some(key) = key {
-                req_headers.insert(key, value);
-            }
-        }
+        req_headers.extend(headers);
         if let Some(encoding) = content_encoding {
             req_headers.insert(CONTENT_ENCODING, encoding);
         }
@@ -1014,6 +1008,37 @@ mod tests {
 
     fn test_pool() -> Pool<HttpConnector> {
         Pool::new(HttpConnector::new())
+    }
+
+    #[test]
+    fn default_headers_preserve_multiple_values_and_sensitive_flags_on_wire_request() {
+        let mut headers = HeaderMap::new();
+        headers.append("x-tag", HeaderValue::from_static("first"));
+        let mut second = HeaderValue::from_static("second");
+        second.set_sensitive(true);
+        headers.append("x-tag", second);
+        headers.insert(CONTENT_ENCODING, HeaderValue::from_static("wrong-encoding"));
+
+        let request = RequestBuilder::get("http://example.test".parse().unwrap())
+            .header("x-tag", "replaced")
+            .headers(&headers)
+            .build()
+            .unwrap();
+        let cloned = request.try_clone().unwrap();
+        let http = build_http_request(
+            cloned.method,
+            &cloned.uri,
+            cloned.headers,
+            cloned.body.into_http_body(),
+            Some(HeaderValue::from_static("gzip")),
+        )
+        .unwrap();
+        let values = http.headers().get_all("x-tag").iter().collect::<Vec<_>>();
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0], "first");
+        assert_eq!(values[1], "second");
+        assert!(values[1].is_sensitive());
+        assert_eq!(http.headers()[CONTENT_ENCODING], "gzip");
     }
 
     #[test]

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -16,6 +16,7 @@ use std::{
 use async_trait::async_trait;
 use bytes::Bytes;
 use http::{
+    HeaderMap,
     header::HeaderValue,
     uri::{Authority, Scheme},
 };
@@ -511,6 +512,7 @@ pub struct S2Config {
     pub(crate) retry: RetryConfig,
     pub(crate) compression: Compression,
     pub(crate) user_agent: HeaderValue,
+    pub(crate) default_headers: HeaderMap,
     pub(crate) insecure_skip_cert_verification: bool,
     pub(crate) rustls_crypto_provider: Option<Arc<rustls::crypto::CryptoProvider>>,
 }
@@ -528,6 +530,7 @@ impl S2Config {
             user_agent: concat!("s2-sdk-rust/", env!("CARGO_PKG_VERSION"))
                 .parse()
                 .expect("valid user agent"),
+            default_headers: HeaderMap::new(),
             insecure_skip_cert_verification: false,
             rustls_crypto_provider: default_rustls_crypto_provider(),
         }
@@ -545,6 +548,24 @@ impl S2Config {
     /// Set the S2 endpoints to connect to.
     pub fn with_endpoints(self, endpoints: S2Endpoints) -> Self {
         Self { endpoints, ..self }
+    }
+
+    /// Set additional HTTP headers to send with every request.
+    ///
+    /// These headers apply to account, basin, and stream operations, including
+    /// retries and streaming requests. SDK-generated headers, such as
+    /// authorization and basin routing, take precedence over these defaults.
+    /// Calling this method again replaces the previous set of default headers.
+    ///
+    /// Headers are sent to all configured S2 endpoints. Use
+    /// [`HeaderValue::set_sensitive`] for values that should be redacted in debug
+    /// output. Do not use these defaults for per-request identifiers, since the
+    /// same values are reused across requests.
+    pub fn with_default_headers(self, default_headers: HeaderMap) -> Self {
+        Self {
+            default_headers,
+            ..self
+        }
     }
 
     /// Set the timeout for establishing a connection to the server.

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -557,6 +557,11 @@ impl S2Config {
     /// authorization and basin routing, take precedence over these defaults.
     /// Calling this method again replaces the previous set of default headers.
     ///
+    /// `Content-Encoding` defaults are ignored; the SDK sets it to match the
+    /// request body encoding. `Accept-Encoding` defaults are used only when
+    /// [`Compression::None`] is configured; otherwise the SDK sets the header
+    /// to the configured compression algorithm.
+    ///
     /// Headers are sent to all configured S2 endpoints. Use
     /// [`HeaderValue::set_sensitive`] for values that should be redacted in debug
     /// output. Do not use these defaults for per-request identifiers, since the

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -568,7 +568,8 @@ impl S2Config {
     ///
     /// # Errors
     ///
-    /// Returns an error if `default_headers` contains `Content-Encoding`.
+    /// Returns an error if `default_headers` contains `Content-Encoding`,
+    /// `Content-Length`, or `Transfer-Encoding`. The SDK controls body framing.
     /// Use [`Self::with_compression`] to configure request body encoding.
     #[cfg(feature = "_hidden")]
     #[doc(hidden)]
@@ -578,6 +579,16 @@ impl S2Config {
                 "Content-Encoding cannot be set in default headers; use S2Config::with_compression instead"
                     .into(),
             ));
+        }
+        for name in [
+            http::header::CONTENT_LENGTH,
+            http::header::TRANSFER_ENCODING,
+        ] {
+            if default_headers.contains_key(&name) {
+                return Err(ValidationError(format!(
+                    "{name} cannot be set in default headers; the SDK controls request body framing"
+                )));
+            }
         }
         Ok(Self {
             default_headers,
@@ -4047,6 +4058,26 @@ mod tests {
             .unwrap_err();
         assert!(error.0.contains("Content-Encoding"));
         assert!(error.0.contains("with_compression"));
+    }
+
+    #[cfg(feature = "_hidden")]
+    #[rstest]
+    #[case::content_length("content-length", "123")]
+    #[case::content_length_mixed_case("Content-Length", "0")]
+    #[case::content_length_empty("content-length", "")]
+    #[case::transfer_encoding("transfer-encoding", "chunked")]
+    #[case::transfer_encoding_mixed_case("Transfer-Encoding", "chunked")]
+    #[case::transfer_encoding_empty("transfer-encoding", "")]
+    fn default_headers_reject_framing_headers(#[case] name: &str, #[case] value: &str) {
+        let headers = HeaderMap::from_iter([(
+            name.parse::<http::header::HeaderName>().unwrap(),
+            HeaderValue::from_str(value).unwrap(),
+        )]);
+        let error = S2Config::new("token")
+            .with_default_headers(headers)
+            .unwrap_err();
+        assert!(error.0.contains(&name.to_ascii_lowercase()));
+        assert!(error.0.contains("framing"));
     }
 
     // -- StorageClass --

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -557,22 +557,32 @@ impl S2Config {
     /// authorization and basin routing, take precedence over these defaults.
     /// Calling this method again replaces the previous set of default headers.
     ///
-    /// `Content-Encoding` defaults are ignored; the SDK sets it to match the
-    /// request body encoding. `Accept-Encoding` defaults are used only when
-    /// [`Compression::None`] is configured; otherwise the SDK sets the header
-    /// to the configured compression algorithm.
+    /// `Accept-Encoding` defaults are used only when [`Compression::None`] is
+    /// configured; otherwise the SDK sets the header to the configured
+    /// compression algorithm.
     ///
     /// Headers are sent to all configured S2 endpoints. Use
     /// [`HeaderValue::set_sensitive`] for values that should be redacted in debug
     /// output. Do not use these defaults for per-request identifiers, since the
     /// same values are reused across requests.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `default_headers` contains `Content-Encoding`.
+    /// Use [`Self::with_compression`] to configure request body encoding.
     #[cfg(feature = "_hidden")]
     #[doc(hidden)]
-    pub fn with_default_headers(self, default_headers: HeaderMap) -> Self {
-        Self {
+    pub fn with_default_headers(self, default_headers: HeaderMap) -> Result<Self, ValidationError> {
+        if default_headers.contains_key(http::header::CONTENT_ENCODING) {
+            return Err(ValidationError(
+                "Content-Encoding cannot be set in default headers; use S2Config::with_compression instead"
+                    .into(),
+            ));
+        }
+        Ok(Self {
             default_headers,
             ..self
-        }
+        })
     }
 
     /// Set the timeout for establishing a connection to the server.
@@ -4015,6 +4025,28 @@ mod tests {
         assert_eq!(cfg.connection_timeout, Duration::from_secs(3));
         assert_eq!(cfg.request_timeout, Duration::from_secs(5));
         assert!(!cfg.insecure_skip_cert_verification);
+    }
+
+    #[cfg(feature = "_hidden")]
+    #[rstest]
+    #[case::matching_compression("content-encoding", "gzip", Compression::Gzip)]
+    #[case::mixed_case("Content-Encoding", "identity", Compression::None)]
+    #[case::empty_value("content-encoding", "", Compression::None)]
+    fn default_headers_reject_content_encoding(
+        #[case] name: &str,
+        #[case] value: &str,
+        #[case] compression: Compression,
+    ) {
+        let headers = HeaderMap::from_iter([(
+            name.parse::<http::header::HeaderName>().unwrap(),
+            HeaderValue::from_str(value).unwrap(),
+        )]);
+        let error = S2Config::new("token")
+            .with_compression(compression)
+            .with_default_headers(headers)
+            .unwrap_err();
+        assert!(error.0.contains("Content-Encoding"));
+        assert!(error.0.contains("with_compression"));
     }
 
     // -- StorageClass --

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -561,6 +561,8 @@ impl S2Config {
     /// [`HeaderValue::set_sensitive`] for values that should be redacted in debug
     /// output. Do not use these defaults for per-request identifiers, since the
     /// same values are reused across requests.
+    #[cfg(feature = "_hidden")]
+    #[doc(hidden)]
     pub fn with_default_headers(self, default_headers: HeaderMap) -> Self {
         Self {
             default_headers,


### PR DESCRIPTION
Allow a set of additional `default_headers` to be specified. This will be present on all requests, unless replaced by the SDK.

Setting content-encoding headers is not supported, SDK needs full control of that.

This is motivated by an internal (s2 cloud) usecase, hence the gate under `_hidden`.